### PR TITLE
fix: sync sibling manifests to 0.8.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "longhand",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Persistent local memory for Claude Code. Every tool call, every file edit, every thinking block from every session — stored verbatim on your machine. Semantic recall in ~126ms with zero API calls.",
   "author": {
     "name": "Nate Nelson",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim
 
-RUN pip install --no-cache-dir longhand==0.8.0
+RUN pip install --no-cache-dir longhand==0.8.1
 
 ENTRYPOINT ["longhand", "mcp-server"]

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Wynelson94/longhand",
   "title": "Longhand",
   "description": "Local memory for Claude Code. Semantic recall across session history with zero API calls.",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "repository": {
     "url": "https://github.com/Wynelson94/longhand",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "longhand",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
## Summary
- v0.8.1 shipped to PyPI successfully, but the version-sync CI step flagged four sibling manifests still pinned to `0.8.0`.
- Bumps `server.json` (top-level + `packages[]`), `.claude-plugin/plugin.json`, and `Dockerfile` to `0.8.1` so Docker builds, MCP registry resolution, and the Claude Code plugin manifest all advertise the version users can actually install.
- Same drift class as v0.6.0 (c83879f). Wiring the sibling-file sync into the release skill would prevent this from repeating.

## Test plan
- [x] `python3 scripts/check_version_sync.py` — "All manifests match 0.8.1"
- [x] `ruff check` — clean
- [x] `pytest` — 211 passed
- [ ] CI workflow on this branch passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)