### PR TITLE
docs: add SafeSkill 93/100 badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ![License](https://img.shields.io/badge/license-MIT-green)
 ![Tests](https://img.shields.io/badge/tests-222%20passing-brightgreen)
 ![Local](https://img.shields.io/badge/100%25-local-informational)
+[![SafeSkill 93/100](https://img.shields.io/badge/SafeSkill-93%2F100_Verified%20Safe-brightgreen)](https://safeskill.dev/scan/wynelson94-longhand)
 
 **Persistent local memory for Claude Code.** Every tool call, every file edit, every thinking block from every Claude Code session — stored verbatim on your machine. Searchable, replayable, and recallable by fuzzy natural-language questions. Zero API calls. Zero summaries. Zero decisions made by an AI about what's worth remembering.
 


### PR DESCRIPTION
## Summary
- Adds the SafeSkill verified-safe badge ([93/100](https://safeskill.dev/scan/wynelson94-longhand)) to the existing badge stack between Local and the body copy.
- Manual port of #1 (OyaAIProd) — that PR was built against the pre-v0.9.0 README and conflicted hard with the current intro / badge stack.

## Notes
- Verified the badge SVG resolves on shields.io (HTTP 200).
- Verified the scan link resolves on safeskill.dev (HTTP 200).
- One-line diff, README only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)