### PR TITLE
ci: test py3.14, gate coverage, add non-blocking mypy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -26,8 +26,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
-      - name: Run pytest
-        run: pytest -q
+      - name: Run pytest (with coverage gate)
+        run: pytest -q --cov=longhand --cov-report=term-missing --cov-fail-under=60
 
   lint:
     name: Ruff
@@ -53,3 +53,22 @@ jobs:
           python-version: "3.12"
       - name: Check version sync
         run: python scripts/check_version_sync.py
+
+  typecheck:
+    name: mypy (non-blocking)
+    runs-on: ubuntu-latest
+    # Type debt (see AUDIT) is being paid down incrementally — surfaced here,
+    # not gated. Flip continue-on-error to false once `mypy longhand` is clean.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+      - name: Run mypy
+        run: mypy longhand

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,6 @@ jobs:
   typecheck:
     name: mypy (non-blocking)
     runs-on: ubuntu-latest
-    # Type debt (see AUDIT) is being paid down incrementally — surfaced here,
-    # not gated. Flip continue-on-error to false once `mypy longhand` is clean.
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
@@ -71,4 +68,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
       - name: Run mypy
+        # Type debt (see AUDIT) is paid down incrementally — surfaced here, not
+        # gated, so the job stays green. Remove continue-on-error once clean.
+        continue-on-error: true
         run: mypy longhand

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,6 +36,9 @@ jobs:
     name: Publish to PyPI
     needs: build
     runs-on: ubuntu-latest
+    # NOTE: enable "Required reviewers" on the 'pypi' environment in the repo
+    # Settings → Environments so a human must approve each publish. Without that
+    # protection rule, any pushed v* tag publishes to PyPI unattended.
     environment: pypi
     permissions:
       id-token: write


### PR DESCRIPTION
## What

CI hardening from the v0.9.2 audit — closes the process gaps that let the dead-hook bug (PR #11) hide for three releases behind untested, ungated code. Addresses **test_quality-4**, **packaging_deps-4**, **packaging_deps-1**.

## Changes

**1. Test Python 3.14 (`ci.yml`)** — `pyproject.toml` already advertises a `3.14` classifier, but the matrix only ran 3.10–3.13. Added `3.14` as a full (blocking) leg.
- Verified `onnxruntime 1.26.0` (pulled via chromadb) ships a `cp314` `manylinux_2_28` wheel, which ubuntu-latest satisfies → 3.14 installs on Linux.
- The full suite already passes locally on Python 3.14.2.

**2. Gate coverage (`ci.yml`)** — the test step now runs `pytest -q --cov=longhand --cov-report=term-missing --cov-fail-under=60`. `pytest-cov` was already a dev dep but never invoked, so coverage could rot silently.
- Actual total is **65.82%**; the floor is set to **60** deliberately — a conservative anti-rot guard meant to be ratcheted up as the CLI/`time_parser` tests land (audit PR #5). (Setting it to 66 would fail today at 65.82%.)

**3. Non-blocking `mypy` job (`ci.yml`)** — new `typecheck` job runs `mypy longhand` with `continue-on-error: true`. mypy was a dev dep with **22 standing errors** and no CI step. Non-blocking surfaces them as a ratchet without turning CI red; flip `continue-on-error` to `false` once clean.

**4. PyPI publish guard (`publish.yml`)** — a pushed `v*` tag currently publishes to PyPI unattended (the `pypi` environment has no protection rules). The real fix is a **repo Settings change**, not YAML, so I added a documenting comment and the one-time step is below.

### ⚠️ One manual step for you (can't be done in a PR diff)
Enable a human approval gate on the `pypi` environment:
- **GitHub → Settings → Environments → `pypi` → Required reviewers → add yourself.**
- Or via API: `gh api -X PUT repos/Wynelson94/longhand/environments/pypi -f 'reviewers[][type]=User' -F 'reviewers[][id]=<your-user-id>'`

After that, each tag-triggered publish waits for your one-click approval.

## Verification (local, CI-equivalent — `FORCE_COLOR` unset)
- Both workflow files parse as valid YAML.
- Full suite under the new gate: **EXIT 0 — "Required test coverage of 60% reached. Total coverage: 65.82%"**, 228 passed.
- `mypy longhand` → 22 errors (expected; job is non-blocking).
- 3.14 wheel availability for onnxruntime confirmed against PyPI.

> This PR edits CI itself, so its own checks exercise the new 3.14 leg, the coverage gate, and the mypy job directly.

---
Audit PR 3 of the recommended set (independent of PR #11 and PR #12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
