### PR TITLE
test: backfill CLI render + time_parser coverage (66% → 72%)

### DIFF
--- a/tests/test_cli_render.py
+++ b/tests/test_cli_render.py
@@ -1,0 +1,201 @@
+"""Behavioral tests for the read/render CLI commands.
+
+cli/_commands.py is the primary user surface and was ~15% covered — the render
+commands (stats, sessions, timeline, history, replay, export, config, doctor)
+had no behavioral tests, which is how a broken command could ship unnoticed.
+These drive each against a seeded store via CliRunner.
+
+Rich output is made deterministic for substring assertions by widening the
+terminal and stripping ANSI (the suite otherwise flakes when FORCE_COLOR is set
+in the environment — see the reconcile tests).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from longhand.cli import app
+
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def plain(s: str) -> str:
+    """Strip ANSI escapes so assertions don't depend on color settings."""
+    return _ANSI.sub("", s)
+
+
+@pytest.fixture
+def runner() -> CliRunner:
+    return CliRunner()
+
+
+@pytest.fixture(autouse=True)
+def _deterministic_rich(monkeypatch: pytest.MonkeyPatch):
+    # Wide + no forced color → Rich renders stable, unwrapped, ANSI-free text
+    # regardless of the caller's terminal/FORCE_COLOR.
+    monkeypatch.setenv("COLUMNS", "200")
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.setenv("NO_COLOR", "1")
+
+
+@pytest.fixture
+def seeded(tmp_path: Path, sample_session_file: Path):
+    """A temp store with the sample session ingested. Returns (data_dir, session_id)."""
+    from longhand.parser import JSONLParser
+    from longhand.storage import LonghandStore
+
+    data_dir = tmp_path / "longhand"
+    store = LonghandStore(data_dir=data_dir)
+    parser = JSONLParser(sample_session_file)
+    events = list(parser.parse_events())
+    session = parser.build_session(events)
+    store.ingest_session(session, events, run_analysis=False)
+
+    sid = store.sqlite.list_sessions(limit=10)[0]["session_id"]
+    return data_dir, sid
+
+
+# ─── stats ──────────────────────────────────────────────────────────────────
+
+
+def test_stats_renders_counts(runner: CliRunner, seeded):
+    data_dir, _ = seeded
+    result = runner.invoke(app, ["stats", "--data-dir", str(data_dir)])
+    assert result.exit_code == 0, result.stdout
+    out = plain(result.stdout)
+    for label in ("Sessions", "Events", "Tool calls", "Data directory"):
+        assert label in out, f"stats output missing {label!r}"
+
+
+# ─── sessions ─────────────────────────────────────────────────────────────────
+
+
+def test_sessions_lists_ingested(runner: CliRunner, seeded):
+    data_dir, sid = seeded
+    result = runner.invoke(app, ["sessions", "--data-dir", str(data_dir)])
+    assert result.exit_code == 0, result.stdout
+    out = plain(result.stdout)
+    assert "Longhand Sessions" in out
+    assert sid[:8] in out
+
+
+def test_sessions_empty_store_is_friendly(runner: CliRunner, tmp_path: Path):
+    result = runner.invoke(app, ["sessions", "--data-dir", str(tmp_path / "empty")])
+    assert result.exit_code == 0, result.stdout
+    assert "No sessions found" in plain(result.stdout)
+
+
+# ─── timeline ─────────────────────────────────────────────────────────────────
+
+
+def test_timeline_renders_session_events(runner: CliRunner, seeded):
+    data_dir, sid = seeded
+    result = runner.invoke(app, ["timeline", sid[:8], "--data-dir", str(data_dir)])
+    assert result.exit_code == 0, result.stdout
+    out = plain(result.stdout)
+    # The sample session's first user message.
+    assert "Edit the readme" in out
+
+
+def test_timeline_unknown_session_exits_nonzero(runner: CliRunner, seeded):
+    data_dir, _ = seeded
+    result = runner.invoke(app, ["timeline", "zzzznope", "--data-dir", str(data_dir)])
+    assert result.exit_code == 1
+    assert "No session found" in plain(result.stdout)
+
+
+# ─── history ──────────────────────────────────────────────────────────────────
+
+
+def test_history_lists_file_edits(runner: CliRunner, seeded):
+    data_dir, _ = seeded
+    result = runner.invoke(app, ["history", "README.md", "--data-dir", str(data_dir)])
+    assert result.exit_code == 0, result.stdout
+    out = plain(result.stdout)
+    assert "File History" in out
+    assert "README.md" in out
+
+
+def test_history_no_edits_is_friendly(runner: CliRunner, seeded):
+    data_dir, _ = seeded
+    result = runner.invoke(
+        app, ["history", "does-not-exist.xyz", "--data-dir", str(data_dir)]
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "No edits found" in plain(result.stdout)
+
+
+# ─── replay ───────────────────────────────────────────────────────────────────
+
+
+def test_replay_reconstructs_written_file(runner: CliRunner, seeded):
+    data_dir, sid = seeded
+    # new.txt was created with a Write of "Hello, World!".
+    result = runner.invoke(
+        app,
+        ["replay", sid[:8], "/tmp/test-project/new.txt", "--data-dir", str(data_dir)],
+    )
+    assert result.exit_code == 0, result.stdout
+    out = plain(result.stdout)
+    assert "Reconstructed State" in out
+    assert "Hello" in out
+
+
+# ─── export ───────────────────────────────────────────────────────────────────
+
+
+def test_export_session_writes_markdown_file(runner: CliRunner, seeded, tmp_path: Path):
+    data_dir, sid = seeded
+    out_file = tmp_path / "session.md"
+    result = runner.invoke(
+        app,
+        ["export", sid[:8], "--out", str(out_file), "--data-dir", str(data_dir)],
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "Exported to" in plain(result.stdout)
+    assert out_file.exists()
+    assert out_file.read_text().strip(), "exported markdown should not be empty"
+
+
+# ─── config (HOME-scoped, no data_dir) ───────────────────────────────────────
+
+
+def test_config_set_then_show(runner: CliRunner, tmp_path: Path, monkeypatch):
+    # config reads/writes ~/.longhand/config.json — isolate HOME.
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    set_result = runner.invoke(app, ["config", "--set", "hook.min_relevance=3.5"])
+    assert set_result.exit_code == 0, set_result.stdout
+    assert "Set hook.min_relevance" in plain(set_result.stdout)
+
+    cfg = json.loads((tmp_path / ".longhand" / "config.json").read_text())
+    assert cfg["hook"]["min_relevance"] == 3.5
+
+    show_result = runner.invoke(app, ["config"])
+    assert show_result.exit_code == 0, show_result.stdout
+    assert "hook.min_relevance" in plain(show_result.stdout)
+
+
+def test_config_rejects_non_hook_key(runner: CliRunner, tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    result = runner.invoke(app, ["config", "--set", "bogus.key=1"])
+    assert result.exit_code == 0
+    assert "Only hook.* keys" in plain(result.stdout)
+
+
+# ─── doctor ───────────────────────────────────────────────────────────────────
+
+
+def test_doctor_runs_clean(runner: CliRunner, tmp_path: Path, monkeypatch):
+    # doctor uses the default (HOME-based) store; isolate HOME so it inspects an
+    # empty environment rather than the developer's real ~/.longhand / ~/.claude.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LONGHAND_HOME", str(tmp_path / ".longhand"))
+    result = runner.invoke(app, ["doctor"])
+    assert result.exit_code == 0, result.stdout
+    assert plain(result.stdout).strip(), "doctor should print a report"

--- a/tests/test_time_parser.py
+++ b/tests/test_time_parser.py
@@ -1,0 +1,121 @@
+"""Tests for the deterministic time-phrase parser.
+
+`parse_time_phrase` drives recall's date filtering, so a wrong window silently
+degrades every "what did I do last week" query. It was previously exercised only
+incidentally (the no-match return); these tests pin the actual phrase semantics.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from longhand.recall.time_parser import parse_time_phrase
+
+# A fixed "now" so every window is deterministic.
+NOW = datetime(2026, 5, 28, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _dt(y, mo, d, h=0, mi=0):
+    return datetime(y, mo, d, h, mi, tzinfo=timezone.utc)
+
+
+# Phrases that must produce a (since, until) window. The phrase text must also
+# be stripped out of the returned cleaned query.
+MATCHING = [
+    "today",
+    "yesterday",
+    "earlier today",
+    "this morning",
+    "right now",
+    "this week",
+    "last week",
+    "a couple weeks ago",
+    "this month",
+    "last month",
+    "a couple months ago",
+    "a few months ago",
+    "this year",
+    "last year",
+    "recently",
+    "3 days ago",
+    "2 weeks ago",
+    "5 months ago",
+    "1 year ago",
+]
+
+
+@pytest.mark.parametrize("phrase", MATCHING)
+def test_phrase_produces_ordered_window_and_is_stripped(phrase):
+    query = f"the auth bug from {phrase} that broke login"
+    since, until, cleaned = parse_time_phrase(query, now=NOW)
+
+    assert since is not None and until is not None, f"{phrase!r} should match"
+    assert since <= until, f"{phrase!r} produced an inverted window"
+    assert until <= NOW, f"{phrase!r} window extends into the future"
+    # The matched phrase is removed; the surrounding words survive.
+    assert phrase not in cleaned, f"{phrase!r} not stripped from cleaned query"
+    assert "auth bug" in cleaned and "broke login" in cleaned
+
+
+@pytest.mark.parametrize(
+    "query",
+    [
+        "where did I put the readme",
+        "fix the failing test",
+        "",
+        "summary of the deployment",
+    ],
+)
+def test_no_time_phrase_returns_none_and_unchanged_query(query):
+    since, until, cleaned = parse_time_phrase(query, now=NOW)
+    assert since is None
+    assert until is None
+    assert cleaned == query
+
+
+def test_yesterday_exact_window():
+    since, until, _ = parse_time_phrase("what about yesterday", now=NOW)
+    # (days_ago_start, days_ago_end) = (2, 1): since = start of 2 days ago,
+    # until = exactly 1 day before now.
+    assert since == _dt(2026, 5, 26)
+    assert until == _dt(2026, 5, 27, 12, 0)
+
+
+def test_today_window_runs_up_to_now():
+    since, until, _ = parse_time_phrase("anything today", now=NOW)
+    assert since == _dt(2026, 5, 27)  # start of (now - 1 day)
+    assert until == NOW  # days_end == 0 → until is now
+
+
+def test_numeric_phrase_brackets_the_target_day():
+    # "3 days ago": target = now - 3d, fuzzy window = max(1, int(3*0.25)) = 1 day.
+    since, until, cleaned = parse_time_phrase("the bug 3 days ago here", now=NOW)
+    assert since == _dt(2026, 5, 24)  # day-start of (target - 1d)
+    assert until == _dt(2026, 5, 26, 12, 0)  # target + 1d
+    assert "3 days ago" not in cleaned
+    assert "the bug" in cleaned and "here" in cleaned
+
+
+def test_numeric_phrase_takes_precedence_over_fixed():
+    # "2 weeks ago" (numeric) should win over the bare "week" fixed phrases.
+    since, until, _ = parse_time_phrase("2 weeks ago", now=NOW)
+    # 14 days back, ±25% → window = 3 days.
+    assert since == _dt(2026, 5, 11)  # day-start of (now - 14d - 3d)
+    assert until == _dt(2026, 5, 17, 12, 0)  # (now - 14d) + 3d
+
+
+def test_naive_now_is_treated_as_utc():
+    naive = datetime(2026, 5, 28, 12, 0, 0)  # no tzinfo
+    since, until, _ = parse_time_phrase("yesterday", now=naive)
+    assert since is not None and until is not None
+    assert since.tzinfo is not None and until.tzinfo is not None
+
+
+def test_default_now_uses_current_time():
+    # Exercises the `now is None` default branch (falls back to datetime.now).
+    since, until, cleaned = parse_time_phrase("the deploy yesterday")
+    assert since is not None and until is not None
+    assert since <= until
+    assert "yesterday" not in cleaned


### PR DESCRIPTION
## What

Backfills behavioral test coverage on the surfaces the audit flagged as dangerously thin — the same gap that let the dead prompt-hook (PR #11) ship unnoticed. **322 lines of new tests, 41 new cases, zero production changes.**

Addresses audit findings **test_quality-1** (CLI 15% covered), **test_quality-2** (`time_parser` untested), **test_quality-3** (`doctor` untested).

## Coverage impact

| Module | Before | After |
|---|---|---|
| **Total** | 66% | **72%** |
| `cli/_commands.py` (primary user surface) | 15% | **34%** |
| `recall/time_parser.py` (drives recall date filtering) | 54% | **100%** |

269 passed, ruff clean. Comfortably clears the `--cov-fail-under=60` gate from PR #13 (and once both land, that floor can be ratcheted toward 70).

## New tests

**`tests/test_cli_render.py`** — `CliRunner` behavioral tests against a seeded store for the read/render commands that had none: `stats`, `sessions` (+ empty-store path), `timeline` (+ unknown-session exit-1 path), `history` (+ no-edits path), `replay`, `export` (writes markdown to a file), `config` (`--set` round-trips to `config.json`, `--show`, and the non-`hook.*` rejection), and `doctor`. Each asserts real behavior (counts, content, side effects), not just "didn't crash."

**`tests/test_time_parser.py`** — parametrized table tests for `parse_time_phrase`: every fixed phrase (`yesterday`, `last week`, `a couple months ago`, …) and numeric phrase (`3 days ago`, `2 weeks ago`) produces an ordered, non-future window and is stripped from the cleaned query; plus exact-window math for `yesterday`/`today`/numeric, numeric-beats-fixed precedence, no-match passthrough, naive-`now`, and the default-`now` branch.

### Robustness note
Rich output is ANSI-stripped and width-pinned (`COLUMNS=200`, `NO_COLOR`) in the CLI tests so substring assertions don't flake under `FORCE_COLOR` — the same fragility that makes the existing `test_cli_reconcile_*` tests environment-sensitive. (Hardening those two with the same technique is a small, separate follow-up.)

### Not in scope
`test_quality-6` (the conditional `pytest.skip` in `test_episode_pipeline.py`) is left for a focused follow-up to avoid touching an existing passing test here.

## Verification (CI-equivalent, `FORCE_COLOR` unset)
- `ruff check longhand tests` → clean
- `pytest --cov=longhand --cov-fail-under=60` → **EXIT 0, "Total coverage: 71.69%", 269 passed**

---
Audit PR 5 of the recommended set (independent of #11/#12/#13).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
