### PR TITLE
harden: close remaining AUDIT-2026-05-28 findings

### DIFF
--- a/longhand/mcp_server.py
+++ b/longhand/mcp_server.py
@@ -82,6 +82,7 @@ _HINT_PROJECTS = "Use a smaller `limit`, a `keyword`, or a `category` filter."
 
 MAX_LIMIT = 1000
 MAX_OUTPUT_CHARS = 200000
+MAX_QUERY_CHARS = 2000
 
 
 # All tools except `reconcile` are pure read-over-local-storage:
@@ -151,8 +152,27 @@ def _int(value: Any, default: int) -> int:
 
 
 def _limit(value: Any, default: int) -> int:
-    """Coerce to int and cap at MAX_LIMIT to prevent OOM on huge result sets."""
-    return min(_int(value, default), MAX_LIMIT)
+    """Coerce to int and clamp to [1, MAX_LIMIT].
+
+    The floor matters: a negative value would otherwise pass straight
+    through min() and become SQLite's LIMIT -1, i.e. unbounded.
+    """
+    return max(1, min(_int(value, default), MAX_LIMIT))
+
+
+def _offset(value: Any) -> int:
+    """Coerce to int and floor at 0 so negative offsets can't reach SQL."""
+    return max(0, _int(value, 0))
+
+
+def _query(value: Any) -> str:
+    """Coerce the semantic query to a bounded string.
+
+    Caps length before the text reaches the ChromaDB ONNX encoder so a
+    multi-megabyte query can't pin the CPU embedding it.
+    """
+    text = value if isinstance(value, str) else str(value or "")
+    return text[:MAX_QUERY_CHARS]
 
 
 def _max_chars(value: Any, default: int) -> int:
@@ -848,6 +868,7 @@ async def list_tools() -> list[Tool]:
 async def _tool_search(store: LonghandStore, arguments: dict[str, Any]) -> list[TextContent]:
     limit = _limit(arguments.get("limit"), 10)
     max_chars = _max_chars(arguments.get("max_chars"), 12000)
+    query = _query(arguments.get("query"))
 
     # Resolve session_id prefix if provided
     search_session_id = None
@@ -866,7 +887,7 @@ async def _tool_search(store: LonghandStore, arguments: dict[str, Any]) -> list[
     auto_scoped_to: str | None = None
     if not project_id and not project_name:
         try:
-            matches = match_projects(store, arguments.get("query", ""), top_k=1)
+            matches = match_projects(store, query, top_k=1)
             if matches and matches[0].score >= 0.8:
                 project_name = matches[0].display_name
                 auto_scoped_to = matches[0].display_name
@@ -901,7 +922,7 @@ async def _tool_search(store: LonghandStore, arguments: dict[str, Any]) -> list[
     fetch_multiplier = 5 if has_post_filter else 1
 
     hits = store.vectors.search(
-        query=arguments["query"],
+        query=query,
         n_results=limit * fetch_multiplier,
         event_type=arguments.get("event_type"),
         session_id=search_session_id,
@@ -960,10 +981,11 @@ async def _tool_search_in_context(
     context_n = _int(arguments.get("context_events"), 5)
     limit = _limit(arguments.get("limit"), 3)
     max_chars = _max_chars(arguments.get("max_chars"), 20000)
+    query = _query(arguments.get("query"))
 
     # Semantic search scoped to this session
     hits = store.vectors.search(
-        query=arguments["query"],
+        query=query,
         n_results=limit * 3,  # fetch extra for dedup
         session_id=full_id,
         event_type=arguments.get("event_type"),
@@ -1042,7 +1064,7 @@ async def _tool_search_in_context(
 
     payload = {
         "session_id": full_id,
-        "query": arguments["query"],
+        "query": query,
         "total_matches": len(hits),
         "showing": len(all_match_ids),
         "context_windows": results,
@@ -1098,7 +1120,7 @@ async def _tool_get_session_timeline(
         return [TextContent(type="text", text=f"No session matching: {arguments['session_id']}")]
 
     tail = _limit(arguments.get("tail"), 0)
-    offset = _int(arguments.get("offset"), 0)
+    offset = _offset(arguments.get("offset"))
     limit = _limit(arguments.get("limit"), 100)
     max_chars = _max_chars(arguments.get("max_chars"), 16000)
     include_thinking = _bool(arguments.get("include_thinking"), True)
@@ -1255,7 +1277,7 @@ async def _tool_recall(
 ) -> list[TextContent]:
     result = recall_pipeline(
         store=store,
-        query=arguments["query"],
+        query=_query(arguments.get("query")),
         max_episodes=_limit(arguments.get("max_episodes"), 5),
     )
     payload = {
@@ -1361,7 +1383,7 @@ async def _tool_match_project(
 ) -> list[TextContent]:
     matches = match_projects(
         store=store,
-        query=arguments["query"],
+        query=_query(arguments.get("query")),
         top_k=_limit(arguments.get("top_k"), 5),
     )
     payload = [
@@ -1461,7 +1483,7 @@ async def _tool_find_commits(
     if arguments.get("session_id"):
         search_session_id = _resolve_prefix(store, arguments["session_id"])
     ops = store.sqlite.search_git_operations(
-        query=arguments["query"],
+        query=_query(arguments.get("query")),
         session_id=search_session_id,
         operation_type=arguments.get("operation_type"),
         limit=_limit(arguments.get("limit"), 20),

--- a/longhand/parser.py
+++ b/longhand/parser.py
@@ -226,6 +226,10 @@ class JSONLParser:
                 except json.JSONDecodeError:
                     # Skip corrupted lines rather than failing the whole parse
                     continue
+                if not isinstance(entry, dict):
+                    # Valid JSON but not an object (e.g. a bare list/string) —
+                    # skip it rather than crashing the whole session parse.
+                    continue
 
                 for event in self._entry_to_events(entry, sequence):
                     base_id = event.event_id
@@ -301,6 +305,8 @@ class JSONLParser:
             try:
                 entry = json.loads(line)
             except json.JSONDecodeError:
+                continue
+            if not isinstance(entry, dict):
                 continue
 
             for event in self._entry_to_events(entry, sequence):

--- a/longhand/recall/project_fallback.py
+++ b/longhand/recall/project_fallback.py
@@ -170,13 +170,27 @@ def claim_ingest_lock(store: LonghandStore) -> bool:
             return True
         if existing and _lock_holder_alive(existing):
             return False
-        # Stale — fall through and overwrite.
+        # Stale — remove it so the atomic create below can claim it.
+        try:
+            lock.unlink()
+        except FileNotFoundError:
+            pass
+        except OSError:
+            return False
 
     try:
-        lock.write_text(str(my_pid))
-        return True
+        # O_CREAT|O_EXCL makes create-if-absent atomic: if two processes
+        # race past the exists() check above, exactly one wins here.
+        fd = os.open(lock, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except FileExistsError:
+        return False
     except OSError:
         return False
+    try:
+        os.write(fd, str(my_pid).encode())
+    finally:
+        os.close(fd)
+    return True
 
 
 def release_ingest_lock(store: LonghandStore) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,9 @@ classifiers = [
 dependencies = [
     "chromadb>=0.5.0; python_version<'3.14'",
     "chromadb>=0.5.0,<1.0; python_version>='3.14'",
+    # Not imported directly: pins chromadb's transitive telemetry client.
+    # posthog>=3 changed capture() to keyword-only args, which makes chromadb
+    # print "Failed to send telemetry event" on every CLI call (see v0.5.11).
     "posthog<3.0",
     "typer>=0.12.0,<1.0",
     "rich>=13.7.0,<15.0",

--- a/tests/test_episode_pipeline.py
+++ b/tests/test_episode_pipeline.py
@@ -473,8 +473,7 @@ def test_fixless_episode_is_in_sqlite_but_not_vectors(tmp_path: Path):
 
     # SQLite has the episode (forensic preservation)
     eps = store.sqlite.query_episodes(limit=10)
-    if not eps:
-        pytest.skip("extraction didn't produce a fixless episode — skip coverage check")
+    assert eps, "extraction must produce a fixless episode for this fixture"
     assert any(not e.get("fix_event_id") for e in eps), (
         "expected at least one fixless episode in the fixture"
     )

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -736,5 +736,30 @@ def test_dispatch_unknown_tool(temp_store):
     assert mcp_server._DISPATCH.get("not-a-real-tool") is None
 
 
+def test_limit_floors_negative_values():
+    """A negative limit must clamp to 1, not flow through to SQLite LIMIT -1
+    (which means unbounded)."""
+    assert mcp_server._limit(-1, 10) == 1
+    assert mcp_server._limit(-500, 10) == 1
+    assert mcp_server._limit(0, 10) == 1
+    assert mcp_server._limit(None, 10) == 10
+    assert mcp_server._limit(999999, 10) == mcp_server.MAX_LIMIT
+
+
+def test_offset_floors_negative_values():
+    assert mcp_server._offset(-3) == 0
+    assert mcp_server._offset(None) == 0
+    assert mcp_server._offset("7") == 7
+
+
+def test_query_is_bounded_and_coerced():
+    """Semantic queries are capped before reaching the ONNX encoder."""
+    huge = "x" * (mcp_server.MAX_QUERY_CHARS * 10)
+    assert len(mcp_server._query(huge)) == mcp_server.MAX_QUERY_CHARS
+    assert mcp_server._query(None) == ""
+    assert mcp_server._query(123) == "123"
+    assert mcp_server._query("hello") == "hello"
+
+
 # ensure pytest doesn't collect the Any import as a test
 _ = pytest, Any

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -301,3 +301,49 @@ def test_user_image_block_is_replaced_with_placeholder(tmp_path):
     joined = " ".join(contents)
     assert fake_base64 not in joined
     assert "base64" not in joined
+
+
+def test_non_dict_json_lines_are_skipped(tmp_path):
+    """Valid-JSON-but-non-dict lines (a bare list, string, or number) must be
+    skipped, not crash the whole session parse with AttributeError."""
+    path = tmp_path / "mixed.jsonl"
+    valid_entry = {
+        "type": "user",
+        "uuid": "u1",
+        "sessionId": "s1",
+        "timestamp": "2026-04-01T10:00:00.000Z",
+        "cwd": "/tmp/x",
+        "message": {"role": "user", "content": "hello world"},
+    }
+    lines = [
+        "[1, 2, 3]",
+        '"just a string"',
+        "42",
+        json.dumps(valid_entry),
+    ]
+    path.write_text("\n".join(lines) + "\n")
+
+    parser = JSONLParser(path)
+    events = list(parser.parse_events())
+    assert len(events) == 1
+    assert events[0].event_type == EventType.USER_MESSAGE
+
+
+def test_tail_parse_skips_non_dict_json_lines(tmp_path):
+    """The live-ingest tail path needs the same non-dict guard as the full parse."""
+    path = tmp_path / "mixed_tail.jsonl"
+    valid_entry = {
+        "type": "user",
+        "uuid": "u2",
+        "sessionId": "s2",
+        "timestamp": "2026-04-01T10:00:01.000Z",
+        "cwd": "/tmp/x",
+        "message": {"role": "user", "content": "tail hello"},
+    }
+    content = "[1, 2, 3]\n" + json.dumps(valid_entry) + "\n"
+    path.write_text(content)
+
+    parser = JSONLParser(path)
+    events, safe_offset = parser.parse_tail_from_offset(0)
+    assert len(events) == 1
+    assert safe_offset == len(content.encode("utf-8"))

--- a/tests/test_project_fallback.py
+++ b/tests/test_project_fallback.py
@@ -177,3 +177,35 @@ def test_fallback_recursion_guard(temp_store):
 
     # Should return [] — and importantly, shouldn't have recursed infinitely.
     assert results == []
+
+
+def test_claim_lock_reclaims_stale_pid(temp_store):
+    """A lockfile left by a dead PID is removed and reclaimed."""
+    lock = temp_store.data_dir / ".ingest.lock"
+    temp_store.data_dir.mkdir(parents=True, exist_ok=True)
+    # PID 0 is treated as invalid/dead by _read_lock_pid/_lock_holder_alive.
+    lock.write_text("0")
+
+    assert project_fallback.claim_ingest_lock(temp_store) is True
+    assert lock.read_text().strip() == str(os.getpid())
+
+    project_fallback.release_ingest_lock(temp_store)
+    assert not lock.exists()
+
+
+def test_claim_lock_atomic_create_loses_race(temp_store):
+    """If another process creates the lockfile between the exists() check and
+    the create, O_CREAT|O_EXCL must lose cleanly instead of overwriting."""
+    lock = temp_store.data_dir / ".ingest.lock"
+    temp_store.data_dir.mkdir(parents=True, exist_ok=True)
+    other_pid = os.getppid()
+    lock.write_text(str(other_pid))
+
+    # Force the pre-check to say "no lockfile" so claim falls through to the
+    # atomic create against a file that actually exists — simulating the race.
+    with patch.object(Path, "exists", return_value=False):
+        assert project_fallback.claim_ingest_lock(temp_store) is False
+
+    # The racing winner's PID must be untouched.
+    assert lock.read_text().strip() == str(other_pid)
+    lock.unlink()


### PR DESCRIPTION
Closes the six items left open after the v0.9.3 audit follow-ups (AUDIT-2026-05-28).

## Fixes

| Finding | Fix |
|---|---|
| correctness-2 (medium) | `parser.py`: non-dict JSON lines (`[1,2,3]`, bare strings) are skipped in both full-parse and live-tail paths instead of raising AttributeError and losing the session |
| concurrency-1 (medium) | `project_fallback.py`: ingest lock claimed via `os.open(O_CREAT\|O_EXCL)` — atomic, race-safe; stale locks unlinked then re-claimed |
| security-1 (low) | `mcp_server.py`: `_limit()` clamps to `[1, MAX_LIMIT]` — negative values no longer become SQLite `LIMIT -1` (unbounded); `_offset()` floors at 0 |
| security-2 (low) | `mcp_server.py`: semantic queries capped at `MAX_QUERY_CHARS=2000` before ChromaDB ONNX encoding, applied to all query-taking tools |
| test_quality-6 (low) | `test_episode_pipeline.py`: `pytest.skip` replaced with the real assertion — it passes |
| security-3 / packaging | `posthog<3.0` **kept**, now with a comment: it deliberately pins chromadb's transitive telemetry client (v0.5.11, commit d912d7c). The audit's "dead dependency" call was wrong — removing it resurrects the stderr telemetry wall |

## Verification

- `ruff check longhand tests` clean
- `pytest -q`: **280 passed** (273 → 280; 7 new tests covering the parser guard, lock atomicity + stale reclaim + lost-race semantics, and MCP limit/offset/query bounds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)