### PR TITLE
release: v0.9.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "longhand",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Persistent local memory for Claude Code. Every tool call, every file edit, every thinking block from every session \u2014 stored verbatim on your machine. Semantic recall in ~126ms with zero API calls.",
   "author": {
     "name": "Nate Nelson",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ commits and tag annotations of those releases.
 
 ---
 
+## [0.9.4] — 2026-06-09
+
+Hardening release: closes the six findings left open after the v0.9.3 security audit (AUDIT-2026-05-28). No new features, no API changes.
+
+### Fixed
+
+- **Parser no longer crashes on non-object JSON lines.** A transcript line that is valid JSON but not an object (a bare list, string, or number) raised `AttributeError` and silently lost the rest of the session. Both the full-parse and live-tail paths now skip such lines. (#22)
+- **Ingest lock is now race-safe.** `claim_ingest_lock` used a check-then-write that let two racing processes both believe they held the lock. The lock is now claimed with an atomic `O_CREAT|O_EXCL` create; stale locks from dead PIDs are unlinked and re-claimed. (#22)
+
+### Security
+
+- **MCP input bounds tightened.** A negative `limit` could slip past the cap and become SQLite's unbounded `LIMIT -1`; `limit` is now clamped to `[1, 1000]` and `offset` floored at 0. Semantic queries are capped at 2,000 characters before reaching the ChromaDB ONNX encoder, across all query-taking tools. Local-only exposure either way, but defense-in-depth is cheap. (#22)
+
+### Internal
+
+- The `posthog<3.0` pin is now documented in `pyproject.toml`: it deliberately constrains chromadb's transitive telemetry client (posthog ≥3 breaks chromadb's `capture()` calls and floods stderr — the v0.5.11 fix). It is not a dead dependency; do not remove it.
+- Un-skipped the fixless-episode forensic assertion in the test suite (it passes) and added coverage for the parser guard, lock atomicity, and MCP bounds. 273 → 280 tests.
+
 ## [0.9.3] — 2026-05-28
 
 Bug-fix release: restores two features that were silently broken in Claude Code, plus CI/test/doc hardening.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim
 
-RUN pip install --no-cache-dir longhand==0.9.3
+RUN pip install --no-cache-dir longhand==0.9.4
 
 ENTRYPOINT ["longhand", "mcp-server"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/longhand?label=PyPI&color=blue)](https://pypi.org/project/longhand/)
 ![Python](https://img.shields.io/badge/python-3.10+-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
-![Tests](https://img.shields.io/badge/tests-222%20passing-brightgreen)
+![Tests](https://img.shields.io/badge/tests-280%20passing-brightgreen)
 ![Local](https://img.shields.io/badge/100%25-local-informational)
 [![SafeSkill 93/100](https://img.shields.io/badge/SafeSkill-93%2F100_Verified%20Safe-brightgreen)](https://safeskill.dev/scan/wynelson94-longhand)
 
@@ -67,7 +67,7 @@ longhand reanalyze               # fill in episodes + vectors whenever, safe to 
 
 Exact-text search, timelines, file history, and commit lookup all work after `--skip-analysis`. Semantic `recall` needs the `reanalyze` pass to complete. Typical throughput on an M-class Mac is ~1–2 sessions/sec for full analysis.
 
-> *Status: v0.9.3 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 131+ real Claude Code sessions across 40+ inferred projects. 222 unit tests passing.*
+> *Status: v0.9.4 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 131+ real Claude Code sessions across 40+ inferred projects. 280 unit tests passing.*
 
 **Full docs:** [Longhand Wiki](https://github.com/Wynelson94/longhand/wiki) — getting started, CLI reference, MCP tools reference, architecture, and troubleshooting.
 
@@ -489,7 +489,7 @@ Longhand is flat-cost: the cap is per-call, not per-corpus. Recalling across 10 
 
 ---
 
-222 unit tests passing. All 19 MCP tools stress-tested. Full security audit: zero critical findings, zero high findings. `~/.longhand/` created with 0700 permissions, all SQL parameterized, all inputs bounded. Dependencies: chromadb, typer, rich, pydantic, mcp.
+280 unit tests passing. All 19 MCP tools stress-tested. Full security audit: zero critical findings, zero high findings. `~/.longhand/` created with 0700 permissions, all SQL parameterized, all inputs bounded. Dependencies: chromadb, typer, rich, pydantic, mcp.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "longhand"
-version = "0.9.3"
+version = "0.9.4"
 description = "Persistent local memory for Claude Code. Total recall from your session files — no API calls, no summaries, no AI deciding what matters."
 readme = "README.md"
 license = { text = "MIT" }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Wynelson94/longhand",
   "title": "Longhand",
   "description": "Local memory for Claude Code: 19 MCP tools for semantic recall, file replay, project timelines, and git history across your session JSONL \u2014 zero API calls, all local.",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "repository": {
     "url": "https://github.com/Wynelson94/longhand",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "longhand",
-      "version": "0.9.3",
+      "version": "0.9.4",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Version bump + changelog for the v0.9.4 hardening release. Code changes shipped in #22 (closes the six open AUDIT-2026-05-28 findings).

- pyproject.toml / server.json / plugin.json / Dockerfile → 0.9.4 (`check_version_sync.py` passes)
- README: status line + test badge 222 → 280
- CHANGELOG: new 0.9.4 section

After merge: tag `v0.9.4` on main → GitHub Actions publishes to PyPI via OIDC Trusted Publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)