### PR TITLE
fix: benign-noise denylist, chromadb pin, mypy clean + blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         run: python scripts/check_version_sync.py
 
   typecheck:
-    name: mypy (non-blocking)
+    name: mypy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -76,7 +76,4 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
       - name: Run mypy
-        # Type debt (see AUDIT) is paid down incrementally — surfaced here, not
-        # gated, so the job stays green. Remove continue-on-error once clean.
-        continue-on-error: true
         run: mypy longhand

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ credentials.json
 # OS
 .DS_Store
 Thumbs.db
+
+# Local working docs (not for the public repo)
+outreach/
+plans/

--- a/docs/audits/AUDIT-2026-05-28.md
+++ b/docs/audits/AUDIT-2026-05-28.md
@@ -1,0 +1,160 @@
+# Longhand v0.9.2 — Deep-Dive Audit (2026-05-28)
+
+> Scope: full-repo deep-dive of Longhand v0.9.2 (`/Users/natenelson/Projects/longhand`), a published, local-only Claude Code memory tool. Every kept finding below was independently verified by two adversarial skeptics; severities here are recalibrated against the skeptics' lens-aware (`local, offline, single-user, no network/privilege boundary`) corrections. Findings spot-checked live against current source by the lead before sign-off.
+
+## Executive Summary
+
+Longhand v0.9.2 is a well-engineered, security-conscious tool with strong fundamentals: it is ruff-clean, ships 228 passing tests (on the maintainer's active Python 3.14), carries a real SECURITY.md threat model, parameterizes all SQL with escaped LIKE wildcards, has **no** shell/eval/deserialization injection surface, performs **no** outbound network calls, hard-disables ChromaDB telemetry, creates its data/log dirs `0o700`, and has a genuinely solid release pipeline (a version-sync guard wired into CI plus OIDC Trusted Publishing with no long-lived tokens).
+
+The headline finding is a **silently-dead flagship feature**. The UserPromptSubmit auto-context-injection hook — the entire reason that hook exists — emits empty `{}` on every prompt because of a broken import introduced in the v0.2.3-era `cli.py` → `cli/` package split: `setup_commands.py:326` does `from longhand.cli import context`, but `cli/__init__.py` re-exports only `app`. The `ImportError` is swallowed by the fail-open `except Exception: print("{}")` handler. `doctor` reports the hook green, no error surfaces, and no test exercises the path — so it has been live and invisible since v0.9.0. This was surfaced independently under both Correctness and Architecture and is the one item worth treating as a release-blocker for the feature.
+
+Everything else is a tier (or two) down. The genuine-but-bounded set: a TOCTOU ingest-lock race and a downstream read-modify-write race (both contained by WAL + idempotent upserts — no corruption); a few input-bounds hardening gaps on the **local** MCP surface (unfloored negative `LIMIT`, uncapped semantic-query length); the dead `posthog` declared dependency; and a parser robustness gap where one valid-JSON-but-non-object line aborts a whole session. On the docs side, SECURITY.md makes a false categorical "no subprocess execution" claim with a stale embedded grep — the underlying calls are actually safe, so this is a credibility defect, not a vulnerability. On process: CI gates neither coverage nor mypy and omits the advertised Python 3.14, and the PyPI publish has no approval gate.
+
+No data-loss, corruption, RCE, or exfiltration path was found anywhere. The recurring, honest pattern across the audit is that most security/concurrency/performance findings were correctly self-scoped as low/info once the local single-user threat model is applied, and the skeptics confirmed those calibrations.
+
+## Overall Grade
+
+**B+**
+
+Strong fundamentals — clean lint, a real and mostly-accurate threat model, safe-by-construction SQL and storage, no network surface, and a solid release/version-sync story — held back by one silently-dead advertised feature, thin coverage on the primary CLI surface and the recall-critical time parser, and the absence of mypy/coverage/py3.14 gating in CI. Fix the prompt-hook import, bound the MCP edges, correct SECURITY.md, and close the CI gates and this is a comfortable A-.
+
+## Top Risks
+
+1. **Silently-dead flagship feature** — UserPromptSubmit auto-context injection (`setup_commands.py:326`) emits `{}` on every prompt for every user who ran `longhand prompt-hook install`. Fail-open, invisible, `doctor`-green, untested, live since v0.9.0. *(correctness-1 / architecture-1)*
+2. **Untested primary user surface** — `cli/_commands.py` (2267 lines, the most-touched module) is 15% covered; ~18 user-facing commands (`export`, `recap`, `history`, `context`, `patterns`, `config`) have zero behavioral tests. *(test_quality-1, architecture-4)*
+3. **False categorical claim in published SECURITY.md** — "No subprocess execution … Zero command injection surface" with an embedded grep annotated `# (no results)` that now returns real matches. The calls are safe (list-form argv, no `shell=True`), so no exploit — but a reviewer running the embedded proof finds it false. *(docs_accuracy-1)*
+4. **CI / release process holes** — neither coverage nor mypy is gated (22 standing type errors); Python 3.14 is advertised (classifier + 3.14-specific `chromadb` marker) but never tested; a `v*` tag auto-publishes to PyPI through an unprotected `pypi` environment with no approval gate. *(test_quality-4, packaging_deps-4, packaging_deps-1)*
+5. **Concurrency races (bounded)** — a non-atomic `exists()+write_text` ingest lock (`project_fallback.py:164-179`) is a real TOCTOU that can let two ingests run at once, feeding a self-healing read-modify-write race in `upsert_project`. WAL + `busy_timeout` + idempotent upserts cap the blast radius to wasted work, not corruption. *(concurrency-1, concurrency-2)*
+
+## Findings by Severity
+
+Severities are the lead's recalibration. Where two skeptics split, the table shows the recalibrated value and notes the split; `contested` findings are labeled. "Dedup'd into" marks findings that another dimension surfaced as the same root issue.
+
+### High
+
+| ID | Severity | Title | File | Status | Recommendation |
+|----|----------|-------|------|--------|----------------|
+| correctness-1 / architecture-1 | **High** (one skeptic each said critical / high vs medium; lead holds High) | Auto-context UserPromptSubmit hook is silently dead — wrong import swallowed by fail-open handler; emits `{}` on every prompt since v0.9.0 | `longhand/setup_commands.py:326` | confirmed (dedup: same root issue under Correctness + Architecture) | Change to `from longhand.cli._commands import context as context_cmd`; add an end-to-end stdin test |
+| test_quality-1 | **High** (skeptic split high/medium) | Primary CLI surface `_commands.py` is 15% covered; ~18 user-facing commands have zero behavioral tests | `longhand/cli/_commands.py:477-1969` | confirmed | Add CliRunner smoke+assert tests for export/recap/history/context/patterns/config |
+| docs_accuracy-1 | **High** (skeptic split medium/low) | SECURITY.md "No subprocess execution / zero command injection surface" is false; embedded grep proof is stale (now 7 matches) | `SECURITY.md:8,129-136` vs `recall/project_fallback.py:143`, `setup_commands.py:481-490` | confirmed | Reword to "no shell execution, no user-derived subprocess args"; update the grep block to the two safe call sites |
+
+> Note on correctness-1/architecture-1: one skeptic argued **critical** (textbook silent failure of the flagship feature), the others argued **high/medium** (fail-open, no harm, optional feature, local tool). The lead lands on **High**: an advertised feature being a silent no-op behind a green success panel, untested, across three releases, is a serious correctness regression — but it causes no data loss, crash, or security breach, so it is not critical.
+
+### Medium
+
+| ID | Severity | Title | File | Status | Recommendation |
+|----|----------|-------|------|--------|----------------|
+| correctness-2 | **Medium** (skeptic split high/medium) | One valid-JSON-but-non-object line (`[1,2,3]`) aborts parsing of an entire session via `AttributeError` — silent per-session memory loss; wedges live-tail until SessionEnd | `longhand/parser.py:325` | confirmed | Add `if not isinstance(entry, dict): continue` after `json.loads` in both parse paths |
+| concurrency-1 | **Medium** (skeptic split medium/low) | Ingest lockfile uses non-atomic `exists()+write_text` — TOCTOU lets two ingests run concurrently (bounded by WAL + idempotent upserts) | `longhand/recall/project_fallback.py:164-179` | confirmed | Replace with `os.open(O_CREAT\|O_EXCL\|O_WRONLY)`; treat EEXIST as held |
+| performance-1 | **Medium** (skeptic split medium/low) | `_resolve_prefix` loads up to 1000 full session rows and scans in Python on every session-scoped call | `longhand/cli/helpers.py:22-28` | confirmed | Use indexed `SELECT session_id ... WHERE session_id LIKE ? LIMIT 1` |
+| performance-3 | **Medium** (skeptic split medium/low) | CLI ingest materializes the full event list in RAM; duplicated `raw_json` doubles memory/disk; 500MB file cap makes worst-case peak multi-GB | `longhand/cli/_commands.py:332` | confirmed | Drop/compress per-event `raw_json`; lower MAX_FILE_SIZE_BYTES to a realistic ceiling |
+| architecture-3 | **Medium** (skeptic split medium/low) | Copy-pasted Chroma where-clause / result-parsing / batch-upsert scaffolding across 4-5 VectorStore methods (~60 lines) | `longhand/storage/vector_store.py:141-145,217-221,371-373,480-482` | confirmed | Extract `_build_where`, `_parse_results(results, id_field)`, `_upsert_in_batches` |
+| architecture-4 | **Medium** (skeptic split medium/low) | `_commands.py` is a 2267-line god module mixing CLI parsing, business logic, and markdown rendering | `longhand/cli/_commands.py:1-2267` | confirmed (dedup: testability overlaps test_quality-1) | Move renderers to `cli/render.py`; push command logic into recall/analysis layers |
+| test_quality-3 | **Medium** (skeptic split medium/low) | `doctor` (primary health-check, walks live `~/.claude`) has zero test coverage beyond `_freshness_status` | `longhand/cli/_commands.py:2128-2131` → `setup_commands.py:913-1062` | confirmed | Add a CliRunner `doctor` test against isolated_home + empty store |
+| test_quality-4 | **Medium** (skeptic split medium/low) | CI gates neither coverage nor mypy (22 errors) despite both installed; py3.14 absent from matrix | `.github/workflows/ci.yml:18,29-30` | confirmed | Add 3.14; `pytest --cov --cov-fail-under=66`; add a mypy job |
+| packaging_deps-1 | **Medium** (skeptic split high/low) | Tag push auto-publishes to PyPI; the `pypi` OIDC environment has zero protection rules (no reviewer/wait) | `.github/workflows/publish.yml:3-6,35-41` | confirmed | Add a required reviewer or short wait timer to the `pypi` environment |
+| packaging_deps-3 | **Medium** (skeptic split medium/low) | No lockfile; only loose lower-bound floors (`chromadb>=0.5.0` unbounded on py<3.14) → non-reproducible installs | `pyproject.toml:30-38` | confirmed | Commit a `uv.lock`/`pip-compile` constraints file; add chromadb upper bound |
+| packaging_deps-4 | **Medium** (skeptic split low/low) | Python 3.14 advertised (classifier + chromadb marker) but never exercised in CI | `pyproject.toml:25,32` / `ci.yml:18` | confirmed | Add `"3.14"` to the matrix (allow-failure if needed) |
+| architecture-2 | **Low→Medium** (both skeptics: low) | Audit-cleanup roadmap is stale: quick wins shipped, all four structural-refactor items still open; targets v0.5.13-v0.6.0 at v0.9.2 | `plans/audit-cleanup-roadmap.md:1-360` | confirmed | Reconcile inline or delete and fold open items into the punchlist |
+
+> `architecture-2`, `architecture-4`, `correctness-2`, `concurrency-1`, `performance-1/3`, `test_quality-3/4`, `packaging_deps-1/3/4` were each argued down to **low** by one skeptic on the local/offline/single-user lens. The lead keeps several at the medium/low boundary (shown above) where the issue touches a published-package surface, a self-healing-but-real race, or a worst-case memory ceiling; pure maintainability/process items (architecture-2) are treated as low-medium. None are runtime defects today.
+
+### Low
+
+| ID | Severity | Title | File | Status | Recommendation |
+|----|----------|-------|------|--------|----------------|
+| security-1 | **Low** (skeptic split medium/low) | Negative `limit` bypasses `MAX_LIMIT` on every MCP path (`min(-1,1000)==-1`; SQLite `LIMIT -1` = unbounded) | `longhand/mcp_server.py:153-155` | confirmed | `return max(1, min(_int(value, default), MAX_LIMIT))`; clamp offset >= 0 |
+| security-2 | **Low** | `MAX_FILTER_LENGTH` not enforced at MCP boundary; semantic `query` to ChromaDB is unbounded (multi-MB string would be ONNX-encoded in full) | `longhand/mcp_server.py:887-894` | confirmed | Cap `arguments['query']` to a `MAX_QUERY_CHARS` |
+| concurrency-2 | **Low** (skeptic split low/info) | `upsert_project` read-modify-write can lose merged keywords/aliases (self-healing) and double-count `session_count` under concurrent ingest | `longhand/storage/sqlite_store.py:570-606` | confirmed | `BEGIN IMMEDIATE` before the SELECT or fold into a single UPSERT |
+| concurrency-3 | **Low** | Live-ingest loses a row on a JSONL uuid collision straddling a tail boundary (transient; SessionEnd full re-parse self-heals) | `longhand/parser.py:271-314` | confirmed | Seed `seen_ids` from DB rows or persist the per-base-id counter |
+| concurrency-4 | **Low** | Session/global `event_count` includes `#`-suffixed collision rows, inflating stats vs dedup'd user-facing views | `longhand/setup_commands.py:758-780`; `sqlite_store.py:528-542` | confirmed | Add `AND event_id NOT LIKE '%#%'` to the count aggregations |
+| performance-2 | **Low** | `get_events` orders by `timestamp` but the only session index is `(session_id, sequence)` → filesort on every timeline/replay fetch | `longhand/storage/sqlite_store.py:442-448` | confirmed (one skeptic: `search_in_context` doesn't route through this — uses index-covered range query) | Order session-scoped reads by `sequence`, or add `(session_id, timestamp)` index |
+| performance-4 | **Low** | `parse_tail_from_offset` reads the whole un-ingested tail into one bytes buffer + split-list (2-3x file size transiently) | `longhand/parser.py:277-287` | confirmed | Stream the tail with a buffered line reader |
+| performance-7 | **Low** (skeptic split low/info) | Per-call connection open with `PRAGMA journal_mode=WAL` re-asserted every query; no `cache_size`/`mmap_size`/`synchronous` read tuning | `longhand/storage/sqlite_store.py:122-135` | confirmed | Cache one connection per store; set WAL once; add read pragmas |
+| security-3 / correctness-3 / packaging_deps-2 / architecture-7 / docs_accuracy-5 / test_quality-8 | **Low** (multiple skeptics: info; architecture-7 **contested** → info) | `posthog<3.0` declared as a runtime dep but never imported anywhere; also pulled transitively by chromadb (so removing it doesn't shrink the install) | `pyproject.toml:33` | confirmed (dedup: surfaced under 6 dimensions) | Remove the line; reconcile README dep list |
+| architecture-5 | **Low** | Storage layer (`LonghandStore.analyze_session`) owns analysis orchestration, importing 6 analysis symbols — inverted dependency direction | `longhand/storage/store.py:108-160` | confirmed | Extract into `longhand/analysis/pipeline.py`; leave a 1-line delegator |
+| architecture-6 | **Low** (skeptic split low/info) | `query_episodes` / `query_segments` are structured filters wearing a semantic `query_` prefix (convention reserves `query_`/`search_` for semantic, `list_` for structured) | `longhand/storage/sqlite_store.py:767,1006` | confirmed | Rename to `list_episodes`/`list_segments` (11 internal call sites) |
+| test_quality-2 | **Medium→Low** (both skeptics: medium) | `time_parser.py` (recall-accuracy-critical pure function) has no dedicated tests; 54% coverage is incidental | `longhand/recall/time_parser.py:61-99` | confirmed | Parametrized table test of `(since, until, cleaned_query)` per phrase with a frozen `now` |
+| test_quality-5 / docs_accuracy-2 | **Low** (skeptic split low/info) | README claims "222 unit tests passing" in 3 places; suite collects 228 (CHANGELOG 0.9.2 already says 228) | `README.md:9,70,492` vs `CHANGELOG.md:44` | confirmed (dedup) | Update to 228 or drop the hard number; extend `check_version_sync.py` |
+| test_quality-6 | **Low** | `pytest.skip` in `test_episode_pipeline.py` masks the forensic-preservation assertion if the extractor stops emitting fixless episodes | `tests/test_episode_pipeline.py:476-485` | confirmed | Replace skip with `assert eps` |
+| packaging_deps-5 | **Low** (skeptic split low/low) | README test-count badge (222 vs 228) not covered by the version-sync guard, so it drifts silently | `README.md:9,70,492` / `scripts/check_version_sync.py:62-70` | confirmed | Extend the sync guard to the badge count |
+| packaging_deps-6 | **Low** | chromadb drags a server-grade stack (onnxruntime, kubernetes, fastapi, full OpenTelemetry) into a local offline CLI; used in one module | `pyproject.toml:31-32` / `vector_store.py:15-43` | confirmed | Track lighter chromadb client / leaner vector store as future footprint work |
+| packaging_deps-7 | **Low** | Stale global non-editable 0.9.0 install shadows the working tree on PATH (developer footgun) | `longhand/version.py:1-6` | confirmed (one skeptic: cwd-dependent; repo cwd runs working tree; no `--version` flag exists) | Reinstall editable in a venv; remove the stale global install |
+| docs_accuracy-3 | **Low** | SECURITY.md "zero f-string SQL constructions" overstated — `migrations.py:165` builds a `PRAGMA table_info({table})` f-string (hardcoded literal, no injection) | `SECURITY.md:140` | confirmed | Soften to "no f-string SQL from user input; only a hardcoded PRAGMA identifier" |
+| docs_accuracy-4 | **Low** | README architecture diagram lists `cli.py` as a single module; it is now a package (`cli/_commands.py` + `helpers.py`) | `README.md:414` | confirmed | Update the diagram to `cli/` package |
+| docs_accuracy-6 | **Low** (skeptic split low/info) | README Auto-Ingest hook JSON example uses flat `{"command":...}`; installer writes nested `{"hooks":[{"type":"command",...}]}` | `README.md:376-387` vs `setup_commands.py:63-70,119-124` | confirmed | Update the snippet to the nested shape the installer writes |
+
+### Info (verified clean / accurate / documented strength)
+
+| ID | Severity | Title | File | Status |
+|----|----------|-------|------|--------|
+| security-4 | Info | No shell/command injection: both subprocess sites use list-form argv with trusted constants | `setup_commands.py:484-494`, `project_fallback.py:143-149` | confirmed |
+| security-5 | Info | No dangerous deserialization or dynamic code execution anywhere (transcript JSONL parsed with stdlib `json`) | `parser.py:225`, `replay.py:133` | confirmed |
+| security-6 | Info | SQL uniformly parameterized; LIKE wildcards escaped via `_escape_like`; no f-string/format SQL in queries | `storage/sqlite_store.py:92-106,366-394` | confirmed |
+| security-7 | Info | No outbound network from Longhand code; ChromaDB telemetry hard-disabled (one-time ONNX model fetch is dependency behavior) | `storage/vector_store.py:37-43` | confirmed |
+| security-8 | Info | No secret logging/transmission; data and log dirs created `0o700` | `store.py:54`, `setup_commands.py:474`, `project_fallback.py:131` | confirmed |
+| correctness-4 | Info | Verified-clean leads: FD-leak fixed, parser.py:556 & project_match.py:153 mypy flags are type-only noise, git extractor / migration runner / malformed-JSON path all sound | `recall/project_fallback.py:142` et al. | confirmed |
+| concurrency-5 | Info | Dual-store ordering (Chroma upsert before `ingestion_log`) is correctly self-healing; reconcile/drift_cache atomic & sound | `store.py:74-92`, `reconcile.py:59-112`, `drift_cache.py:108-133` | confirmed |
+| performance-6 | Info | Recall read path is well-bounded — no O(n²) full-corpus scans; episode/segment search is semantic-first with capped fan-out | `recall/recall_pipeline.py:134-426` | confirmed |
+| performance-5 | Info | ChromaDB uses default ONNX embedder with no warm-up — advertised ~126ms is warm-in-process latency, not cold first-call | `storage/vector_store.py:45-68` | confirmed |
+| architecture-8 | Info | Clean signals: no TODO/FIXME/HACK markers, no dead-code helper duplication, MCP tool naming consistent | `mcp_server.py:1519-1539` | confirmed |
+| test_quality-7 | Info | Existing tests are genuinely assertive and well-isolated — no flakiness/pollution risk (function-scoped fixtures, tmp_path, isolated HOME) | `tests/conftest.py` et al. | confirmed |
+| packaging_deps-8 | Info | Release plumbing (`bump_version.py` + `check_version_sync.py`) is solid and self-consistent; OIDC publish, actions pinned to major tags | `scripts/check_version_sync.py`, `scripts/bump_version.py`, `version.py` | confirmed |
+| docs_accuracy-7 | Info | Confirmed accurate: CLAUDE.md MCP guidance, the "19 tools" count, full CHANGELOG 0.9.0/0.9.1/0.9.2 coverage, and most SECURITY.md bound/permission claims | `mcp_server.py:187-800`, CHANGELOG, SECURITY.md | confirmed |
+
+### Contested findings
+
+- **architecture-7** (posthog as a hard runtime dep): one skeptic rated **partial→info**, the other **refuted→info**, on the grounds that chromadb already pulls posthog transitively (`posthog>=2.4.0`), so the "adds install weight / larger attack surface" impact is false — removing the line changes the install footprint by zero. The factual core (declared, never imported) holds and is deduplicated with security-3/correctness-3/packaging_deps-2. **Net: Info-level dependency-hygiene cleanup**, not a security or footprint issue. The removal is still worth doing (a "strictly local, no telemetry" tool listing an analytics SDK as a *direct* dep looks bad to an auditor scanning the tree), but the rationale is cosmetic, not functional.
+
+## Test & Quality Assessment
+
+Test health is depth over breadth. **What is tested is tested well** (test_quality-7, confirmed by both skeptics): existing tests assert real values and semantics rather than non-crash (`edit_call.old_content == "Old content"`, `payload["meta"]["order"] == "sequence DESC"`, a relative embedding-distance gap `related_d + 0.15 < unrelated_d`); fixtures are function-scoped on `tmp_path` with an `isolated_home` that monkeypatches HOME, LONGHAND_HOME, and the import-time `CLAUDE_SETTINGS_PATH`; there are no session/module-scope fixtures and no xdist, so no order-dependence or real-home pollution.
+
+**The gaps are breadth and CI gating.** Total coverage is 66% (5214 stmts, 1782 missing) and is **not gated**, so it can rot silently. The primary user surface, `cli/_commands.py`, is 15% covered (951/1124 missing) — ~18 user-facing rendering commands (`export`, `recap`, `history`, `context`, `patterns`, `config`) have **zero** behavioral tests. That gap is exactly why the dead prompt-hook (correctness-1) shipped: no test pipes stdin through `run_prompt_hook`. The highest-leverage pure function in the codebase, `recall/time_parser.py:parse_time_phrase` — which decides the since/until window for "what did we do last week" — has **zero direct tests** (its 54% is incidental, hitting only the no-match `return None, None, query`). CI runs a bare `pytest -q` with no `--cov`/`--cov-fail-under` despite `pytest-cov` being a declared dev dep; there is **no mypy step at all** despite mypy being a dev dep and 22 standing type errors (mostly Optional ChromaDB return-type indexing in `vector_store.py`); and the matrix is 3.10–3.13, omitting the Python 3.14 the project advertises (classifier + 3.14-specific chromadb marker) and that the maintainer actually runs. Note the README badge ("222") even understates the real count (228) — the safe direction, but stale and unguarded.
+
+None of these are runtime defects today, but for a published tool whose pitch is *accuracy* they are the gaps most likely to let a real regression through unobserved. Minimum bar: CliRunner smoke+assert tests for the six untested commands and `doctor`; a parametrized `time_parser` table test; replace the `pytest.skip` in `test_episode_pipeline.py:476-485` with `assert eps`; add `"3.14"` to the matrix; turn on `--cov-fail-under=66`; and add a (initially non-blocking) `mypy longhand` job.
+
+## What We Checked and Found Clean
+
+An honest audit names what it cleared, not just what it flagged. The following leads were investigated against current v0.9.2 source and confirmed sound or type-only noise:
+
+- **No command/shell injection** (security-4): both subprocess sites use list-form argv (`[sys.executable, "-m", "longhand.cli", "ingest"]` and `["launchctl", "load"/"unload", <fixed plist>]`), no `shell=True`, no `os.system`/`os.popen`, no user-derived input reaches argv.
+- **No dangerous deserialization / dynamic execution** (security-5): transcript JSONL is parsed with stdlib `json.loads`; a whole-package grep for `pickle`/`yaml.load`/`eval(`/`exec(`/`marshal`/`__import__`/`compile(` finds only `re.compile` and `sqlite .execute*` — no RCE-via-deserialization vector.
+- **SQL is uniformly parameterized** (security-6): every dynamic WHERE joins static condition strings with hardcoded column names and binds values via `?`; `_escape_like` escapes `\ % _` and every LIKE uses `ESCAPE '\'`; the only SQL f-strings are count-derived `?`-placeholder lists.
+- **No outbound network; telemetry off** (security-7): no `requests`/`urllib`/`httpx`/`socket` imports anywhere; ChromaDB telemetry disabled by both env var and explicit `Settings(anonymized_telemetry=False)`. (Caveat documented: ChromaDB's default embedder does a one-time ONNX model download on first use — dependency behavior, not Longhand code.)
+- **No secret logging/transmission** (security-8): no `logging` module use at all; the only `os.environ` access is the telemetry-disable line; storage sits under `0o700` dirs.
+- **Dual-store consistency is self-healing** (concurrency-5): `ingestion_log` is written last, so a mid-ingest Chroma failure leaves the file unmarked and reprocessable; missing vector index auto-backfills from SQLite; reconcile holds the lock and reports `lock_unavailable` without partial work; `drift_cache` uses atomic `tempfile + os.replace`.
+- **Recall read path is well-bounded** (performance-6): fixed, capped vector queries; `match_projects` is bounded by project count, not corpus size; extraction is a single forward walk run once at ingest. No O(n²) query-time scans.
+- **Previously-reported items already fixed / not bugs** (correctness-4): the FD-leak is fixed (`with log_file.open(...)`), and the `parser.py:556` / `project_match.py:153` mypy flags are type-only (defaulted-optional field; immediately `if proj:`-guarded). The git extractor, migration runner, and malformed-JSON decode path are all sound.
+- **Release plumbing is a genuine strength** (packaging_deps-8): `check_version_sync.py` validates pyproject against server.json/plugin.json/Dockerfile/README and is wired into CI; `bump_version.py` mirrors the set, refuses downgrades and non-semver, and is idempotent; `__version__` derives from installed metadata; OIDC Trusted Publishing avoids long-lived tokens; all four manifests verified at 0.9.2.
+- **Docs that are accurate** (docs_accuracy-7): the "19 tools" count, the CLAUDE.md MCP guidance and filters, the full 0.9.0/0.9.1/0.9.2 CHANGELOG, and most SECURITY.md bound/permission claims all match the code. (Note: the audit lead's earlier "21 tools" figure was wrong — the docs are right at 19.)
+- **Existing tests are trustworthy** (test_quality-7) and **the codebase has clean architectural signals** (architecture-8): no debt markers, single-source `_resolve_prefix` helper, consistent MCP tool naming.
+
+The refuted set was empty — every lead either confirmed as a real (if often low-severity) issue or was recorded as a positive verification above.
+
+## Recommended PRs
+
+Longhand is **PR-only** — never direct to main. Grouped for review, ordered by value/effort.
+
+1. **Fix the silently-dead UserPromptSubmit auto-context hook + add an end-to-end test** *(correctness-1, architecture-1)* — trivial / low risk. One-line import fix at `setup_commands.py:326` plus the stdin guard test that would have caught it. Highest value in the audit.
+2. **Bound MCP input edges** *(security-1, security-2)* — small / low risk. Floor negative `LIMIT`/`OFFSET` in `_limit`; cap free-text `query` length before it hits `store.vectors.search`. Optionally add schema `minimum`/`maxLength`.
+3. **Correct SECURITY.md to match the code** *(docs_accuracy-1, docs_accuracy-3)* — trivial / low risk. The calls are safe; the doc is not. Reword the categorical subprocess and f-string claims and refresh the embedded grep proof.
+4. **CI hardening: py3.14, coverage gate, mypy job, PyPI review** *(test_quality-4, packaging_deps-4, packaging_deps-1)* — small / low risk. Add 3.14 (allow-failure), `--cov-fail-under=66`, a non-blocking-then-blocking mypy job, and a required reviewer/wait timer on the `pypi` environment.
+5. **Backfill behavioral tests for the untested CLI + time_parser + doctor** *(test_quality-1, -2, -3, -6, architecture-4)* — medium / low risk. CliRunner smoke+assert tests against isolated `--data-dir` stores; parametrized `time_parser` table; replace the `pytest.skip`.
+6. **Make the ingest lock atomic and project upsert race-safe** *(concurrency-1, concurrency-2)* — small / medium risk. `O_EXCL` lock acquire; `BEGIN IMMEDIATE` (or single UPSERT) in `upsert_project`. Medium risk because it touches the live ingest path — needs concurrent-ingest tests.
+7. **Parser robustness: skip non-object lines, fix cross-boundary uuid collisions, fix stat counts** *(correctness-2, concurrency-3, concurrency-4)* — small / low risk. `isinstance(entry, dict)` guard; seed `seen_ids` from the DB; add `AND event_id NOT LIKE '%#%'` to the count aggregations.
+8. **Dependency + doc hygiene** *(security-3, correctness-3, packaging_deps-2, test_quality-5, docs_accuracy-2/4/5/6, performance-5, security-7)* — small / low risk. Drop `posthog`; sync README test count to 228 and the dep list; fix the architecture diagram and hook-JSON example; caveat the ~126ms figure and the one-time ONNX fetch.
+9. **Performance cleanups** *(performance-1, -2, -3, -4, -7)* — medium / medium risk. Indexed prefix resolution; `ORDER BY sequence` (or composite index) for session reads; drop/compress `raw_json` and lower the file cap; stream the tail; cache a connection with read pragmas. Medium risk because the storage-read paths are hot — verify against the existing suite.
+10. **Maintainability refactors (post-functionality, low priority)** *(architecture-2, -3, -4, -5, -6)* — large / medium risk. De-duplicate VectorStore scaffolding; extract `AnalysisPipeline`; rename `query_`→`list_`; move CLI renderers out; reconcile or delete the stale roadmap. Pure quality, no behavior change — do after the functional and test PRs land.
+---
+
+## Independent Verification (post-synthesis)
+
+The highest-impact finding was reproduced directly before publishing this report:
+
+- `setup_commands.py:326` runs `from longhand.cli import context as context_cmd`.
+- `longhand/cli/__init__.py` declares `__all__ = ["app"]` and exposes no `context`.
+- A live import raises `ImportError: cannot import name 'context' from 'longhand.cli'`, which the hook's outer `except` swallows → `run_prompt_hook` prints `{}` on every UserPromptSubmit. **Dead since the `cli.py` → `cli/` package split.**
+- `posthog` confirmed never imported anywhere under `longhand/` (grep), corroborating packaging_deps-2 / security-3.
+
+Baseline at audit time (Python 3.14.2, editable 0.9.2): ruff **clean**, version-sync **OK**, **228 tests passing**, coverage **66%**, mypy **22 ungated errors** — of which the FD-leak, `parser.py:556`, and `project_match.py:153` items were verified **NOT real bugs** (see correctness-4). The one real type-level defect (the dead-hook import) is the critical finding above.

--- a/longhand/extractors/errors.py
+++ b/longhand/extractors/errors.py
@@ -109,6 +109,28 @@ _PATTERNS: list[tuple[re.Pattern[str], Severity, Category, str]] = [
     (re.compile(r"ENOENT|EACCES|EPERM"), "error", "bash", "bash_errno"),
 ]
 
+# Lines that match an error pattern above but are known benign noise.
+# Checked against the matched LINE, not the whole output — a benign hit
+# skips that one match and keeps scanning, so a real error later in the
+# same output still registers.
+_BENIGN_LINE_PATTERNS: list[re.Pattern[str]] = [
+    # Next.js streaming-SSR / hydration artifacts from dynamic({ssr:false})
+    re.compile(r"<!--\s*/?\$!?\s*-->"),
+    re.compile(r"data-dgst="),
+    # Zero-count test summaries ("0 failing", "Tests: 0 failed")
+    re.compile(r"\b0 (?:failing|failed)\b", re.IGNORECASE),
+    # Structured payloads reporting an empty/absent error field
+    re.compile(r"[\"']?error[\"']?\s*:\s*(?:null|none|\[\]|\{\}|[\"']{2})\s*,?\s*$", re.IGNORECASE),
+    # Claude Code Task/TodoWrite tool churn — not a user-code error
+    re.compile(r"^Error: Task .* not found|^Error: Task not found", re.IGNORECASE),
+    # macOS lacks GNU timeout; harness probes for it constantly
+    re.compile(r"command not found: timeout\b|timeout: command not found", re.IGNORECASE),
+]
+
+
+def _is_benign_line(line: str) -> bool:
+    return any(p.search(line) for p in _BENIGN_LINE_PATTERNS)
+
 
 def detect_error(content: str | None) -> ErrorSignal | None:
     """Detect if a tool_result content string indicates an error.
@@ -124,14 +146,15 @@ def detect_error(content: str | None) -> ErrorSignal | None:
 
     # Scan against patterns in priority order
     for pattern, severity, category, name in _PATTERNS:
-        match = pattern.search(text)
-        if match:
+        for match in pattern.finditer(text):
             # Extract the line containing the match
             start = text.rfind("\n", 0, match.start()) + 1
             end = text.find("\n", match.end())
             if end == -1:
                 end = len(text)
             snippet = text[start:end].strip()
+            if _is_benign_line(snippet):
+                continue
             if len(snippet) > 300:
                 snippet = snippet[:300] + "..."
             return ErrorSignal(

--- a/longhand/parser.py
+++ b/longhand/parser.py
@@ -592,6 +592,7 @@ class JSONLParser:
             cwd=None,
             git_branch=None,
             is_sidechain=False,
+            model=None,
             raw=entry,
         )
 

--- a/longhand/recall/project_match.py
+++ b/longhand/recall/project_match.py
@@ -150,14 +150,14 @@ def match_projects(
                 scored[pid].score += semantic_score
                 scored[pid].reasons.append(f"semantic: {semantic_score:.2f}")
             else:
-                proj = store.sqlite.get_project(pid)
-                if proj:
-                    recency = _recency_boost(proj["last_seen"], now)
+                proj_row = store.sqlite.get_project(pid)
+                if proj_row:
+                    recency = _recency_boost(proj_row["last_seen"], now)
                     scored[pid] = ProjectMatch(
                         project_id=pid,
-                        display_name=proj["display_name"],
-                        category=proj.get("category"),
-                        canonical_path=proj["canonical_path"],
+                        display_name=proj_row["display_name"],
+                        category=proj_row.get("category"),
+                        canonical_path=proj_row["canonical_path"],
                         score=semantic_score * recency,
                         reasons=[f"semantic: {semantic_score:.2f}", f"recency: {recency:.2f}"],
                     )

--- a/longhand/storage/vector_store.py
+++ b/longhand/storage/vector_store.py
@@ -27,6 +27,11 @@ MAX_EMBED_CHARS = 2000
 CHROMA_BATCH_SIZE = 500
 
 
+def _first_batch(rows: Any) -> list[Any]:
+    """Unwrap Chroma's per-query result lists, which may be None or empty."""
+    return rows[0] if rows else []
+
+
 class VectorStore:
     """ChromaDB wrapper for semantic search over Longhand events."""
 
@@ -81,7 +86,7 @@ class VectorStore:
 
         ids: list[str] = []
         documents: list[str] = []
-        metadatas: list[dict[str, Any]] = []
+        metadatas: list[Any] = []
 
         for e in events:
             if not e.content or not e.content.strip():
@@ -158,10 +163,10 @@ class VectorStore:
             # Empty collection or query failure — return no results gracefully
             return []
 
-        ids = results.get("ids", [[]])[0]
-        documents = results.get("documents", [[]])[0]
-        metadatas = results.get("metadatas", [[]])[0]
-        distances = results.get("distances", [[]])[0]
+        ids = _first_batch(results.get("ids"))
+        documents = _first_batch(results.get("documents"))
+        metadatas = _first_batch(results.get("metadatas"))
+        distances = _first_batch(results.get("distances"))
 
         hits: list[dict[str, Any]] = []
         for i, event_id in enumerate(ids):
@@ -236,10 +241,10 @@ class VectorStore:
         except Exception:
             return []
 
-        ids = results.get("ids", [[]])[0]
-        documents = results.get("documents", [[]])[0]
-        metadatas = results.get("metadatas", [[]])[0]
-        distances = results.get("distances", [[]])[0]
+        ids = _first_batch(results.get("ids"))
+        documents = _first_batch(results.get("documents"))
+        metadatas = _first_batch(results.get("metadatas"))
+        distances = _first_batch(results.get("distances"))
 
         hits: list[dict[str, Any]] = []
         for i, sid in enumerate(ids):
@@ -277,7 +282,7 @@ class VectorStore:
         category: str | None = None,
     ) -> list[dict[str, Any]]:
         """Semantic search over project descriptions."""
-        where = {"category": category} if category else None
+        where: dict[str, Any] | None = {"category": category} if category else None
 
         try:
             results = self.projects_collection.query(
@@ -288,10 +293,10 @@ class VectorStore:
         except Exception:
             return []
 
-        ids = results.get("ids", [[]])[0]
-        documents = results.get("documents", [[]])[0]
-        metadatas = results.get("metadatas", [[]])[0]
-        distances = results.get("distances", [[]])[0]
+        ids = _first_batch(results.get("ids"))
+        documents = _first_batch(results.get("documents"))
+        metadatas = _first_batch(results.get("metadatas"))
+        distances = _first_batch(results.get("distances"))
 
         hits: list[dict[str, Any]] = []
         for i, pid in enumerate(ids):
@@ -335,7 +340,7 @@ class VectorStore:
 
         ids: list[str] = []
         documents: list[str] = []
-        metadatas: list[dict[str, Any]] = []
+        metadatas: list[Any] = []
         for item in items:
             text = item.get("text") or ""
             if not text.strip():
@@ -392,10 +397,10 @@ class VectorStore:
         except Exception:
             return []
 
-        ids = results.get("ids", [[]])[0]
-        documents = results.get("documents", [[]])[0]
-        metadatas = results.get("metadatas", [[]])[0]
-        distances = results.get("distances", [[]])[0]
+        ids = _first_batch(results.get("ids"))
+        documents = _first_batch(results.get("documents"))
+        metadatas = _first_batch(results.get("metadatas"))
+        distances = _first_batch(results.get("distances"))
 
         hits: list[dict[str, Any]] = []
         for i, sid in enumerate(ids):
@@ -446,7 +451,7 @@ class VectorStore:
 
         ids: list[str] = []
         documents: list[str] = []
-        metadatas: list[dict[str, Any]] = []
+        metadatas: list[Any] = []
         for item in items:
             text = item.get("text") or ""
             if not text.strip():
@@ -503,10 +508,10 @@ class VectorStore:
         except Exception:
             return []
 
-        ids = results.get("ids", [[]])[0]
-        documents = results.get("documents", [[]])[0]
-        metadatas = results.get("metadatas", [[]])[0]
-        distances = results.get("distances", [[]])[0]
+        ids = _first_batch(results.get("ids"))
+        documents = _first_batch(results.get("documents"))
+        metadatas = _first_batch(results.get("metadatas"))
+        distances = _first_batch(results.get("distances"))
 
         hits: list[dict[str, Any]] = []
         for i, eid in enumerate(ids):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "chromadb>=0.5.0; python_version<'3.14'",
-    "chromadb>=0.5.0,<1.0; python_version>='3.14'",
+    "chromadb>=0.5.0,<1.0",
     # Not imported directly: pins chromadb's transitive telemetry client.
     # posthog>=3 changed capture() to keyword-only args, which makes chromadb
     # print "Failed to send telemetry event" on every CLI call (see v0.5.11).

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -143,3 +143,52 @@ def test_extract_extensions():
     assert "ts" in exts
     assert "tsx" in exts
     assert "toml" in exts
+
+
+def test_benign_nextjs_streaming_markers_not_errors():
+    """Next.js dynamic({ssr:false}) streaming-SSR artifacts are benign noise,
+    not real errors — they were inflating the unresolved-rate stat."""
+    assert detect_error('<!--$!--><template data-dgst="BAILOUT_TO_CSR"></template>') is None
+    assert detect_error("<!--/$!-->") is None
+    assert detect_error('Error: <template data-dgst="x9"> hydration marker') is None
+
+
+def test_benign_zero_count_test_summaries_not_errors():
+    assert detect_error("  0 failing") is None
+    assert detect_error("Tests: 0 failed, 12 passed") is None
+
+
+def test_benign_empty_error_fields_not_errors():
+    assert detect_error("error: null") is None
+    assert detect_error('"error": ""') is None
+
+
+def test_real_error_still_detected_past_benign_noise():
+    """A benign line must be skipped, not end the scan — real errors after it
+    still register."""
+    content = '<!--$!--><template data-dgst="x"></template>\nError: connection refused'
+    sig = detect_error(content)
+    assert sig is not None
+    assert "connection refused" in sig.snippet
+
+
+def test_nonzero_test_summary_still_detected():
+    sig = detect_error("Tests: 3 failed, 9 passed")
+    assert sig is not None
+    assert sig.pattern == "test_summary_fail"
+
+
+def test_benign_task_tool_churn_not_error():
+    assert detect_error("Error: Task not found") is None
+    assert detect_error('Error: Task "3" not found') is None
+
+
+def test_benign_missing_timeout_binary_not_error():
+    assert detect_error("(eval):1: command not found: timeout") is None
+    assert detect_error("bash: timeout: command not found") is None
+
+
+def test_other_command_not_found_still_detected():
+    sig = detect_error("(eval):1: command not found: python")
+    assert sig is not None
+    assert sig.pattern == "bash_common"


### PR DESCRIPTION
Second of three PRs toward v0.10.0.

## Changes

- **Error-detector denylist** (`extractors/errors.py`): matched lines are checked against `_BENIGN_LINE_PATTERNS` — Next.js `data-dgst`/`<!--$!-->` streaming markers, "0 failing"/"Tests: 0 failed", empty `error:` fields, `Error: Task not found` churn, missing-`timeout`-binary probes. Benign hits skip that match and keep scanning, so real errors later in the same output still register. This is the main driver of the inflated unresolved-episode rate (observed ~66% unresolved, dominated by false positives).
- **chromadb `<1.0` for all Pythons** — was unbounded below py3.14; a chromadb 1.x release would have broken fresh installs while existing envs kept working.
- **mypy 21 → 0, job now blocking** — `_first_batch()` helper unwraps Chroma's Optional query results (12 errors), metadata/where annotations (4), `model=None` in `_file_snapshot_event` (1), Optional-shadow rename in `project_match` (1). `continue-on-error` removed from the CI typecheck job.
- **Housekeeping** — `AUDIT-2026-05-28.md` committed under `docs/audits/`; `outreach/` and `plans/` gitignored; stale `plans/audit-cleanup-roadmap.md` deleted (5 of its items had already shipped; the rest live on the punch list).

## Verification

ruff check + format check clean, mypy clean (40 files), pytest **288 passed** (280 → 288; 8 new denylist tests incl. real-error-past-noise and non-benign command-not-found still detected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)