### PR TITLE
release: v0.10.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "longhand",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "description": "Persistent local memory for Claude Code. Every tool call, every file edit, every thinking block from every session \u2014 stored verbatim on your machine. Semantic recall in ~126ms with zero API calls.",
   "author": {
     "name": "Nate Nelson",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ commits and tag annotations of those releases.
 
 ---
 
+## [0.10.0] — 2026-06-09
+
+Feature release: opt-in secret redaction, plus recall-quality and toolchain hardening.
+
+### Added
+
+- **Secret redaction at ingest (opt-in).** `longhand config --set redact.enabled=true` masks secret-shaped strings — Anthropic/OpenAI/AWS/GitHub/Google/Slack/Stripe keys, SSH key headers, JWTs, database URLs with passwords, SSNs, and Luhn-validated card numbers — at parse time, before they reach SQLite, the raw JSON blobs, or the vector index. Masks keep only the first/last 4 characters and the length (`sk-a…wxyz (len=50)`). Default is off: Longhand stays forensic unless you opt in. (#26)
+- **`longhand redact`** — retroactive scan of an existing store. Reports pattern names and counts only (never the matched values); `--apply` masks matches in place across events, episodes, segments, and outcomes, and re-embeds changed vector documents. (#26)
+
+### Fixed
+
+- **Benign noise no longer counts as errors.** The error detector now skips known-noise lines — Next.js streaming-SSR `data-dgst`/`<!--$!-->` markers, "0 failing"/"Tests: 0 failed" summaries, empty `error:` fields, `Error: Task not found` tool churn, and missing-GNU-`timeout` probes — while continuing to scan, so real errors in the same output still register. This was the main inflator of the unresolved-episode rate. Run `longhand analyze --all` to re-extract episodes with the cleaner detector. (#25)
+
+### Security
+
+- chromadb is now capped `<1.0` for **all** Python versions (previously unbounded below 3.14) — a chromadb 1.x release can no longer break fresh installs. (#25)
+
+### Internal
+
+- mypy is clean (21 → 0 errors) and the CI typecheck job is now blocking. (#25)
+- `ruff format` adopted repo-wide and gated in CI. (#24)
+- 311 tests (280 → 311). The May 2026 audit report is archived under `docs/audits/`. (#24–#26)
+
 ## [0.9.4] — 2026-06-09
 
 Hardening release: closes the six findings left open after the v0.9.3 security audit (AUDIT-2026-05-28). No new features, no API changes.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim
 
-RUN pip install --no-cache-dir longhand==0.9.4
+RUN pip install --no-cache-dir longhand==0.10.0
 
 ENTRYPOINT ["longhand", "mcp-server"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/longhand?label=PyPI&color=blue)](https://pypi.org/project/longhand/)
 ![Python](https://img.shields.io/badge/python-3.10+-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
-![Tests](https://img.shields.io/badge/tests-280%20passing-brightgreen)
+![Tests](https://img.shields.io/badge/tests-311%20passing-brightgreen)
 ![Local](https://img.shields.io/badge/100%25-local-informational)
 [![SafeSkill 93/100](https://img.shields.io/badge/SafeSkill-93%2F100_Verified%20Safe-brightgreen)](https://safeskill.dev/scan/wynelson94-longhand)
 
@@ -67,7 +67,7 @@ longhand reanalyze               # fill in episodes + vectors whenever, safe to 
 
 Exact-text search, timelines, file history, and commit lookup all work after `--skip-analysis`. Semantic `recall` needs the `reanalyze` pass to complete. Typical throughput on an M-class Mac is ~1–2 sessions/sec for full analysis.
 
-> *Status: v0.9.4 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 131+ real Claude Code sessions across 40+ inferred projects. 280 unit tests passing.*
+> *Status: v0.10.0 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 131+ real Claude Code sessions across 40+ inferred projects. 311 unit tests passing.*
 
 **Full docs:** [Longhand Wiki](https://github.com/Wynelson94/longhand/wiki) — getting started, CLI reference, MCP tools reference, architecture, and troubleshooting.
 
@@ -490,7 +490,7 @@ Longhand is flat-cost: the cap is per-call, not per-corpus. Recalling across 10 
 
 ---
 
-280 unit tests passing. All 19 MCP tools stress-tested. Full security audit: zero critical findings, zero high findings. `~/.longhand/` created with 0700 permissions, all SQL parameterized, all inputs bounded. Dependencies: chromadb, typer, rich, pydantic, mcp.
+311 unit tests passing. All 19 MCP tools stress-tested. Full security audit: zero critical findings, zero high findings. `~/.longhand/` created with 0700 permissions, all SQL parameterized, all inputs bounded. Dependencies: chromadb, typer, rich, pydantic, mcp.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "longhand"
-version = "0.9.4"
+version = "0.10.0"
 description = "Persistent local memory for Claude Code. Total recall from your session files — no API calls, no summaries, no AI deciding what matters."
 readme = "README.md"
 license = { text = "MIT" }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Wynelson94/longhand",
   "title": "Longhand",
   "description": "Local memory for Claude Code: 19 MCP tools for semantic recall, file replay, project timelines, and git history across your session JSONL \u2014 zero API calls, all local.",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "repository": {
     "url": "https://github.com/Wynelson94/longhand",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "longhand",
-      "version": "0.9.4",
+      "version": "0.10.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Version bump + changelog for v0.10.0. Code shipped in #24 (ruff format), #25 (denylist/pin/mypy), #26 (secret redaction).

- All manifests → 0.10.0 (`check_version_sync.py` passes)
- README: status line + test badge 280 → 311
- CHANGELOG: new 0.10.0 section (Added / Fixed / Security / Internal)

After merge: tag `v0.10.0` on main → OIDC publish to PyPI (needs the pypi environment deployment approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)