### PR TITLE
release: v0.11.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "longhand",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Persistent local memory for Claude Code. Every tool call, every file edit, every thinking block from every session \u2014 stored verbatim on your machine. Semantic recall in ~126ms with zero API calls.",
   "author": {
     "name": "Nate Nelson",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ commits and tag annotations of those releases.
 
 ---
 
+## [0.11.0] — 2026-06-09
+
+UX release: the CLI gets organized, the stats get honest, and first-run gets smarter. No breaking changes — every existing command and flag still works.
+
+### Changed
+
+- **`longhand --help` is now grouped.** Commands render in six panels — Recall, Archaeology, Browse & insights, Data, Setup & health, Plumbing — instead of a 40-command alphabetical list. (#28)
+- **Plumbing commands are hidden** (still fully callable, exact names unchanged): `ingest-session`, `ingest-live`, `context`, `backfill-episodes`, `mcp-server`. These are hook/desktop-config entry points, not user commands. (#28)
+- **`analyze --all` now also rebuilds episode embeddings**, absorbing what `reanalyze` did. `reanalyze` remains as a hidden deprecated alias that warns and delegates — it will be removed in v1.0. (#28)
+- **Honest episode stats.** `longhand stats` and the `get_stats` MCP tool now split out `low_confidence_episodes` (fixless extractions below 0.5 confidence — probes and tool churn, not real problems) and report `resolved_rate_pct` over substantive episodes only. Your resolved rate was never as bad as the old denominator made it look. (#28)
+- **First-run output teaches with your own data.** `setup` ends with an indexed-summary line (sessions · projects · episodes) and suggests `longhand status "<your top project>"` instead of a placeholder. (#28)
+
+### Deprecated
+
+- `longhand reanalyze` → use `longhand analyze --all`. Alias removed in v1.0.
+
 ## [0.10.0] — 2026-06-09
 
 Feature release: opt-in secret redaction, plus recall-quality and toolchain hardening.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim
 
-RUN pip install --no-cache-dir longhand==0.10.0
+RUN pip install --no-cache-dir longhand==0.11.0
 
 ENTRYPOINT ["longhand", "mcp-server"]

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/longhand?label=PyPI&color=blue)](https://pypi.org/project/longhand/)
 ![Python](https://img.shields.io/badge/python-3.10+-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
-![Tests](https://img.shields.io/badge/tests-311%20passing-brightgreen)
+![Tests](https://img.shields.io/badge/tests-316%20passing-brightgreen)
 ![Local](https://img.shields.io/badge/100%25-local-informational)
 [![SafeSkill 93/100](https://img.shields.io/badge/SafeSkill-93%2F100_Verified%20Safe-brightgreen)](https://safeskill.dev/scan/wynelson94-longhand)
 
@@ -67,7 +67,7 @@ longhand analyze --all           # fill in episodes + vectors whenever, safe to 
 
 Exact-text search, timelines, file history, and commit lookup all work after `--skip-analysis`. Semantic `recall` needs the `analyze --all` pass to complete. Typical throughput on an M-class Mac is ~1–2 sessions/sec for full analysis.
 
-> *Status: v0.10.0 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 131+ real Claude Code sessions across 40+ inferred projects. 311 unit tests passing.*
+> *Status: v0.11.0 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 131+ real Claude Code sessions across 40+ inferred projects. 316 unit tests passing.*
 
 **Full docs:** [Longhand Wiki](https://github.com/Wynelson94/longhand/wiki) — getting started, CLI reference, MCP tools reference, architecture, and troubleshooting.
 
@@ -490,7 +490,7 @@ Longhand is flat-cost: the cap is per-call, not per-corpus. Recalling across 10 
 
 ---
 
-311 unit tests passing. All 19 MCP tools stress-tested. Full security audit: zero critical findings, zero high findings. `~/.longhand/` created with 0700 permissions, all SQL parameterized, all inputs bounded. Dependencies: chromadb, typer, rich, pydantic, mcp.
+316 unit tests passing. All 19 MCP tools stress-tested. Full security audit: zero critical findings, zero high findings. `~/.longhand/` created with 0700 permissions, all SQL parameterized, all inputs bounded. Dependencies: chromadb, typer, rich, pydantic, mcp.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "longhand"
-version = "0.10.0"
+version = "0.11.0"
 description = "Persistent local memory for Claude Code. Total recall from your session files — no API calls, no summaries, no AI deciding what matters."
 readme = "README.md"
 license = { text = "MIT" }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Wynelson94/longhand",
   "title": "Longhand",
   "description": "Local memory for Claude Code: 19 MCP tools for semantic recall, file replay, project timelines, and git history across your session JSONL \u2014 zero API calls, all local.",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "repository": {
     "url": "https://github.com/Wynelson94/longhand",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "longhand",
-      "version": "0.10.0",
+      "version": "0.11.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Version bump + changelog for v0.11.0. Code shipped in #28.

- All manifests → 0.11.0 (`check_version_sync.py` passes)
- README: status + test badge 311 → 316
- CHANGELOG: 0.11.0 section (Changed / Deprecated)

After merge: tag `v0.11.0` → OIDC publish (pypi env approval required).

🤖 Generated with [Claude Code](https://claude.com/claude-code)