### PR TITLE
chore: heal fieldnotes pins + install the drift gate

### DIFF
--- a/.fieldnotes/notes/0002-project-inference-cwd-mode.md
+++ b/.fieldnotes/notes/0002-project-inference-cwd-mode.md
@@ -2,9 +2,11 @@
 confidence: high
 id: '0002'
 references:
-- lines: null
+- advisory: false
+  lines: null
   path: longhand/parser.py
-  sha: d577dd844bffe6eed691048e6cb744f87ffe4bab527686d5fc50319991fef1b3
+  pinned_at: '2026-06-11T17:58:33.907018Z'
+  sha: 89c1beb169b9c06521aeee28fce3246641d09f973a793ac2023d180114025d0a
   symbol: null
 session_id: null
 superseded_by: '0006'

--- a/.fieldnotes/notes/0004-fix-summary-no-intent-prefix.md
+++ b/.fieldnotes/notes/0004-fix-summary-no-intent-prefix.md
@@ -2,11 +2,13 @@
 confidence: high
 id: '0004'
 references:
-- lines:
-  - 405
-  - 458
+- advisory: false
+  lines:
+  - 406
+  - 459
   path: longhand/analysis/episode_extraction.py
-  sha: 5aeb69c605a667efd9e4f06908442492706cd629e097bd226af88a67e5101a30
+  pinned_at: '2026-06-11T17:58:33.908312Z'
+  sha: 5a6d3255796d264515fe0583df4722723184bc87006293d8943dab92a5333162
   symbol: _compose_fix_summary
 session_id: null
 superseded_by: null

--- a/.fieldnotes/notes/0006-project-inference-cwd-mode.md
+++ b/.fieldnotes/notes/0006-project-inference-cwd-mode.md
@@ -2,11 +2,13 @@
 confidence: high
 id: '0006'
 references:
-- lines:
-  - 501
-  - 563
+- advisory: false
+  lines:
+  - 617
+  - 683
   path: longhand/parser.py
-  sha: a008ae34c0665ddbf558fc103344028e53430f9ceb8f8b14263dd7c8d1621e23
+  pinned_at: '2026-06-11T17:58:33.908597Z'
+  sha: b8b583658f110c8b62314e57d7b127ca88b40e9631bd32f96644a589055f18e2
   symbol: JSONLParser.build_session
 session_id: null
 superseded_by: null


### PR DESCRIPTION
## What

- Re-pins the 3 stale fieldnotes (0002, 0004, 0006) after the repo-wide ruff format adoption (#24) and the v0.10/v0.11 redaction + truncation changes drifted their SHAs.
- Each note's **claim was re-validated against current code before re-pinning** (the new fieldnotes v0.9 workflow — `fieldnotes diff <id>` per note, then re-read):
  - 0002/0006 — mode-of-cwds project attribution: intact (`parser.py` Counter/most_common, `_MAX_UNIQUE_CWDS_SCANNED` still bounds the scan).
  - 0004 — no `Intent:` prefix on fix_summary: intact (only the docstring and the v4 migration reference the string).
- The fieldnotes pre-commit drift gate is now installed locally (`.git/hooks`, untracked) so future commits can't silently strand these notes again.

## Why

Cross-repo staleness audit (2026-06-11): repos without the gate sat at 50–100% stale notes; gated repos under 20%. Longhand was at 3/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)