### PR TITLE
fix: repair project misattribution (cwd↔project_id desync)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ commits and tag annotations of those releases.
 
 ---
 
-## [0.11.1] — Unreleased
+## [0.11.1] — 2026-06-18
 
 Bugfix release: per-project rollup counters were inflated, and sessions could be
 filed under the wrong project. No schema-breaking changes; a one-time migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,23 @@ commits and tag annotations of those releases.
 
 ## [0.11.1] — Unreleased
 
-Bugfix release: the per-project rollup counters were inflated. No schema-breaking
-changes; a one-time migration repairs existing databases automatically on first open.
+Bugfix release: per-project rollup counters were inflated, and sessions could be
+filed under the wrong project. No schema-breaking changes; a one-time migration
+repairs existing databases automatically on first open.
 
 ### Fixed
 
+- **Project misattribution: sessions no longer drift to the wrong project.**
+  `session.cwd` (set by the Stop-hook live tail via `MAX(cwd)`, a meaningless
+  lexicographic pick) and `project_id` (set only by the full analysis pass) were
+  written by independent paths and could desync — so work launched from `$HOME`
+  ended up filed under the home catch-all project, invisible to per-project
+  recall. On a real 265-session corpus, 35 sessions (13%) were affected. Now
+  project attribution and cwd are always derived together from the same events
+  (`attribute_session_project()`), and the live tail derives cwd the same way
+  `build_session` does instead of `MAX(cwd)`. New `longhand reattribute` command
+  re-derives every session's project from the **events table** (not the
+  transcript, which may have rotated away) to repair existing databases.
 - **`projects.session_count` and `projects.total_edits` no longer double-count.**
   `upsert_project()` incremented both columns on *every* (re-)ingest of a session
   — SessionEnd, the live-tail Stop hook's analysis path, and `reconcile`

--- a/longhand/cli/_commands.py
+++ b/longhand/cli/_commands.py
@@ -983,6 +983,27 @@ def analyze(
         console.print(f"[green]✓[/green] Embedded {embedded} episode(s).")
 
 
+@app.command(rich_help_panel="Data")
+def reattribute(
+    data_dir: str | None = typer.Option(None, "--data-dir"),
+):
+    """Repair project misattribution.
+
+    Re-derives each session's project from its events in the database (not the
+    transcript file, which may have been rotated away) and re-attaches it. Fixes
+    sessions that drifted to the wrong project — e.g. work filed under the home
+    catch-all because cwd and project_id desynced. Idempotent.
+    """
+    store = _get_store(data_dir)
+    console.print("[cyan]Re-attributing sessions from the events table...[/cyan]")
+    result = store.reattribute_sessions()
+    console.print(
+        f"[bold]Scanned {result['scanned']}[/bold] sessions, "
+        f"[bold]{result['reattributed']}[/bold] re-attributed "
+        f"([dim]{result['skipped']} skipped — no events[/dim])"
+    )
+
+
 def _deprecated(old: str, new: str) -> None:
     """Print a deprecation warning for an aliased command.
 

--- a/longhand/setup_commands.py
+++ b/longhand/setup_commands.py
@@ -616,6 +616,45 @@ def ingest_single_session(
 # ─── Live ingest (for Stop hook) ──────────────────────────────────────────
 
 
+def _live_best_project_cwd(store: LonghandStore, session_id: str) -> str | None:
+    """Most-common event cwd for a session that resolves to a real project root
+    ($HOME and marker-less dirs excluded) — the same signal `build_session` uses.
+
+    SQL-driven and bounded so it stays cheap in the per-turn Stop hook, and never
+    raises. Returns None when no project cwd is found, in which case the caller
+    preserves the existing cwd rather than overwriting it. Replaces the old
+    `MAX(cwd)` pick, which chose a meaningless lexicographic max and drifted cwd
+    out of sync with project_id.
+    """
+    from longhand.analysis.project_inference import find_project_root_strict
+    from longhand.parser import _resolve_cwd_to_project
+
+    try:
+        with store.sqlite.connect() as conn:
+            rows = conn.execute(
+                "SELECT cwd, COUNT(*) AS n FROM events "
+                "WHERE session_id = ? AND cwd IS NOT NULL AND cwd != '' "
+                "GROUP BY cwd ORDER BY n DESC",
+                (session_id,),
+            ).fetchall()
+    except Exception:
+        return None
+
+    try:
+        home_resolved = Path.home().resolve()
+    except (OSError, PermissionError):
+        home_resolved = None
+
+    counts: dict[str, int] = {}
+    for row in rows[:20]:  # bounded, mirrors _MAX_UNIQUE_CWDS_SCANNED
+        root = _resolve_cwd_to_project(row["cwd"], home_resolved, find_project_root_strict)
+        if root:
+            counts[root] = counts.get(root, 0) + int(row["n"])
+    if not counts:
+        return None
+    return max(counts, key=lambda k: counts[k])
+
+
 def ingest_live_tail(
     transcript: str,
     data_dir: str | None = None,
@@ -756,7 +795,6 @@ def ingest_live_tail(
                              AND file_operation IN ('edit','write','multi_edit','notebook_edit')
                         THEN 1 ELSE 0 END
                     ) AS edit_count,
-                    MAX(cwd) AS cwd,
                     MAX(git_branch) AS git_branch,
                     MAX(model) AS model
                 FROM events
@@ -774,6 +812,11 @@ def ingest_live_tail(
             existing_session["started_at"] if existing_session else _dt.now().isoformat()
         )
         ended_at = agg["ended_at"] if agg and agg["ended_at"] else _dt.now().isoformat()
+
+        # Derive cwd the same way build_session does (mode of project-resolving
+        # cwds), not MAX(cwd). None → the UPSERT's COALESCE preserves the existing
+        # cwd, so an in-progress session never drifts out of sync with its project.
+        best_cwd = _live_best_project_cwd(store, session_id)
 
         with store.sqlite.connect() as conn:
             conn.execute(
@@ -798,9 +841,7 @@ def ingest_live_tail(
                 """,
                 (
                     session_id,
-                    existing_session["project_path"]
-                    if existing_session
-                    else (agg["cwd"] if agg else None),
+                    existing_session["project_path"] if existing_session else best_cwd,
                     str(path),
                     started_at,
                     ended_at,
@@ -810,7 +851,7 @@ def ingest_live_tail(
                     int(agg["tool_count"] or 0) if agg else 0,
                     int(agg["edit_count"] or 0) if agg else 0,
                     agg["git_branch"] if agg else None,
-                    agg["cwd"] if agg else None,
+                    best_cwd,
                     agg["model"] if agg else None,
                     _dt.now().isoformat(),
                 ),

--- a/longhand/storage/store.py
+++ b/longhand/storage/store.py
@@ -105,20 +105,119 @@ class LonghandStore:
 
         return result
 
+    def attribute_session_project(self, session: Session, events: list[Event]) -> dict:
+        """Infer this session's project, attach it, and refresh the project's
+        derived rollups — WITHOUT the heavy episode/segment/embedding analysis.
+
+        This is the lockstep primitive: project_id is always derived from the same
+        (session, events) pair that determines the session's cwd, so the two can't
+        desync. Used by analyze_session (full pass), the live-tail hook, and the
+        reattribute backfill. session_count / total_edits are recomputed from the
+        sessions table (not incremented), so repeated calls never inflate them.
+        """
+        project = infer_project(session, events)
+        self.sqlite.upsert_project(project)
+        self.sqlite.attach_session_to_project(session.session_id, project["project_id"])
+        self.sqlite.recompute_project_stats(project["project_id"])
+        return project
+
+    def reattribute_sessions(self, session_ids: list[str] | None = None) -> dict:
+        """Re-derive each session's project (and corrected cwd) from its events in
+        the events table — independent of the transcript file, which may have been
+        rotated off disk — and re-attach it.
+
+        Repairs project_id↔cwd drift (the F2 misattribution bug, where sessions
+        ended up filed under the home catch-all). Returns counts:
+        ``{scanned, reattributed, skipped}``.
+        """
+        from longhand.parser import _pick_best_project_cwd
+
+        rows = self.sqlite.list_sessions(limit=1_000_000)
+        if session_ids is not None:
+            wanted = set(session_ids)
+            rows = [r for r in rows if r["session_id"] in wanted]
+
+        scanned = reattributed = skipped = 0
+        for row in rows:
+            sid = row["session_id"]
+            events = self._events_for_session(sid)
+            if not events:
+                skipped += 1
+                continue
+            best_cwd = _pick_best_project_cwd(events) or row.get("cwd") or row.get("project_path")
+            session = self._session_from_row(row, best_cwd)
+            old_pid = row.get("project_id")
+            project = self.attribute_session_project(session, events)
+            if best_cwd and best_cwd != row.get("cwd"):
+                with self.sqlite.connect() as conn:
+                    conn.execute(
+                        "UPDATE sessions SET cwd = ? WHERE session_id = ?", (best_cwd, sid)
+                    )
+            scanned += 1
+            if project["project_id"] != old_pid:
+                reattributed += 1
+
+        # Sessions may have moved between projects — re-derive every project's
+        # rollups so counts stay accurate (emptied projects drop to 0).
+        with self.sqlite.connect() as conn:
+            pids = [r[0] for r in conn.execute("SELECT project_id FROM projects").fetchall()]
+        for pid in pids:
+            self.sqlite.recompute_project_stats(pid)
+
+        return {"scanned": scanned, "reattributed": reattributed, "skipped": skipped}
+
+    def _events_for_session(self, session_id: str) -> list[Event]:
+        """Rebuild Event objects from the events table — only the fields project
+        attribution needs. Used when the transcript is no longer on disk."""
+        from longhand.parser import _parse_timestamp
+
+        rows = self.sqlite.get_events(session_id=session_id, limit=1_000_000)
+        events: list[Event] = []
+        for r in rows:
+            try:
+                events.append(
+                    Event(
+                        event_id=r["event_id"],
+                        session_id=r["session_id"],
+                        parent_event_id=r.get("parent_event_id"),
+                        event_type=r["event_type"],
+                        sequence=r["sequence"],
+                        timestamp=_parse_timestamp(r.get("timestamp")),
+                        cwd=r.get("cwd"),
+                        model=r.get("model"),
+                        content=r.get("content") or "",
+                        file_path=r.get("file_path"),
+                        file_operation=r.get("file_operation"),
+                    )
+                )
+            except Exception:
+                continue
+        return events
+
+    def _session_from_row(self, row: dict, cwd: str | None) -> Session:
+        from longhand.parser import _parse_timestamp
+
+        return Session(
+            session_id=row["session_id"],
+            project_path=cwd or row.get("project_path"),
+            transcript_path=row.get("transcript_path") or "",
+            started_at=_parse_timestamp(row.get("started_at")),
+            ended_at=_parse_timestamp(row.get("ended_at")),
+            event_count=row.get("event_count") or 0,
+            file_edit_count=row.get("file_edit_count") or 0,
+            git_branch=row.get("git_branch"),
+            cwd=cwd,
+            model=row.get("model"),
+        )
+
     def analyze_session(self, session: Session, events: list[Event]) -> dict:
         """Run the analysis layer for a session: project, outcome, episodes, embeddings.
 
         Safe to call multiple times (upserts everywhere). Used both by `ingest_session`
         and by the `longhand analyze --all` backfill command.
         """
-        # 1. Project inference + merge
-        project = infer_project(session, events)
-        self.sqlite.upsert_project(project)
-        self.sqlite.attach_session_to_project(session.session_id, project["project_id"])
-        # session_count / total_edits are derived rollups — recompute from the
-        # sessions table now that this session is attached, so re-ingests don't
-        # inflate them.
-        self.sqlite.recompute_project_stats(project["project_id"])
+        # 1. Project inference + attach (cwd↔project_id kept in lockstep here).
+        project = self.attribute_session_project(session, events)
 
         # 1b. Project embedding
         self.vectors.add_project_embedding(

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -187,7 +187,11 @@ def test_live_tail_sets_cwd_to_project_not_lexicographic_max(tmp_path):
                         "type": "tool_use",
                         "id": "t1",
                         "name": "Edit",
-                        "input": {"file_path": f"{proj}/main.py", "old_string": "a", "new_string": "b"},
+                        "input": {
+                            "file_path": f"{proj}/main.py",
+                            "old_string": "a",
+                            "new_string": "b",
+                        },
                     }
                 ],
             },

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -1,0 +1,206 @@
+"""Project attribution: keep session.cwd and project_id in lockstep, and repair
+drift from the events table (the F2 misattribution fix).
+
+These tests avoid touching the real $HOME by simulating a "launched from a
+non-project directory" scenario: the noise cwd is a marker-less temp dir (which
+_pick_best_project_cwd filters out exactly like it filters $HOME), and the real
+work happens in a temp dir that DOES carry a .git marker.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from longhand.parser import JSONLParser
+from longhand.setup_commands import ingest_live_tail
+from longhand.storage import LonghandStore
+
+
+def _write_session_file(path: Path, noise_cwd: str, project_cwd: str) -> Path:
+    """A session that starts in `noise_cwd` (no project marker) but does its real
+    work — including file edits — in `project_cwd` (which has a .git marker)."""
+    entries = [
+        {
+            "type": "user",
+            "uuid": "u1",
+            "sessionId": "attr-session",
+            "timestamp": "2026-04-09T10:00:01.000Z",
+            "cwd": noise_cwd,
+            "isSidechain": False,
+            "message": {"role": "user", "content": "fix the bug in main.py"},
+        },
+    ]
+    # The bulk of the work happens in the real project.
+    for i in range(2, 8):
+        entries.append(
+            {
+                "type": "assistant",
+                "uuid": f"a{i}",
+                "parentUuid": "u1",
+                "sessionId": "attr-session",
+                "timestamp": f"2026-04-09T10:00:0{i}.000Z",
+                "cwd": project_cwd,
+                "isSidechain": False,
+                "message": {
+                    "model": "claude-sonnet-4-6",
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": f"t{i}",
+                            "name": "Edit",
+                            "input": {
+                                "file_path": f"{project_cwd}/main.py",
+                                "old_string": f"old{i}",
+                                "new_string": f"new{i}",
+                            },
+                        }
+                    ],
+                },
+            }
+        )
+    with path.open("w") as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+    return path
+
+
+def _make_project_dir(tmp_path: Path, name: str) -> str:
+    proj = tmp_path / name
+    (proj / ".git").mkdir(parents=True)
+    return str(proj)
+
+
+def test_build_session_prefers_real_project_over_launch_dir(tmp_path):
+    """Sanity: build_session already picks the real project cwd, not the noise
+    launch dir. (Guards the signal the attribution fix depends on.)"""
+    project_cwd = _make_project_dir(tmp_path, "realproj")
+    noise_cwd = str(tmp_path / "nowhere")
+    Path(noise_cwd).mkdir()
+    sf = _write_session_file(tmp_path / "s.jsonl", noise_cwd, project_cwd)
+
+    parser = JSONLParser(sf)
+    events = list(parser.parse_events())
+    session = parser.build_session(events)
+
+    assert session.cwd == project_cwd
+
+
+def test_attribute_session_project_attaches_and_recomputes(tmp_path):
+    """attribute_session_project infers + attaches the project and refreshes the
+    project rollups, keeping cwd↔project_id in lockstep — without running the
+    heavy episode/segment analysis."""
+    project_cwd = _make_project_dir(tmp_path, "realproj")
+    noise_cwd = str(tmp_path / "nowhere")
+    Path(noise_cwd).mkdir()
+    sf = _write_session_file(tmp_path / "s.jsonl", noise_cwd, project_cwd)
+
+    store = LonghandStore(data_dir=tmp_path / "lh")
+    parser = JSONLParser(sf)
+    events = list(parser.parse_events())
+    session = parser.build_session(events)
+    store.ingest_session(session, events, run_analysis=False)  # events only, no attribution
+
+    project = store.attribute_session_project(session, events)
+
+    assert project["canonical_path"] == project_cwd
+    row = store.sqlite.get_session(session.session_id)
+    assert row["project_id"] == project["project_id"]
+    p = store.sqlite.get_project(project["project_id"])
+    assert p["session_count"] == 1
+    assert p["total_edits"] == session.file_edit_count
+
+
+def test_reattribute_repairs_drift_from_events_table(tmp_path):
+    """The backfill re-derives the project from events in the DB (NOT the
+    transcript) and repairs a session whose project_id has drifted to the wrong
+    project — even when its stored cwd has drifted too."""
+    project_cwd = _make_project_dir(tmp_path, "realproj")
+    other_cwd = _make_project_dir(tmp_path, "wrongproj")
+    noise_cwd = str(tmp_path / "nowhere")
+    Path(noise_cwd).mkdir()
+    sf = _write_session_file(tmp_path / "s.jsonl", noise_cwd, project_cwd)
+
+    store = LonghandStore(data_dir=tmp_path / "lh")
+    parser = JSONLParser(sf)
+    events = list(parser.parse_events())
+    session = parser.build_session(events)
+    store.ingest_session(session, events, run_analysis=True)
+
+    real_pid = store.sqlite.get_session(session.session_id)["project_id"]
+    assert store.sqlite.get_project(real_pid)["canonical_path"] == project_cwd
+
+    # Simulate desync: drift both project_id and cwd to the wrong/noise values,
+    # mimicking a no-analysis re-ingest + MAX(cwd) overwrite.
+    from longhand.analysis.project_inference import _canonicalize_path, _project_id_for
+
+    wrong_pid = _project_id_for(_canonicalize_path(other_cwd))
+    with store.sqlite.connect() as conn:
+        conn.execute(
+            "UPDATE sessions SET project_id = ?, cwd = ? WHERE session_id = ?",
+            (wrong_pid, noise_cwd, session.session_id),
+        )
+        conn.commit()
+
+    result = store.reattribute_sessions()
+
+    assert result["reattributed"] >= 1
+    fixed = store.sqlite.get_session(session.session_id)
+    assert fixed["project_id"] == real_pid  # back to the real project
+    assert fixed["cwd"] == project_cwd  # cwd re-derived from events too
+
+
+def test_live_tail_sets_cwd_to_project_not_lexicographic_max(tmp_path):
+    """The Stop-hook live tail must derive cwd from the real project (like
+    build_session), not MAX(cwd) — a lexicographically larger, marker-less dir
+    would otherwise win and desync cwd from project_id."""
+    proj = _make_project_dir(tmp_path, "proj")  # has a .git marker
+    noise = str(tmp_path / "zzz_noise")  # no marker, lexicographically AFTER proj
+    Path(noise).mkdir()
+    assert noise > proj  # sanity: MAX(cwd) would pick the noise dir
+
+    transcript = tmp_path / "live.jsonl"
+    entries = [
+        {
+            "type": "user",
+            "uuid": "u1",
+            "sessionId": "live-attr",
+            "timestamp": "2026-04-28T10:00:00.000Z",
+            "cwd": noise,
+            "isSidechain": False,
+            "message": {"role": "user", "content": "start"},
+        },
+        {
+            "type": "assistant",
+            "uuid": "a1",
+            "parentUuid": "u1",
+            "sessionId": "live-attr",
+            "timestamp": "2026-04-28T10:00:01.000Z",
+            "cwd": proj,
+            "isSidechain": False,
+            "message": {
+                "model": "claude-sonnet-4-6",
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "t1",
+                        "name": "Edit",
+                        "input": {"file_path": f"{proj}/main.py", "old_string": "a", "new_string": "b"},
+                    }
+                ],
+            },
+        },
+    ]
+    with transcript.open("w") as f:
+        for e in entries:
+            f.write(json.dumps(e) + "\n")
+
+    data_dir = tmp_path / "lh"
+    ingest_live_tail(str(transcript), str(data_dir))
+
+    store = LonghandStore(data_dir=data_dir)
+    row = store.sqlite.get_session("live-attr")
+    assert row is not None
+    assert row["cwd"] == proj


### PR DESCRIPTION
Re-opened as a fresh PR — #34 auto-closed when #33's branch was deleted on merge. Same branch/commits; now targets `main` (which already has the F1 fix as shared ancestry, so this diff is F2-only).

## What
Sessions could be filed under the **wrong project** — work launched from $HOME landed under the home catch-all instead of the real project, invisible to per-project recall. Measured **35 of 265 sessions (13%)** misfiled on the live corpus.

## Root cause
`session.cwd` and `project_id` were written by independent paths and desynced: the per-turn Stop hook (`ingest_live_tail`) overwrote `cwd` with `MAX(cwd)` (a meaningless lexicographic pick) and never touched `project_id`; `project_id` only moved during the full analysis pass.

## Fix
1. `attribute_session_project()` — cwd and project_id now derived together from the same events, in lockstep. `analyze_session` delegates to it.
2. Live tail derives cwd like `build_session` does (`_live_best_project_cwd`), not `MAX(cwd)`.
3. `longhand reattribute` — repairs existing DBs from the **events table** (not transcripts, which may have rotated away).

## Verification
- `tests/test_attribution.py`: lockstep attribution, live-tail cwd is the project not MAX, events-based backfill repairs seeded drift.
- ruff + mypy clean; 323 tests pass.

Releases as part of **0.11.1** (version + sibling manifests + changelog finalized on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)