### PR TITLE
docs: refresh README corpus stats to 281 sessions / 67 projects / 323 tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ longhand analyze --all           # fill in episodes + vectors whenever, safe to 
 
 Exact-text search, timelines, file history, and commit lookup all work after `--skip-analysis`. Semantic `recall` needs the `analyze --all` pass to complete. Typical throughput on an M-class Mac is ~1–2 sessions/sec for full analysis.
 
-> *Status: v0.11.1 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 246 real Claude Code sessions across 54 inferred projects. 316 unit tests passing.*
+> *Status: v0.11.1 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 281 real Claude Code sessions across 67 inferred projects. 323 unit tests passing.*
 
 **Full docs:** [Longhand Wiki](https://github.com/Wynelson94/longhand/wiki) — getting started, CLI reference, MCP tools reference, architecture, and troubleshooting.
 
@@ -97,7 +97,7 @@ The "memory crisis" in AI was an artificial constraint. Storage is solved. SQLit
 
 **Local. Complete. Yours.**
 
-> **Storage footprint:** ~2GB for a heavy power user (240+ sessions, 125k events, months of daily Opus usage across 14 repos). Typical users: 200–400MB. Once Claude Code rotates the source files off disk, Longhand isn't a duplicate — it's the only copy.
+> **Storage footprint:** ~2GB for a heavy power user (280+ sessions, 145k events, months of daily Opus usage across 14 repos). Typical users: 200–400MB. Once Claude Code rotates the source files off disk, Longhand isn't a duplicate — it's the only copy.
 
 ---
 


### PR DESCRIPTION
## What

Pure documentation accuracy refresh — two lines in `README.md`:

- **Status line:** `246 sessions / 54 projects / 316 tests` → `281 / 67 / 323`
- **Storage-footprint example:** `240+ sessions, 125k events` → `280+ sessions, 145k events`

No code, config, dependency, or CI changes.

## Why

The README still cited the corpus from PR #30. Current figures come from a live audit this session:
- `longhand get_stats`: 281 sessions, 145,159 events, 67 projects
- `pytest`: 323 passed

## Audit context

This PR is the one stale item from a full health audit (repo / install-drift / runtime). Verdict: healthy — v0.11.1, 323/323 tests, zero ruff violations, the formerly-dead auto-context hook fixed, installed == repo == latest PyPI (no drift), data store fresh. CI already gates coverage + mypy; the `posthog<3.0` pin is already documented. The README stats were the only thing actually out of date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)