### PR TITLE
fix: multi-process reliability (migration race, dead spawn, hook guards, ingest lock)

### DIFF
--- a/longhand/recall/project_fallback.py
+++ b/longhand/recall/project_fallback.py
@@ -141,7 +141,10 @@ def trigger_background_ingest(store: LonghandStore) -> bool:
         # leaks a file descriptor on the calling process.
         with log_file.open("a") as log_fh:
             subprocess.Popen(
-                [sys.executable, "-m", "longhand.cli", "ingest"],
+                # "-m longhand" (the package __main__), NOT "-m longhand.cli":
+                # longhand.cli is a package with no __main__.py, so spawning
+                # it dies instantly and the background ingest never runs.
+                [sys.executable, "-m", "longhand", "ingest"],
                 stdout=log_fh,
                 stderr=subprocess.STDOUT,
                 start_new_session=True,

--- a/longhand/setup_commands.py
+++ b/longhand/setup_commands.py
@@ -588,13 +588,35 @@ def ingest_single_session(
     runs; even faster when skipped. Pass ``run_analysis=False`` to populate
     SQLite only (no episodes, segments, or vectors). Power users can defer
     the analysis pass via ``longhand analyze --all``.
+
+    Takes the ingest lock: parallel sessions ending together would otherwise
+    open concurrent ChromaDB writers on the same directory, which ChromaDB
+    does not tolerate. A locked-out session defers (success exit) — the bulk
+    ingest holding the lock, or a later reconcile, picks it up.
     """
+    from longhand.recall.project_fallback import (
+        claim_ingest_lock,
+        release_ingest_lock,
+    )
+
     path = Path(transcript).expanduser()
     if not path.exists():
         console.print(f"[red]Transcript not found: {transcript}[/red]")
         raise typer.Exit(1)
 
-    store = LonghandStore(data_dir=data_dir)
+    try:
+        store = LonghandStore(data_dir=data_dir)
+    except Exception as e:
+        console.print(f"[red]✗[/red] Could not open the Longhand store: {e}")
+        raise typer.Exit(1) from e
+
+    if not claim_ingest_lock(store):
+        console.print(
+            f"[yellow]Another Longhand ingest is running — deferring {path.name}; "
+            "reconcile will pick it up.[/yellow]"
+        )
+        return
+
     try:
         parser = JSONLParser(path)
         events = list(parser.parse_events())
@@ -611,6 +633,8 @@ def ingest_single_session(
     except Exception as e:
         console.print(f"[red]✗[/red] Failed to ingest {path.name}: {e}")
         raise typer.Exit(1) from e
+    finally:
+        release_ingest_lock(store)
 
 
 # ─── Live ingest (for Stop hook) ──────────────────────────────────────────
@@ -698,18 +722,23 @@ def ingest_live_tail(
         summary["skipped"] = "empty"
         return summary
 
-    store = LonghandStore(data_dir=data_dir)
-
-    if store.sqlite.live_caught_up(str(path), current_size):
-        summary["skipped"] = "caught-up"
-        return summary
-
-    # Non-blocking lock — if a heavier ingest is running, defer to next Stop.
-    if not claim_ingest_lock(store):
-        summary["skipped"] = "locked"
-        return summary
-
+    locked = False
     try:
+        # LonghandStore() runs migrations and opens ChromaDB — it can raise
+        # (corrupted store, disk full, migration race), so it must sit inside
+        # this guard: nothing in this function may raise into the Stop hook.
+        store = LonghandStore(data_dir=data_dir)
+
+        if store.sqlite.live_caught_up(str(path), current_size):
+            summary["skipped"] = "caught-up"
+            return summary
+
+        # Non-blocking lock — if a heavier ingest is running, defer to next Stop.
+        if not claim_ingest_lock(store):
+            summary["skipped"] = "locked"
+            return summary
+        locked = True
+
         start_offset = store.sqlite.get_live_offset(str(path))
 
         try:
@@ -873,7 +902,8 @@ def ingest_live_tail(
         summary["skipped"] = f"error:{type(e).__name__}"
         return summary
     finally:
-        release_ingest_lock(store)
+        if locked:
+            release_ingest_lock(store)
 
 
 # ─── Doctor ────────────────────────────────────────────────────────────────

--- a/longhand/storage/migrations.py
+++ b/longhand/storage/migrations.py
@@ -8,6 +8,7 @@ Migrations are applied in order, once, and logged in the `schema_version` table.
 from __future__ import annotations
 
 import sqlite3
+import time
 from datetime import datetime
 
 MIGRATIONS: dict[int, str] = {
@@ -255,12 +256,28 @@ def apply_migrations(conn: sqlite3.Connection) -> list[int]:
             continue
 
         sql = MIGRATIONS[version]
-        conn.executescript(sql)
-        _apply_alters(conn, version)
-        conn.execute(
-            "INSERT INTO schema_version (version, applied_at) VALUES (?, ?)",
-            (version, datetime.now().isoformat()),
-        )
+        try:
+            conn.executescript(sql)
+            _apply_alters(conn, version)
+            conn.execute(
+                "INSERT INTO schema_version (version, applied_at) VALUES (?, ?)",
+                (version, datetime.now().isoformat()),
+            )
+        except (sqlite3.IntegrityError, sqlite3.OperationalError):
+            # Two processes can race the same migration right after an
+            # upgrade (parallel session hooks, the MCP server, and the CLI
+            # all construct stores). The loser sees "already exists" /
+            # "duplicate column" from the DDL or a schema_version PK hit.
+            # Wait for the winner to record the version, then move on;
+            # only re-raise if it never lands (a genuine failure).
+            conn.rollback()
+            for _ in range(20):
+                if version in _applied_versions(conn):
+                    break
+                time.sleep(0.05)
+            else:
+                raise
+            continue
         newly_applied.append(version)
 
     conn.commit()

--- a/longhand/storage/sqlite_store.py
+++ b/longhand/storage/sqlite_store.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime
@@ -110,15 +111,33 @@ class SQLiteStore:
         self._init_schema()
 
     def _init_schema(self) -> None:
-        with self.connect() as conn:
-            conn.executescript(SCHEMA)
-            apply_migrations(conn)
+        # Concurrent first-runs (parallel session hooks right after an upgrade)
+        # can deadlock-detect and raise "database is locked" immediately —
+        # busy_timeout does not apply to that path. The whole init is
+        # idempotent (IF NOT EXISTS DDL, guarded ALTERs, versioned migrations),
+        # so retry until it lands instead of crashing the losing process.
+        last_lock_error: sqlite3.OperationalError | None = None
+        for _ in range(100):
+            try:
+                with self.connect() as conn:
+                    conn.executescript(SCHEMA)
+                    apply_migrations(conn)
+                return
+            except sqlite3.OperationalError as e:
+                if "locked" not in str(e).lower():
+                    raise
+                last_lock_error = e
+                time.sleep(0.05)
+        assert last_lock_error is not None
+        raise last_lock_error  # pragma: no cover — >5s of sustained contention
 
     @contextmanager
     def connect(self) -> Iterator[sqlite3.Connection]:
         conn = sqlite3.connect(str(self.db_path))
         conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA busy_timeout = 5000")
+        # 30s: parallel session hooks + bulk ingests can hold the write lock
+        # through large executemany batches; waiting beats "database is locked".
+        conn.execute("PRAGMA busy_timeout = 30000")
         # WAL lets the Stop hook ingest concurrently with reads from MCP/CLI
         # without serializing on the busy_timeout. Idempotent: SQLite remembers
         # the journal mode in the file header.

--- a/tests/test_ingest_live.py
+++ b/tests/test_ingest_live.py
@@ -333,3 +333,57 @@ def test_live_then_session_end_composes(tmp_path: Path) -> None:
 
     assert n_events == len(events)
     assert size_logged == transcript.stat().st_size
+
+
+def test_live_tail_never_raises_when_store_init_fails(tmp_path, monkeypatch):
+    """Store construction failures must surface as a summary, never an exception.
+
+    The Stop hook calls this every assistant turn — a corrupted Chroma dir or
+    a migration race must not crash the hook chain.
+    """
+    entry = {
+        "type": "user",
+        "uuid": "u-x",
+        "sessionId": "s-x",
+        "timestamp": "2026-01-01T00:00:00Z",
+        "cwd": "/tmp/p",
+        "message": {"role": "user", "content": "hi"},
+    }
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text(_line(entry))
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("corrupted store")
+
+    monkeypatch.setattr("longhand.setup_commands.LonghandStore", boom)
+
+    summary = ingest_live_tail(str(transcript), data_dir=str(tmp_path / "lh"))
+    assert summary["skipped"] == "error:RuntimeError"
+
+
+def test_live_tail_never_raises_when_caught_up_check_fails(tmp_path, monkeypatch):
+    """Failures after store construction but before the lock also return a summary."""
+
+    class _BrokenSqlite:
+        def live_caught_up(self, *args, **kwargs):
+            raise RuntimeError("db exploded")
+
+    class _BrokenStore:
+        def __init__(self, *args, **kwargs):
+            self.sqlite = _BrokenSqlite()
+
+    monkeypatch.setattr("longhand.setup_commands.LonghandStore", _BrokenStore)
+
+    entry = {
+        "type": "user",
+        "uuid": "u-y",
+        "sessionId": "s-y",
+        "timestamp": "2026-01-01T00:00:00Z",
+        "cwd": "/tmp/p",
+        "message": {"role": "user", "content": "hi"},
+    }
+    transcript = tmp_path / "t.jsonl"
+    transcript.write_text(_line(entry))
+
+    summary = ingest_live_tail(str(transcript), data_dir=None)
+    assert summary["skipped"] == "error:RuntimeError"

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -318,3 +318,66 @@ def test_v6_migration_repairs_inflated_project_counts(tmp_path: Path):
     p = store.get_project("proj1")
     assert p["session_count"] == 2
     assert p["total_edits"] == 5
+
+
+def test_migration_race_loser_recovers(tmp_path: Path):
+    """A process that loses the post-upgrade migration race must not crash.
+
+    Simulate the loser: its first read of applied versions is stale (empty),
+    but the winner has already fully applied every migration. The loser's
+    DDL/INSERT conflicts must be swallowed once the version rows are visible.
+    """
+    from unittest.mock import patch
+
+    from longhand.storage import migrations as mig
+
+    store = SQLiteStore(tmp_path / "race.db")  # fully migrated on init
+
+    real = mig._applied_versions
+    calls = {"n": 0}
+
+    def stale_first(conn):
+        calls["n"] += 1
+        return set() if calls["n"] == 1 else real(conn)
+
+    with (
+        store.connect() as conn,
+        patch.object(mig, "_applied_versions", side_effect=stale_first),
+    ):
+        applied = apply_migrations(conn)
+
+    assert applied == []  # loser records nothing; the winner's rows stand
+
+
+def test_concurrent_store_init_does_not_crash(tmp_path: Path):
+    """Two stores constructed concurrently on one fresh DB must both survive.
+
+    Stand-in for parallel session hooks racing migrations right after an
+    upgrade — each thread opens its own connection, like separate processes.
+    """
+    import threading
+
+    db = tmp_path / "concurrent.db"
+    errors: list[Exception] = []
+    barrier = threading.Barrier(2)
+
+    def build() -> None:
+        try:
+            barrier.wait(timeout=10)
+            SQLiteStore(db)
+        except Exception as e:  # pragma: no cover — the bug this guards against
+            errors.append(e)
+
+    threads = [threading.Thread(target=build) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=60)
+
+    assert errors == []
+    conn = sqlite3.connect(str(db))
+    dupes = conn.execute(
+        "SELECT version FROM schema_version GROUP BY version HAVING COUNT(*) > 1"
+    ).fetchall()
+    conn.close()
+    assert dupes == []

--- a/tests/test_project_fallback.py
+++ b/tests/test_project_fallback.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import importlib.util
 import os
+import subprocess
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
 from longhand.parser import JSONLParser
 from longhand.recall import project_fallback
 from longhand.recall.project_match import match_projects
+from longhand.setup_commands import ingest_single_session
 
 
 def _ingest(fixture_path, store):
@@ -205,3 +209,71 @@ def test_claim_lock_atomic_create_loses_race(temp_store):
     # The racing winner's PID must be untouched.
     assert lock.read_text().strip() == str(other_pid)
     lock.unlink()
+
+
+def test_trigger_background_ingest_spawn_target_is_executable(temp_store):
+    """The spawned `-m` target must be an importable, runnable module.
+
+    Regression guard: v0.11.1 spawned `-m longhand.cli` — a package with no
+    __main__.py — so every background ingest died instantly and silently.
+    """
+    temp_store.data_dir.mkdir(parents=True, exist_ok=True)
+
+    with patch("subprocess.Popen") as mock_popen:
+        assert project_fallback.trigger_background_ingest(temp_store) is True
+
+    argv = mock_popen.call_args[0][0]
+    assert argv[0] == sys.executable
+    assert argv[1] == "-m"
+    target = argv[2]
+    spec = importlib.util.find_spec(target)
+    assert spec is not None, f"spawn target {target!r} is not importable"
+    if spec.submodule_search_locations is not None:
+        assert importlib.util.find_spec(f"{target}.__main__") is not None, (
+            f"spawn target {target!r} is a package without __main__.py — it dies instantly under -m"
+        )
+
+
+def test_python_dash_m_longhand_runs():
+    """`python -m longhand` must keep working — the background spawn depends on it."""
+    result = subprocess.run(
+        [sys.executable, "-m", "longhand", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_ingest_single_session_defers_when_lock_held(sample_session_file, temp_store):
+    """SessionEnd ingest defers with a success exit when another ingest owns the lock."""
+    lock = temp_store.data_dir / ".ingest.lock"
+    temp_store.data_dir.mkdir(parents=True, exist_ok=True)
+    # Another alive PID (claim is idempotent for our own PID, so use the parent).
+    lock.write_text(str(os.getppid()))
+
+    ingest_single_session(
+        str(sample_session_file), data_dir=str(temp_store.data_dir), run_analysis=False
+    )
+
+    with temp_store.sqlite.connect() as conn:
+        n = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+    assert n == 0  # deferred — nothing ingested, nothing raised
+    assert lock.exists()  # not ours; must be left untouched
+    lock.unlink()
+
+
+def test_ingest_single_session_reclaims_stale_lock_and_releases(sample_session_file, temp_store):
+    """A dead holder must not block SessionEnd; the lock is released afterwards."""
+    lock = temp_store.data_dir / ".ingest.lock"
+    temp_store.data_dir.mkdir(parents=True, exist_ok=True)
+    lock.write_text("0")  # PID 0 — treated as dead/invalid
+
+    ingest_single_session(
+        str(sample_session_file), data_dir=str(temp_store.data_dir), run_analysis=False
+    )
+
+    with temp_store.sqlite.connect() as conn:
+        n = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+    assert n == 1
+    assert not lock.exists()  # released in the finally

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -296,3 +296,9 @@ def test_batched_methods_return_upserted_count(temp_store):
         {"segment_id": "s-2", "text": "", "metadata": {"segment_type": "discussion"}},
     ]
     assert temp_store.vectors.add_segment_embeddings_batch(seg_items) == 1
+
+
+def test_busy_timeout_pragma(temp_store):
+    """Write-lock waits must be generous — parallel hooks contend on one DB."""
+    with temp_store.sqlite.connect() as conn:
+        assert conn.execute("PRAGMA busy_timeout").fetchone()[0] == 30000


### PR DESCRIPTION
Part 1 of 2 of the v0.11.2 patch from the 2026-07-09 full audit. Bug fixes only — zero new migrations (deliberate: the migration-race fix must reach users one release before any new migration ships).

## Fixes

1. **Dead background-ingest spawn** (`recall/project_fallback.py`) — the fallback spawned `python -m longhand.cli`, but `longhand.cli` is a package with no `__main__.py`: every background ingest since the cli-package refactor died instantly and silently (daily on the maintainer's machine; it's why the Chroma index lags SQLite). Now spawns `python -m longhand`.
2. **Post-upgrade migration race** (`storage/migrations.py`) — two processes constructing stores right after an upgrade both read stale `schema_version`, both apply, and the loser crashed on the PK `IntegrityError`. The loser now waits (bounded) for the winner's version row and continues.
3. **Immediate 'database is locked' on concurrent init** (`storage/sqlite_store.py`) — deadlock-detected lock errors bypass `busy_timeout`; schema init is fully idempotent, so it now retries instead of crashing the losing process. Also raises `busy_timeout` 5s → 30s.
4. **SessionEnd ingest takes the ingest lock** (`setup_commands.py`) — parallel sessions ending together opened concurrent ChromaDB writers on one directory (index-corruption risk). Locked-out sessions defer with a success exit; reconcile picks them up.
5. **Stop-hook never-raises guard actually covers everything** (`setup_commands.py`) — store construction ran migrations + opened ChromaDB *outside* the guard, so a corrupted store crashed the hook every turn. Now inside, with lock-release correctly gated.

## Tests

+9 (332 total): race-loser recovery, 2-thread concurrent init (×5 stable), spawn-target-executability (kills the dead-`-m` bug class permanently), `python -m longhand --help` integration, SessionEnd defer/reclaim lock behavior, Stop-hook store-init failure returns a summary dict, busy_timeout readback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)