### PR TITLE
chore: land 6 stranded analytics snapshots; surface non-blocking py3.14 failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
       - name: Run pytest (with coverage gate)
+        id: pytest
         # 3.14 runs but is non-blocking: onnxruntime's cp314 wheel (via chromadb)
         # intermittently raises an illegal-instruction SIGILL on GitHub's
         # heterogeneous runner CPUs. The CPython code is fine (3.14 passes locally
@@ -34,6 +35,14 @@ jobs:
         # 3.10–3.13 gated; surface 3.14 without letting a native crash block PRs.
         continue-on-error: ${{ matrix.python-version == '3.14' }}
         run: pytest -q --cov=longhand --cov-report=term-missing --cov-fail-under=60
+      - name: Surface non-blocking 3.14 failure
+        # continue-on-error hides a red 3.14 job behind a green check; make the
+        # failure loud (annotation + step summary) without blocking the merge.
+        # Tracking: https://github.com/Wynelson94/longhand/issues/40
+        if: matrix.python-version == '3.14' && steps.pytest.outcome == 'failure'
+        run: |
+          echo "::warning title=Python 3.14 tests failed (non-blocking)::pytest failed on 3.14. The job is continue-on-error (onnxruntime cp314 SIGILL, issue #40), so this does NOT block the merge — but look before releasing."
+          echo "### :warning: Python 3.14 tests FAILED (non-blocking — issue #40)" >> "$GITHUB_STEP_SUMMARY"
 
   lint:
     name: Ruff

--- a/outreach/analytics-2026-05-29.md
+++ b/outreach/analytics-2026-05-29.md
@@ -1,0 +1,103 @@
+# Longhand Analytics Snapshot — 2026-05-29
+
+**Snapshot date:** 2026-05-29 (UTC)  
+**Snapshot type:** Bootstrap — first `analytics-*.md` file. No prior snapshot exists; deltas section omitted. Reference baseline from `outreach/README.md` (2026-05-17) is cited inline where useful.
+
+---
+
+## Live Usage
+
+| Metric | Value | Source |
+|--------|-------|--------|
+| PyPI installs (last day) | DATA UNAVAILABLE | pypistats.org not in network allowlist |
+| PyPI installs (last week) | DATA UNAVAILABLE | pypistats.org not in network allowlist |
+| PyPI installs (last month) | DATA UNAVAILABLE | pypistats.org not in network allowlist |
+| GitHub unique visitors (14d) | DATA UNAVAILABLE | Traffic API requires auth; no `gh` CLI |
+| GitHub unique cloners (14d) | DATA UNAVAILABLE | Traffic API requires auth; no `gh` CLI |
+| PulseMCP est. weekly visitors | DATA UNAVAILABLE | pulsemcp.com not in network allowlist |
+| Current version | v0.9.3 | GitHub commits |
+| Tests passing | 269 | v0.9.3 release notes |
+| Test coverage | 73% | v0.9.3 CI gate |
+| MCP tools exposed | 19 | v0.9.1+ |
+
+> **Prior reference (2026-05-17, from outreach/README.md):** PyPI ~175/wk, unique cloners 78, unique visitors 13.
+
+---
+
+## Social Proof
+
+| Metric | Value | Prior (2026-05-17) | Δ |
+|--------|-------|---------------------|---|
+| Stars | 10 | 8 | +2 (+25%) |
+| Forks | 4 | 2 | +2 (+100%) |
+| Watchers/Subscribers | 10 | — | — |
+| Open issues | 2 | 0 | +2 (spam — see note) |
+| GLAMA tier | A-tier | A-tier (confirmed v0.9.1) | no change |
+| SafeSkill score | 93/100 | 93/100 | no change |
+
+> **Open issue note:** Issues #18 and #19 are identical automated spam from user `HMCHENGGH` ("Agent Tool Intel"), opened 2026-05-29 within minutes of the v0.9.3 release merge. Both solicit a "Grade B+" badge. Not organic. The 2 open issues reported by the API are entirely spam.
+
+---
+
+## Discovery Channels — Referrers
+
+DATA UNAVAILABLE — GitHub traffic API requires authentication (`/traffic/popular/referrers`). No `gh` CLI available in this execution environment.
+
+> **Prior reference (2026-05-17):** Top referrer was github.com itself (5 uniques). Facebook-origin traffic is Nate self-seeding via FB comments, not organic virality.
+
+---
+
+## Top Repo Paths
+
+DATA UNAVAILABLE — GitHub traffic API requires authentication (`/traffic/popular/paths`). No `gh` CLI available in this execution environment.
+
+---
+
+## Distribution Channel Status
+
+| Channel | Status | Notes |
+|---------|--------|-------|
+| pulsemcp.com | ✅ Live | Auto-ingested via Official MCP Registry. 193 weekly visitors as of 2026-04-17; current count unavailable. |
+| Claude Code Plugin Marketplace | ✅ Live | Published 2026-04-17. Highest-intent channel. |
+| glama.ai/mcp | ✅ Live | A-tier security / license / quality scores. Detailed score data unavailable (network blocked). |
+| mcp.so | ⬜ Not submitted | Pending second-push batch. |
+| mcpservers.org | ⬜ Not submitted | Pending second-push batch. |
+| awesome-mcp-servers | ⬜ Not submitted | Pending second-push batch. |
+| awesome-claude-code | ⏸️ Carry-forward blocked | Shipwright #1380 must resolve first; was eligible after Apr 16 but checklist requires zero other open issues. Currently 2 spam issues block eligibility — close them first. |
+| Show HN | ⬜ Not posted | Planned for v0.9.2 second push (not yet executed). |
+| X/Twitter | ✅ Posted | 2026-04-17 launch thread. |
+| Dev.to | ✅ Posted | 2026-04-17. Article stats unavailable (network blocked). |
+| Product Hunt | ⬜ Not launched | Awaiting Show HN momentum. |
+| TLDR AI | ⬜ Not pitched | Ready to pitch. |
+| Ben's Bites | ⬜ Not pitched | Ready to pitch. |
+| Latent Space | ⬜ Not pitched | Ready to pitch. |
+| The Pragmatic Engineer | ⬜ Not pitched | Ready to pitch. |
+
+---
+
+## What the Numbers Say
+
+1. **V0.9.3 silently fixed two regressions that had been breaking Longhand since v0.9.0.** The `outputSchema` validator incompatibility meant 12 of 19 MCP tools simply didn't load in Claude Code — any user who installed between v0.9.0 and v0.9.2 was running at 7-tool capacity, not 19, without knowing it. The UserPromptSubmit hook was also silently emitting `{}` on every prompt, killing auto-context injection entirely. These are both "the thing didn't work" bugs, not edge-case regressions. Users who installed at launch have been quietly running a degraded experience for weeks.
+
+2. **Stars gained +2 (+25%) in 12 days without a new public push.** Both forks also doubled (2 → 4). At this sample size, individual data points dominate, but the trajectory is not decaying — the repo is attracting quiet organic attention despite no second-push distribution activity having executed since the April launch. The v0.9.3 bug-fix release landed today and may produce a small additional bump as existing users re-engage.
+
+3. **The second-push checklist (Show HN, Tier 1 directory submissions) has not executed yet.** The v0.9.2 plan called for Show HN + mcp.so + mcpservers.org + awesome-mcp-servers in the week of May 17; none of those are checked off. V0.9.3 is now the correct version to pair with that push — the "all 19 tools now work" angle is more credible than leading with the demo command, since the underlying tool actually functions end-to-end.
+
+4. **Spam issues are blocking the awesome-claude-code resubmission checklist.** Issues #18 and #19 must be closed before that submission is eligible (the checklist forbids any open issues). Closing those spam issues is the fastest way to unlock a channel that was already ready to receive a submission.
+
+5. **All PyPI and traffic metrics are unavailable in this snapshot** due to network restrictions in the automated execution environment. The PyPI weekly install rate (last known: ~175/wk as of 2026-05-17, down from 733/wk peak) is the most critical missing signal — it's the primary install-momentum indicator. Future snapshots should be run from an environment with network access to pypistats.org and GitHub's authenticated traffic endpoints.
+
+---
+
+## Data Gaps This Snapshot
+
+| Source | Endpoint | Gap Reason |
+|--------|----------|------------|
+| PyPI | pypistats.org/api/packages/longhand/recent | Host not in network allowlist |
+| GitHub Traffic (views) | /repos/Wynelson94/longhand/traffic/views | Requires auth; no `gh` CLI |
+| GitHub Traffic (clones) | /repos/Wynelson94/longhand/traffic/clones | Requires auth; no `gh` CLI |
+| GitHub Referrers | /repos/Wynelson94/longhand/traffic/popular/referrers | Requires auth; no `gh` CLI |
+| GitHub Top Paths | /repos/Wynelson94/longhand/traffic/popular/paths | Requires auth; no `gh` CLI |
+| PulseMCP | pulsemcp.com/servers?q=longhand | Host not in network allowlist |
+| Dev.to | dev.to/api/articles/wynelson94/… | Host not in network allowlist |
+| Glama | glama.ai/mcp/servers/Wynelson94/longhand | HTTP 403 |

--- a/outreach/analytics-2026-06-05.md
+++ b/outreach/analytics-2026-06-05.md
@@ -1,0 +1,102 @@
+# Longhand Analytics Snapshot — 2026-06-05
+
+**Snapshot date:** 2026-06-05  
+**Previous snapshot:** None (first snapshot — no prior `outreach/analytics-*.md` file found)  
+**Baseline for deltas:** `outreach/README.md` § "Current numbers (2026-05-17 — pre-second-push baseline)"
+
+---
+
+## Live Usage
+
+| Metric | Value | Source | Notes |
+|---|---|---|---|
+| PyPI weekly installs | DATA UNAVAILABLE | pypistats.org | 403 — outbound network blocked in this execution environment |
+| PyPI monthly installs | DATA UNAVAILABLE | pypistats.org | 403 — outbound network blocked |
+| GitHub stars | 10 | GitHub API | |
+| GitHub forks | 4 | GitHub API | |
+| GitHub watchers | 10 | GitHub API | |
+| PulseMCP est. weekly visitors | DATA UNAVAILABLE | pulsemcp.com | 403 — outbound network blocked |
+
+---
+
+## Social Proof
+
+| Signal | Value | Notes |
+|---|---|---|
+| GitHub stars | 10 | |
+| GitHub forks | 4 | |
+| Glama.ai tier | A-tier (last confirmed pre-2026-05-17) | `glama.json` present in repo; no score embedded in file |
+| SafeSkill score | 93/100 | Badge added 2026-05-07 via PR #7 |
+
+---
+
+## Discovery Channels (Referrers)
+
+| Referrer | Uniques (14d) | Notes |
+|---|---|---|
+| DATA UNAVAILABLE | — | GitHub traffic API not exposed via available MCP tools; requires `gh` CLI or a REST token with `repo` scope |
+
+---
+
+## Top Paths on Repo
+
+| Path | Views (14d) | Notes |
+|---|---|---|
+| DATA UNAVAILABLE | — | GitHub traffic API not exposed via available MCP tools |
+
+---
+
+## Distribution Channel Status
+
+| Channel | Status | Notes |
+|---|---|---|
+| pulsemcp.com | ✅ Listed | Auto-ingested via Official MCP Registry; 193 weekly visitors as of 2026-04-17 (current count unavailable — 403) |
+| Claude Code Plugin Marketplace | ✅ Published | Published 2026-04-17; highest-intent channel |
+| glama.ai/mcp | ✅ Listed | A-tier security / license / quality scores |
+| X/Twitter | ✅ Posted | Thread posted 2026-04-17 |
+| Dev.to blog post | ✅ Posted | Posted 2026-04-17; article stats unavailable — 403 |
+| mcp.so | ⏸️ Pending | Not yet submitted |
+| mcpservers.org | ⏸️ Pending | Not yet submitted |
+| awesome-mcp-servers | ⏸️ Pending | PR not yet opened |
+| awesome-claude-code | ⏸️ Blocked | Prior submission #1578 closed 2026-04-15 (repo too young); eligible to resubmit once Shipwright issue #1380 resolves |
+| Show HN | ⏸️ Planned | Second-push sequence drafted in outreach/README.md but no commit evidence it has launched |
+| Product Hunt | ⏸️ Planned | Awaiting HN/newsletter momentum per sequencing plan |
+| TLDR AI / Ben's Bites / Latent Space / Pragmatic Engineer | ⏸️ Planned | Newsletter pitches not yet sent |
+
+---
+
+## Week-over-Week Deltas
+
+> **Baseline:** `outreach/README.md` "Current numbers" as of 2026-05-17.  
+> **Current:** GitHub API via MCP, pulled 2026-06-05.  
+> ⚠️ = metric moved >20% in either direction.
+
+| Metric | 2026-05-17 baseline | 2026-06-05 | Δ% | Flag |
+|---|---|---|---|---|
+| GitHub stars | 8 | 10 | +25% | ⚠️ |
+| GitHub forks | 2 | 4 | +100% | ⚠️ |
+| Open issues | 0 | 0 | 0% | |
+| PyPI weekly installs | 175 | DATA UNAVAILABLE | — | |
+| GitHub unique cloners (14d) | 78 | DATA UNAVAILABLE | — | |
+| GitHub unique visitors (14d) | 13 | DATA UNAVAILABLE | — | |
+| PulseMCP weekly visitors | 193 (as of 2026-04-17) | DATA UNAVAILABLE | — | |
+| Dev.to page views | DATA UNAVAILABLE | DATA UNAVAILABLE | — | |
+
+---
+
+## What the Numbers Say
+
+1. **Forks doubled, stars up 25% — v0.9.3 is the likely driver.** In the ~19 days since the 2026-05-17 baseline, forks went 2→4 and stars 8→10. This window contains the v0.9.3 release (2026-05-29), which fixed two bugs that had been silently breaking core functionality since v0.9.0: the UserPromptSubmit hook was emitting `{}` on every prompt, and 12 of 19 MCP tools weren't loading in Claude Code at all due to an `outputSchema` validator mismatch. Users hitting real breakage and then seeing it fixed is the most plausible driver of both metrics.
+
+2. **v0.9.3 repaired a severely degraded baseline experience.** Anyone who installed between v0.9.0 and v0.9.3 was running Longhand with most tools silently unavailable and auto-context injection dead. The fix is material: next outreach should lead with "if you tried it before June and it seemed broken, it was — here's what v0.9.3 fixed" rather than a fresh-install pitch.
+
+3. **Second-push distribution has not launched yet.** The sequencing plan in `outreach/README.md` (Show HN, mcp.so, mcpservers.org, awesome-mcp-servers PR, newsletter pitches) was drafted in May alongside v0.9.2 but there is no commit evidence in the git log that any of it has been executed. v0.9.3 strengthens the story — the "12 of 19 tools now actually work" angle is concrete and verifiable.
+
+4. **Most traffic-level metrics are unavailable this week.** PyPI download counts, GitHub clone/view traffic, PulseMCP visitor counts, and Dev.to article stats all returned HTTP 403 from this execution environment (outbound network policy blocks these external hosts). The next scheduled snapshot should verify outbound access to these endpoints before running; without install velocity data, growth signals are limited to repository metadata.
+
+5. **Facebook referrer traffic remains self-seeded — not a virality signal.** The May baseline noted FB as the top referrer source. This is Nate seeding via FB comments, not organic discovery. It should not be interpreted as a super-spreader event or counted toward channel performance.
+
+---
+
+*Generated: 2026-06-05 by Longhand weekly analytics agent.*  
+*Data sources: GitHub MCP (stars, forks, issues, commits) · outreach/README.md (2026-05-17 baseline). All other sources returned DATA UNAVAILABLE due to outbound network restrictions.*

--- a/outreach/analytics-2026-06-12.md
+++ b/outreach/analytics-2026-06-12.md
@@ -1,0 +1,109 @@
+# Longhand Analytics Snapshot — 2026-06-12
+
+**Snapshot date:** 2026-06-12  
+**Previous snapshot:** `outreach/analytics-2026-06-05.md` (PR #21, branch `analytics/2026-06-05`)  
+**Baseline for WoW deltas:** 2026-06-05 snapshot values
+
+---
+
+## Live Usage
+
+| Metric | Value | Source | Notes |
+|---|---|---|---|
+| PyPI weekly installs | DATA UNAVAILABLE | pypistats.org | 403 — outbound network blocked in this execution environment |
+| PyPI monthly installs | DATA UNAVAILABLE | pypistats.org | 403 — outbound network blocked |
+| GitHub stars | 10 | GitHub API | Flat vs prior snapshot |
+| GitHub forks | 4 | GitHub API | Flat vs prior snapshot |
+| GitHub watchers | 10 | GitHub API | Flat vs prior snapshot |
+| PulseMCP est. weekly visitors | DATA UNAVAILABLE | pulsemcp.com | 403 — outbound network blocked |
+
+---
+
+## Social Proof
+
+| Signal | Value | Notes |
+|---|---|---|
+| GitHub stars | 10 | Flat since 2026-06-05 |
+| GitHub forks | 4 | Flat since 2026-06-05 |
+| Glama.ai tier | A-tier (last confirmed pre-2026-05-17) | `glama.json` present in repo; no score embedded in file |
+| SafeSkill score | 93/100 | Badge added 2026-05-07 via PR #7 |
+| Latest version (commit) | v0.11.0 | Released 2026-06-09 via merge commit; PyPI should reflect this |
+| Latest GitHub Release | v0.9.0 (2026-04-29) | GitHub releases page not updated since v0.9.0; newer versions ship via PyPI/commits only |
+
+---
+
+## Discovery Channels (Referrers)
+
+| Referrer | Uniques (14d) | Notes |
+|---|---|---|
+| DATA UNAVAILABLE | — | GitHub traffic API not exposed via available MCP tools; requires `gh` CLI or REST token with `repo` scope |
+
+---
+
+## Top Paths on Repo
+
+| Path | Views (14d) | Notes |
+|---|---|---|
+| DATA UNAVAILABLE | — | GitHub traffic API not exposed via available MCP tools |
+
+---
+
+## Distribution Channel Status
+
+| Channel | Status | Notes |
+|---|---|---|
+| pulsemcp.com | ✅ Listed | Auto-ingested via Official MCP Registry; 193 weekly visitors as of 2026-04-17 (current count unavailable — 403) |
+| Claude Code Plugin Marketplace | ✅ Published | Published 2026-04-17; highest-intent channel |
+| glama.ai/mcp | ✅ Listed | A-tier security / license / quality scores |
+| X/Twitter | ✅ Posted | Thread posted 2026-04-17 |
+| Dev.to blog post | ✅ Posted | Posted 2026-04-17; article stats unavailable — 403 |
+| mcp.so | ⏸️ Pending | Not yet submitted; no commit evidence |
+| mcpservers.org | ⏸️ Pending | Not yet submitted; no commit evidence |
+| awesome-mcp-servers | ⏸️ Pending | PR not yet opened; no commit evidence |
+| awesome-claude-code | ⏸️ Blocked | Prior submission #1578 closed 2026-04-15; resubmit pending Shipwright issue #1380 resolution |
+| Show HN | ⏸️ Planned | Second-push sequence drafted in outreach/README.md; no commit evidence of launch |
+| Product Hunt | ⏸️ Planned | Awaiting HN/newsletter momentum per sequencing plan |
+| TLDR AI / Ben's Bites / Latent Space / Pragmatic Engineer | ⏸️ Planned | Newsletter pitches not yet sent; no commit evidence |
+
+---
+
+## Week-over-Week Deltas
+
+> **Prior week:** `outreach/analytics-2026-06-05.md` snapshot pulled 2026-06-05.  
+> **Current:** GitHub API via MCP, pulled 2026-06-12.  
+> ⚠️ = metric moved >20% in either direction.  
+> Note: all traffic-level metrics (PyPI, clones, views, PulseMCP) are DATA UNAVAILABLE in both periods due to network restrictions — delta cannot be computed.
+
+| Metric | 2026-06-05 | 2026-06-12 | Δ% | Flag |
+|---|---|---|---|---|
+| GitHub stars | 10 | 10 | 0% | |
+| GitHub forks | 4 | 4 | 0% | |
+| GitHub watchers | 10 | 10 | 0% | |
+| Open issues | 0 | 0 | 0% | |
+| Open PRs | 1 (PR #21) | 3 (PRs #20, #21, #31) | +200% | ⚠️ new metric |
+| Releases shipped (week) | 1 (v0.9.3, 2026-05-29) | 3 (v0.9.4, v0.10.0, v0.11.0 — all 2026-06-09) | — | ⚠️ release burst |
+| Test count | 280 (v0.9.4 baseline) | 316 (v0.11.0) | +13% | |
+| PyPI weekly installs | DATA UNAVAILABLE | DATA UNAVAILABLE | — | |
+| GitHub unique cloners (14d) | DATA UNAVAILABLE | DATA UNAVAILABLE | — | |
+| GitHub unique visitors (14d) | DATA UNAVAILABLE | DATA UNAVAILABLE | — | |
+| PulseMCP weekly visitors | DATA UNAVAILABLE | DATA UNAVAILABLE | — | |
+| Dev.to page views | DATA UNAVAILABLE | DATA UNAVAILABLE | — | |
+
+---
+
+## What the Numbers Say
+
+1. **Three releases in one day — the quality sprint landed June 9.** v0.9.4 (security hardening, closing 6 AUDIT-2026-05-28 findings), v0.10.0 (opt-in secret redaction across 13 secret patterns, plus chromadb `<1.0` pin and mypy now blocking CI), and v0.11.0 (grouped CLI help panels, hidden plumbing commands, honest episode stats with a low-confidence bucket, data-derived first-run suggestions) all merged the same day. 280 → 316 tests. This is the strongest technical week since the April launch, but install-velocity data (PyPI) is still dark — no way to confirm whether it moved the needle.
+
+2. **GitHub-visible engagement held flat.** Stars (10) and forks (4) are unchanged from the June 5 snapshot. Flat is not bad given no new public distribution push this week, but it confirms the April spike has fully decayed and the project is in maintenance-mode discovery. The v0.9.4/v0.10.0/v0.11.0 quality story needs distribution to turn into stars.
+
+3. **GitHub releases page still shows v0.9.0 as latest.** v0.9.3, v0.9.4, v0.10.0, and v0.11.0 shipped via merge commits and PyPI but no GitHub release was published for any of them. This matters for discovery: the releases tab is often the first thing a visitor checks to gauge project health. A visitor landing on the repo sees "latest release: v0.9.0, April 2026" while the actual latest is v0.11.0, June 2026 — a six-week staleness signal that undersells the cadence.
+
+4. **Three open PRs, zero open issues.** PR #31 (fieldnotes drift gate) opened 2026-06-11 shows active development one day after the release burst. PRs #20 and #21 are prior analytics snapshots that haven't been merged. Issues queue is empty — no user-reported bugs or feature requests visible.
+
+5. **Second-push distribution sequence remains unlaunched.** The Show HN post, mcp.so submission, mcpservers.org, awesome-mcp-servers PR, and all newsletter pitches drafted in `outreach/README.md` show no commit evidence of execution in three consecutive weekly snapshots. The v0.11.0 UX improvements and v0.10.0 secret redaction give fresh angles. The "if you tried it before June and most tools were broken, v0.9.3 fixed that" message is now a month stale and will need refreshing for a second push.
+
+---
+
+*Generated: 2026-06-12 by Longhand weekly analytics agent.*  
+*Data sources: GitHub MCP (stars, forks, watchers, issues, PRs, commits, releases) · `outreach/analytics-2026-06-05.md` (prior week baseline). All other sources returned DATA UNAVAILABLE due to outbound network restrictions (pypistats.org, pulsemcp.com, dev.to, GitHub traffic REST API).*

--- a/outreach/analytics-2026-06-19.md
+++ b/outreach/analytics-2026-06-19.md
@@ -1,0 +1,114 @@
+# Longhand Analytics Snapshot — 2026-06-19
+
+> **First snapshot.** No prior `analytics-*.md` exists in the repo. Deltas in §6 are computed against the 2026-05-17 baseline recorded in `outreach/README.md` (~33-day window, not a strict 7-day week). Future snapshots will use true week-over-week deltas.
+
+---
+
+## 1. Live Usage
+
+| Channel | Metric | Value | Notes |
+|---------|--------|-------|-------|
+| PyPI | Weekly installs | DATA UNAVAILABLE | pypistats.org blocked by network policy |
+| PyPI | Last known weekly installs | ~175/wk | 2026-05-17 baseline from outreach/README.md |
+| PyPI | Launch peak | ~733/wk | Apr 15–24 spike (from commit message ref) |
+| GitHub | Unique visitors (14d) | DATA UNAVAILABLE | GitHub traffic API not available via MCP tools |
+| GitHub | Unique cloners (14d) | DATA UNAVAILABLE | GitHub traffic API not available via MCP tools |
+| PulseMCP | Est. weekly visitors | DATA UNAVAILABLE | pulsemcp.com blocked by network policy |
+| PulseMCP | Last known weekly visitors | 193 | 2026-04-17 entry in outreach/README.md |
+
+---
+
+## 2. Social Proof
+
+| Metric | Value | Δ vs 2026-05-17 baseline |
+|--------|-------|---------------------------|
+| GitHub stars | 10 | +2 (+25%) ⚠️ |
+| GitHub forks | 4 | +2 (+100%) ⚠️ |
+| GitHub watchers | 10 | — (not tracked previously) |
+| Open issues | 4 | +4 (was 0) |
+| Glama security score | A-tier | ✅ confirmed (glama.json present) |
+| Current version | 0.11.1 | — |
+| Total releases (since Apr 9 launch) | 8 (v0.6–v0.11.1) | — |
+
+⚠️ = metric moved >20% since prior baseline.
+
+---
+
+## 3. Discovery Channels (GitHub Referrers, 14d)
+
+DATA UNAVAILABLE — GitHub traffic referrer API requires `GET /repos/{owner}/{repo}/traffic/popular/referrers`, which is not exposed by the GitHub MCP tools available in this environment. Add this endpoint or a `gh` CLI call to the routine to recover this data.
+
+**Last known referrer snapshot (2026-05-17):** github.com itself (5 uniques); Facebook (self-seeded by Nate via FB comments — NOT organic virality, do not interpret as viral signal).
+
+---
+
+## 4. Top Paths on Repo
+
+DATA UNAVAILABLE — GitHub traffic path API requires `GET /repos/{owner}/{repo}/traffic/popular/paths`, not exposed by MCP tools.
+
+---
+
+## 5. Distribution Channel Status
+
+Carried forward from `outreach/README.md`. No changes detected this week.
+
+| Channel | Status | Notes |
+|---------|--------|-------|
+| pulsemcp.com | ✅ LIVE | Auto-ingested via MCP Registry. 193 est. weekly visitors as of 2026-04-17. |
+| Claude Code Plugin Marketplace | ✅ LIVE | Published 2026-04-17. Highest-intent channel. |
+| glama.ai/mcp | ✅ LIVE | A-tier security/license/quality scores. |
+| X/Twitter | ✅ POSTED | 2026-04-17. No new posts this week. |
+| Dev.to blog post | ✅ POSTED | 2026-04-17. Stats unavailable (dev.to blocked). |
+| mcp.so | ⬜ PENDING | Not yet submitted. |
+| mcpservers.org | ⬜ PENDING | Not yet submitted. |
+| awesome-mcp-servers | ⬜ PENDING | PR not yet opened. |
+| awesome-claude-code | ⏸️ BLOCKED | Was blocked on Shipwright issue #1380; check if unblocked. |
+| Show HN | ⬜ PENDING | Not yet posted. |
+| Product Hunt | ⬜ PENDING | Scheduled for after HN/newsletter momentum. |
+| Medium / Hashnode cross-post | ⬜ PENDING | Awaiting Dev.to spike to justify. |
+| TLDR AI | ⬜ PENDING | Newsletter pitch not sent. |
+| Ben's Bites | ⬜ PENDING | Newsletter pitch not sent. |
+| Latent Space | ⬜ PENDING | Newsletter pitch not sent. |
+| The Pragmatic Engineer | ⬜ PENDING | Newsletter pitch not sent. |
+
+---
+
+## 6. Since-Baseline Deltas (vs 2026-05-17)
+
+> Note: ~33-day window, not a 7-day week. Future snapshots will be true week-over-week.
+
+| Metric | 2026-05-17 | 2026-06-19 | Δ | Δ% | Flag |
+|--------|-----------|-----------|---|-----|------|
+| Stars | 8 | 10 | +2 | +25% | ⚠️ >20% |
+| Forks | 2 | 4 | +2 | +100% | ⚠️ >20% |
+| Open issues | 0 | 4 | +4 | n/a | — |
+| Weekly PyPI installs | 175 | DATA UNAVAIL. | — | — | |
+| Unique cloners (14d) | 78 | DATA UNAVAIL. | — | — | |
+| Unique visitors (14d) | 13 | DATA UNAVAIL. | — | — | |
+| Commits this week | 4 (14d) | 7 (Jun 12–18) | +3 | +75% | ⚠️ >20% |
+
+---
+
+## 7. What the Numbers Say
+
+1. **Stars are up 25% and forks doubled since mid-May, with zero new outreach.** Ten stars and 4 forks is still a small-repo number, but the +2/+2 gains happened with no new promotional push — pure residual from the April launch and the plugin marketplace listing. The trajectory is flat-but-not-dead, which is the expected steady-state after a launch spike.
+
+2. **v0.11.1 (Jun 18) closed two silent-corruption bugs affecting real user data.** The project-misattribution fix corrected 13% of sessions being filed under the wrong project on a 265-session real corpus. These are the kind of correctness bugs that erode trust quietly; shipping them fast with a `longhand reattribute` remediation command is the right call before any new outreach. The release cadence this month (v0.9.4 → v0.10.0 → v0.11.0 → v0.11.1 in 10 days) shows the product is actively hardening.
+
+3. **Open issues jumped from 0 to 4.** Without access to the issue list details (the GraphQL list_issues tool returned 0 — likely a filter mismatch vs the REST count of 4), it's unclear whether these are bug reports, feature requests, or stale. Worth a manual triage pass before the next outreach push.
+
+4. **PyPI install rate is unreadable this week.** pypistats.org is blocked by the analytics routine's network policy. The last known figure (175/wk as of 2026-05-17) was already a steep decay from the 733/wk launch peak. Install rate is the most actionable metric for timing the next outreach push — restoring access to pypistats.org in the network egress settings should be the top priority fix for this routine.
+
+5. **GitHub traffic (visitors, cloners, referrers) is also dark.** The GitHub MCP tools don't expose the `/traffic/*` endpoints. Either switch to a `gh` CLI call in the routine, or use a personal-access token that has the `repo` scope against the REST API directly. Without this data, it's impossible to tell if the recent v0.11.x release activity generated any inbound organic traffic.
+
+---
+
+## Data Gaps & Routine Health
+
+| Source | Status | Fix Needed |
+|--------|--------|------------|
+| pypistats.org | ❌ DATA UNAVAILABLE | Add `pypistats.org` to network egress allowlist |
+| dev.to API | ❌ DATA UNAVAILABLE | Add `dev.to` to network egress allowlist |
+| pulsemcp.com | ❌ DATA UNAVAILABLE | Add `www.pulsemcp.com` to network egress allowlist |
+| GitHub traffic (views/clones/referrers/paths) | ❌ DATA UNAVAILABLE | GitHub MCP tools don't expose `/traffic/*` — use `gh api` calls or direct REST |
+| GitHub open issues detail | ⚠️ PARTIAL | REST count = 4; MCP GraphQL returned 0 (filter mismatch). Check MCP tool OPEN state filter. |

--- a/outreach/analytics-2026-06-26.md
+++ b/outreach/analytics-2026-06-26.md
@@ -1,0 +1,117 @@
+# Longhand Analytics Snapshot — 2026-06-26
+
+> **Week-over-week snapshot.** Prior baseline: `outreach/analytics-2026-06-19.md` (PR #36). True 7-day window: Jun 19 → Jun 26.
+
+---
+
+## 1. Live Usage
+
+| Channel | Metric | Value | Notes |
+|---------|--------|-------|-------|
+| PyPI | Weekly installs | DATA UNAVAILABLE | pypistats.org blocked by network egress policy |
+| PyPI | Last known weekly installs | ~175/wk | 2026-05-17 baseline; PyPI data has been dark since first snapshot (May 29) |
+| PyPI | Launch peak | ~733/wk | Apr 15–24 spike |
+| GitHub | Unique visitors (14d) | DATA UNAVAILABLE | GitHub traffic API not available via MCP tools |
+| GitHub | Unique cloners (14d) | DATA UNAVAILABLE | GitHub traffic API not available via MCP tools |
+| PulseMCP | Est. weekly visitors | DATA UNAVAILABLE | pulsemcp.com blocked by network egress policy |
+| PulseMCP | Last known weekly visitors | 193 | 2026-04-17 entry in outreach/README.md |
+
+---
+
+## 2. Social Proof
+
+| Metric | Value | Δ vs 2026-06-19 |
+|--------|-------|------------------|
+| GitHub stars | 10 | 0 (flat) |
+| GitHub forks | 3 | −1 (−25%) ⚠️ |
+| GitHub watchers | 10 | 0 (flat) |
+| Open issues (bugs/features) | 0 | 0 (flat; prior "4" was open PRs misread from REST count) |
+| Open PRs | 6 | +2 vs ~4 prior |
+| Glama security score | A-tier | ✅ confirmed (glama.json present in repo) |
+| Current version (PyPI) | 0.11.1 | no change |
+| GitHub Releases page | v0.9.0 | ⚠️ stale — latest GitHub Release is still v0.9.0 (Apr 29); v0.11.1 not formally released on GitHub |
+
+⚠️ = metric moved >20% vs prior snapshot.
+
+---
+
+## 3. Discovery Channels (GitHub Referrers, 14d)
+
+DATA UNAVAILABLE — `GET /repos/{owner}/{repo}/traffic/popular/referrers` not exposed by the GitHub MCP tools in this environment. Requires `gh api` or direct REST with a token scoped to `repo`.
+
+**Last known referrer snapshot (2026-05-17):** github.com itself (5 uniques); Facebook present but self-seeded by Nate via FB comments — NOT organic virality, do not interpret as a viral signal.
+
+---
+
+## 4. Top Paths on Repo
+
+DATA UNAVAILABLE — `GET /repos/{owner}/{repo}/traffic/popular/paths` not exposed by MCP tools.
+
+---
+
+## 5. Distribution Channel Status
+
+Carried forward from prior snapshot. No channel status changes detected this week.
+
+| Channel | Status | Notes |
+|---------|--------|-------|
+| pulsemcp.com | ✅ LIVE | Auto-ingested via MCP Registry. 193 est. weekly visitors as of 2026-04-17. |
+| Claude Code Plugin Marketplace | ✅ LIVE | Published 2026-04-17. Highest-intent channel. |
+| glama.ai/mcp | ✅ LIVE | A-tier security/license/quality scores. |
+| X/Twitter | ✅ POSTED | 2026-04-17. No new posts this week. |
+| Dev.to blog post | ✅ POSTED | 2026-04-17. Stats unavailable (dev.to blocked by egress policy). |
+| mcp.so | ⬜ PENDING | Not yet submitted. |
+| mcpservers.org | ⬜ PENDING | Not yet submitted. |
+| awesome-mcp-servers | ⬜ PENDING | PR not yet opened. |
+| awesome-claude-code | ⏸️ BLOCKED | Was blocked on Shipwright issue #1380; check if unblocked. |
+| Show HN | ⬜ PENDING | Not yet posted. |
+| Product Hunt | ⬜ PENDING | Scheduled for after HN/newsletter momentum. |
+| Medium / Hashnode cross-post | ⬜ PENDING | Awaiting Dev.to spike to justify. |
+| TLDR AI | ⬜ PENDING | Newsletter pitch not sent. |
+| Ben's Bites | ⬜ PENDING | Newsletter pitch not sent. |
+| Latent Space | ⬜ PENDING | Newsletter pitch not sent. |
+| The Pragmatic Engineer | ⬜ PENDING | Newsletter pitch not sent. |
+
+---
+
+## 6. Week-over-Week Deltas (vs 2026-06-19)
+
+| Metric | 2026-06-19 | 2026-06-26 | Δ | Δ% | Flag |
+|--------|-----------|-----------|---|-----|------|
+| Stars | 10 | 10 | 0 | 0% | — |
+| Forks | 4 | 3 | −1 | −25% | ⚠️ >20% |
+| Watchers | 10 | 10 | 0 | 0% | — |
+| Open issues (actual) | 0* | 0 | 0 | — | — |
+| Open PRs | ~4 | 6 | +2 | +50% | — (analytics + maintenance PRs, not organic) |
+| Commits to main | 7 (Jun 12–18) | 0 (Jun 19–25) | −7 | −100% | — (burst cadence, not decline) |
+| GitHub Release (latest tag) | v0.9.0 | v0.9.0 | — | — | ⚠️ stale vs v0.11.1 on PyPI |
+| Weekly PyPI installs | DATA UNAVAIL. | DATA UNAVAIL. | — | — | |
+| Unique cloners (14d) | DATA UNAVAIL. | DATA UNAVAIL. | — | — | |
+| Unique visitors (14d) | DATA UNAVAIL. | DATA UNAVAIL. | — | — | |
+
+*The prior snapshot's REST `open_issues_count: 4` included open PRs; actual bug/feature issues were 0. Now `open_issues_count: 6` reflects 6 open PRs. Confirmed via MCP `list_issues` returning 0 open issues.
+
+---
+
+## 7. What the Numbers Say
+
+1. **One fork was deleted this week (4 → 3, −25%).** On a 10-star repo, a single fork removal is within noise — no outreach event triggered a mass unforking, and no new activity explains new interest. Most likely a GitHub profile cleanup. Not a meaningful signal.
+
+2. **Stars and watchers were flat at 10.** The previous ~33-day window showed quiet organic growth (+2 stars, +2 forks) from post-launch residual and the plugin marketplace listing. This week shows zero movement on stars. With the April launch fully decayed and no new distribution push, flat is the expected trajectory. The April launch spike is now 10 weeks behind; without a second push, this number will remain stationary.
+
+3. **Zero commits to main since Jun 18 (v0.11.1 merge).** The project is in a post-release breathing window after a dense burst week (v0.9.4 → v0.10.0 → v0.11.0 → v0.11.1, all merged Jun 9–18). PR #37 (corpus stats doc refresh, opened Jun 23) is the only pending work. This quiet is normal and expected.
+
+4. **GitHub Releases page still shows v0.9.0 as the "latest release" — now 8 weeks stale.** Any visitor landing on the repo via discovery (mcp.so, awesome-mcp-servers, newsletter) sees a project last formally released April 29. v0.9.3 through v0.11.1 are on PyPI but not in GitHub Releases. Before the next outreach push, creating a GitHub Release for v0.11.1 is a quick credibility fix: it changes the profile card date and surfaces the changelog to visitors who judge freshness by the releases tab.
+
+5. **PyPI install data has been dark for four consecutive snapshots (May 29 – Jun 26).** This is the single most actionable metric for timing the second outreach push — whether install rate is recovering, flatlining at ~25/day, or already below noise. The egress policy blocking `pypistats.org` is a persistent blind spot. Until this is resolved, the analytics routine cannot tell Nate whether the hardening releases (v0.10.0, v0.11.x) moved the install needle at all.
+
+---
+
+## 8. Data Gaps & Routine Health
+
+| Source | Status | Fix Needed |
+|--------|--------|------------|
+| pypistats.org | ❌ DATA UNAVAILABLE | Add `pypistats.org` to network egress allowlist |
+| dev.to API | ❌ DATA UNAVAILABLE | Add `dev.to` to network egress allowlist |
+| pulsemcp.com | ❌ DATA UNAVAILABLE | Add `www.pulsemcp.com` to network egress allowlist |
+| GitHub traffic (views/clones/referrers/paths) | ❌ DATA UNAVAILABLE | GitHub MCP tools don't expose `/traffic/*` — use `gh api` calls or direct REST with `repo`-scoped PAT |

--- a/outreach/analytics-2026-07-03.md
+++ b/outreach/analytics-2026-07-03.md
@@ -1,0 +1,117 @@
+# Longhand Analytics Snapshot — 2026-07-03
+
+> **Week-over-week snapshot.** Prior baseline: `outreach/analytics-2026-06-26.md` (PR #38). True 7-day window: Jun 26 → Jul 3.
+
+---
+
+## 1. Live Usage
+
+| Channel | Metric | Value | Notes |
+|---------|--------|-------|-------|
+| PyPI | Weekly installs | DATA UNAVAILABLE | pypistats.org blocked by network egress policy |
+| PyPI | Last known weekly installs | ~175/wk | 2026-05-17 baseline; PyPI data has been dark since first snapshot (May 29) |
+| PyPI | Launch peak | ~733/wk | Apr 15–24 spike |
+| GitHub | Unique visitors (14d) | DATA UNAVAILABLE | GitHub traffic API not available via MCP tools |
+| GitHub | Unique cloners (14d) | DATA UNAVAILABLE | GitHub traffic API not available via MCP tools |
+| PulseMCP | Est. weekly visitors | DATA UNAVAILABLE | pulsemcp.com blocked by network egress policy |
+| PulseMCP | Last known weekly visitors | 193 | 2026-04-17 entry in outreach/README.md |
+
+---
+
+## 2. Social Proof
+
+| Metric | Value | Δ vs 2026-06-26 |
+|--------|-------|------------------|
+| GitHub stars | 10 | 0 (flat) |
+| GitHub forks | 3 | 0 (flat) |
+| GitHub watchers | 10 | 0 (flat) |
+| Open issues (bugs/features) | 0 | 0 (flat; confirmed via `list_issues` returning 0) |
+| Open PRs | 7 | +1 vs 6 prior (all are analytics/maintenance PRs) |
+| Glama security score | A-tier | ✅ confirmed (glama.json present in repo) |
+| Current version (PyPI) | 0.11.1 | no change |
+| GitHub Releases page | v0.9.0 | ⚠️ stale — latest GitHub Release is still v0.9.0 (Apr 29); v0.11.1 not formally released on GitHub |
+
+⚠️ = metric moved >20% vs prior snapshot. No flags this week — all visible metrics flat.
+
+---
+
+## 3. Discovery Channels (GitHub Referrers, 14d)
+
+DATA UNAVAILABLE — `GET /repos/{owner}/{repo}/traffic/popular/referrers` not exposed by the GitHub MCP tools in this environment. Requires `gh api` or direct REST with a token scoped to `repo`.
+
+**Last known referrer snapshot (2026-05-17):** github.com itself (5 uniques); Facebook present but self-seeded by Nate via FB comments — NOT organic virality, do not interpret as a viral signal.
+
+---
+
+## 4. Top Paths on Repo
+
+DATA UNAVAILABLE — `GET /repos/{owner}/{repo}/traffic/popular/paths` not exposed by MCP tools.
+
+---
+
+## 5. Distribution Channel Status
+
+Carried forward from prior snapshot. No channel status changes detected this week.
+
+| Channel | Status | Notes |
+|---------|--------|-------|
+| pulsemcp.com | ✅ LIVE | Auto-ingested via MCP Registry. 193 est. weekly visitors as of 2026-04-17. |
+| Claude Code Plugin Marketplace | ✅ LIVE | Published 2026-04-17. Highest-intent channel. |
+| glama.ai/mcp | ✅ LIVE | A-tier security/license/quality scores. |
+| X/Twitter | ✅ POSTED | 2026-04-17. No new posts this week. |
+| Dev.to blog post | ✅ POSTED | 2026-04-17. Stats unavailable (dev.to blocked by egress policy). |
+| mcp.so | ⬜ PENDING | Not yet submitted. |
+| mcpservers.org | ⬜ PENDING | Not yet submitted. |
+| awesome-mcp-servers | ⬜ PENDING | PR not yet opened. |
+| awesome-claude-code | ⏸️ BLOCKED | Was blocked on Shipwright issue #1380; check if unblocked. |
+| Show HN | ⬜ PENDING | Not yet posted. |
+| Product Hunt | ⬜ PENDING | Scheduled for after HN/newsletter momentum. |
+| Medium / Hashnode cross-post | ⬜ PENDING | Awaiting Dev.to spike to justify. |
+| TLDR AI | ⬜ PENDING | Newsletter pitch not sent. |
+| Ben's Bites | ⬜ PENDING | Newsletter pitch not sent. |
+| Latent Space | ⬜ PENDING | Newsletter pitch not sent. |
+| The Pragmatic Engineer | ⬜ PENDING | Newsletter pitch not sent. |
+
+---
+
+## 6. Week-over-Week Deltas (vs 2026-06-26)
+
+| Metric | 2026-06-26 | 2026-07-03 | Δ | Δ% | Flag |
+|--------|-----------|-----------|---|-----|------|
+| Stars | 10 | 10 | 0 | 0% | — |
+| Forks | 3 | 3 | 0 | 0% | — |
+| Watchers | 10 | 10 | 0 | 0% | — |
+| Open issues (actual) | 0 | 0 | 0 | — | — |
+| Open PRs | 6 | 7 | +1 | +17% | — (analytics + maintenance PRs only) |
+| Commits to main | 0 (Jun 19–25) | 0 (Jun 26–Jul 2) | 0 | — | — (second consecutive quiet week) |
+| GitHub Release (latest tag) | v0.9.0 | v0.9.0 | — | — | ⚠️ now 9 weeks stale vs v0.11.1 on PyPI |
+| Weekly PyPI installs | DATA UNAVAIL. | DATA UNAVAIL. | — | — | |
+| Unique cloners (14d) | DATA UNAVAIL. | DATA UNAVAIL. | — | — | |
+| Unique visitors (14d) | DATA UNAVAIL. | DATA UNAVAIL. | — | — | |
+
+No metrics moved >20% this week.
+
+---
+
+## 7. What the Numbers Say
+
+1. **All GitHub-visible metrics flat for the second consecutive week (stars 10, forks 3, watchers 10).** The April launch residual that produced the +2 stars / +2 forks drift through early June has fully exhausted itself. With no new distribution push and no organic referrer engine running, flat is the expected and stable state until a second push launches. This is not decline — it's baseline.
+
+2. **Seven analytics/maintenance PRs are open and accumulating; the oldest (PR #20, May 29) is now 35 days old with no merge.** The analytics PRs are generating a growing backlog against main. None of the open PRs (analytics #20, #21, #32, #36, #38; doc refresh #37; fieldnotes heal #31) have been merged. If these represent real decisions deferred, the PR list is the right signal. If they represent low-priority housekeeping, a single merge sweep would clean it.
+
+3. **PyPI install data is dark for the fifth consecutive snapshot (May 29 – Jul 3).** The install rate is the primary signal for timing the second outreach push — whether the v0.10.0 secret-redaction and v0.11.x attribution fixes moved the needle is completely unreadable. The ~175/wk figure from May 17 is now 46 days stale. Fixing egress access to `pypistats.org` remains the highest-value fix for this routine.
+
+4. **GitHub Releases page still shows v0.9.0 as the "latest release" — now 9 weeks behind PyPI.** Visitors discovering Longhand via mcp.so, awesome-mcp-servers, or newsletter links see a last-release date of April 29. v0.9.3 through v0.11.1 shipped to PyPI but were never formally released on GitHub. A GitHub Release for v0.11.1 is a low-effort credibility fix that changes the repo's profile card date and surfaces the changelog to anyone checking the releases tab.
+
+5. **Second consecutive zero-commit week on main.** The dense v0.9.4 → v0.10.0 → v0.11.0 → v0.11.1 burst (Jun 9–18) appears to have been followed by a deliberate rest. PR #37 (corpus stats doc refresh, opened Jun 23) is the only pending non-analytics work. The quiet is consistent with post-burst rhythm, not stagnation — but the second push sequence (Show HN, mcp.so, newsletters) has now been deferred for six consecutive weeks with no commit evidence of progress.
+
+---
+
+## 8. Data Gaps & Routine Health
+
+| Source | Status | Fix Needed |
+|--------|--------|------------|
+| pypistats.org | ❌ DATA UNAVAILABLE (5th consecutive snapshot) | Add `pypistats.org` to network egress allowlist |
+| dev.to API | ❌ DATA UNAVAILABLE | Add `dev.to` to network egress allowlist |
+| pulsemcp.com | ❌ DATA UNAVAILABLE | Add `www.pulsemcp.com` to network egress allowlist |
+| GitHub traffic (views/clones/referrers/paths) | ❌ DATA UNAVAILABLE | GitHub MCP tools don't expose `/traffic/*` — use `gh api` calls or direct REST with `repo`-scoped PAT |


### PR DESCRIPTION
Tier 0 repo hygiene from the 2026-07-09 audit.

- Consolidates the six stranded weekly analytics snapshots (#20 #21 #32 #36 #38 #39) — each adds its own dated `outreach/analytics-*.md`, taken verbatim from its branch. Under strict up-to-date branch protection, merging them serially meant six update+CI cycles; one PR lands the identical tree. The originals will be closed with a pointer here once this merges.
- Repo **auto-merge is now enabled**, so future automated snapshot PRs can queue themselves once checks pass.
- CI: the non-blocking py3.14 job now emits a `::warning` annotation + step summary on failure instead of hiding behind a green check (tracking #40).

🤖 Generated with [Claude Code](https://claude.com/claude-code)