### PR TITLE
fix: correctness, cross-platform, and privacy (find_episodes SQL filter, Windows paths, outcomes, redact coverage)

### DIFF
--- a/.fieldnotes/notes/0002-project-inference-cwd-mode.md
+++ b/.fieldnotes/notes/0002-project-inference-cwd-mode.md
@@ -5,8 +5,8 @@ references:
 - advisory: false
   lines: null
   path: longhand/parser.py
-  pinned_at: '2026-06-11T17:58:33.907018Z'
-  sha: 89c1beb169b9c06521aeee28fce3246641d09f973a793ac2023d180114025d0a
+  pinned_at: '2026-07-10T18:16:27.059400Z'
+  sha: c052aa5aa88c5e0f001f5013869d95316ec638ae0cad7fb445060bfb6f4e9c97
   symbol: null
 session_id: null
 superseded_by: '0006'
@@ -18,6 +18,9 @@ tags:
 - dont-reintroduce
 title: Project attribution uses MODE of cwds, not first-event cwd
 topic: project-inference-cwd-mode
+validations:
+- at: '2026-07-10T18:16:41.805585Z'
+  by: unknown
 written_at: '2026-04-26T05:28:36.808901Z'
 written_by: claude-opus-4-7
 ---

--- a/.fieldnotes/notes/0003-subagent-jsonl-discovery-filter.md
+++ b/.fieldnotes/notes/0003-subagent-jsonl-discovery-filter.md
@@ -2,11 +2,13 @@
 confidence: high
 id: '0003'
 references:
-- lines:
-  - 566
-  - 599
+- advisory: false
+  lines:
+  - 686
+  - 719
   path: longhand/parser.py
-  sha: ed8f380e42045a3dfaaad3b9b3f2bb53588efe46a930b67d8cc6fb1a8a4db7dd
+  pinned_at: '2026-07-10T18:16:27.060011Z'
+  sha: 16684994325660f790ada066ff5263e4254277abe9bf3ac507896b9299a1cda1
   symbol: discover_sessions
 session_id: null
 superseded_by: null
@@ -18,6 +20,9 @@ tags:
 - dont-reintroduce
 title: Subagent JSONLs at */subagents/*.jsonl are NOT independent sessions
 topic: subagent-jsonl-discovery-filter
+validations:
+- at: '2026-07-10T18:16:41.913822Z'
+  by: unknown
 written_at: '2026-04-26T05:28:36.914677Z'
 written_by: claude-opus-4-7
 ---
@@ -28,8 +33,8 @@ Subagent transcripts live at `<projects-dir>/.../<session-id>/subagents/<id>.jso
 
 `discover_sessions` filters three classes:
 
-1. `/subagents/` in the path — subagent transcripts
+1. `_is_subagent_transcript(path)` — checks `"subagents" in path.parts` (path *components*, not a substring: `"/subagents/" in str(path)` never matched on Windows backslash paths, so subagent transcripts polluted the corpus there; fixed in v0.11.2)
 2. `pytest-of-` in the path — pytest tmpdir leftovers
 3. `skill-injections` or `vercel-plugin` in the filename — internal plugin files
 
-**If you write a new transcript discovery path** (custom ingest source, a new recall scope, etc.), replicate this filter or you'll re-introduce the double-count. Better: call `discover_sessions` directly when you can.
+**If you write a new transcript discovery path** (custom ingest source, a new recall scope, etc.), call `_is_subagent_transcript` / replicate this filter or you'll re-introduce the double-count. Better: call `discover_sessions` directly when you can.

--- a/longhand/analysis/outcomes.py
+++ b/longhand/analysis/outcomes.py
@@ -88,7 +88,14 @@ def classify_session(session: Session, events: list[Event]) -> dict[str, Any]:
     confidence: float
 
     has_errors = len(error_events) > 0
-    ended_clean = has_errors and last_success_after_error_idx is not None
+    # A clean result only counts as "ended clean" if it came after the LAST
+    # error — error → clean → error must classify stuck, not fixed.
+    ended_clean = (
+        has_errors
+        and last_success_after_error_idx is not None
+        and last_error_idx is not None
+        and last_success_after_error_idx > last_error_idx
+    )
     edit_heavy = edit_count >= 3
     read_heavy = read_count > edit_count * 2 and edit_count < 3
 

--- a/longhand/cli/_commands.py
+++ b/longhand/cli/_commands.py
@@ -1279,8 +1279,13 @@ _REDACT_TABLES: dict[str, tuple[str, list[str]]] = {
         ],
     ),
     "episodes": ("episode_id", ["problem_description", "diagnosis_summary", "fix_summary"]),
-    "segments": ("segment_id", ["summary", "keywords_json"]),
+    # The table is conversation_segments — a bare "segments" key selected a
+    # nonexistent table, was swallowed by the per-table except, and left ALL
+    # segment text unredacted. topic holds the segment's verbatim first user
+    # message, so it must be scanned too.
+    "conversation_segments": ("segment_id", ["topic", "summary", "keywords_json"]),
     "session_outcomes": ("session_id", ["summary", "topics_json"]),
+    "git_operations": ("git_op_id", ["commit_message"]),
 }
 
 

--- a/longhand/mcp_server.py
+++ b/longhand/mcp_server.py
@@ -1605,15 +1605,16 @@ async def _tool_match_project(store: LonghandStore, arguments: dict[str, Any]) -
 
 
 async def _tool_find_episodes(store: LonghandStore, arguments: dict[str, Any]) -> list[TextContent]:
+    # has_fix=True (the default) filters in SQL; False means "no filter",
+    # matching the old post-filter semantics (include fixless episodes too).
     episodes = store.sqlite.query_episodes(
         project_ids=arguments.get("project_ids"),
         since=arguments.get("since"),
         until=arguments.get("until"),
         keyword=arguments.get("keyword"),
+        has_fix=True if _bool(arguments.get("has_fix"), True) else None,
         limit=_limit(arguments.get("limit"), 20),
     )
-    if _bool(arguments.get("has_fix"), True):
-        episodes = [e for e in episodes if e.get("fix_event_id")]
     return [TextContent(type="text", text=json.dumps(episodes, indent=2, default=str))]
 
 

--- a/longhand/parser.py
+++ b/longhand/parser.py
@@ -12,7 +12,7 @@ import json
 from collections import Counter
 from collections.abc import Iterator
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any
 
 from longhand.extractors.errors import detect_error
@@ -709,7 +709,7 @@ def discover_sessions(claude_projects_dir: str | Path | None = None) -> list[Pat
             continue
         # Subagent transcripts live under .../<session-id>/subagents/<id>.jsonl.
         # They're referenced from the parent session's events, not standalone.
-        if "/subagents/" in path_str:
+        if _is_subagent_transcript(jsonl):
             continue
         # Pytest leaves behind JSONLs in tmp project dirs during test runs.
         if "pytest-of-" in path_str:
@@ -717,3 +717,13 @@ def discover_sessions(claude_projects_dir: str | Path | None = None) -> list[Pat
         sessions.append(jsonl)
 
     return sessions
+
+
+def _is_subagent_transcript(path: PurePath) -> bool:
+    """True when the JSONL sits under a `subagents/` directory.
+
+    Checks path components, not the string form — on Windows the separator is
+    a backslash, so a substring test against "/subagents/" never matches and
+    subagent transcripts would be ingested as standalone sessions.
+    """
+    return "subagents" in path.parts

--- a/longhand/recall/drift_cache.py
+++ b/longhand/recall/drift_cache.py
@@ -169,7 +169,10 @@ def _scan_jsonl(jsonl_path: Path, mtime: float) -> DriftCacheEntry | None:
     entry = DriftCacheEntry(mtime=mtime)
     seen_cwds: set[str] = set()
     try:
-        with jsonl_path.open() as f:
+        # utf-8 + replace matches the main parser (parser.py). A bare open()
+        # uses the platform encoding — cp1252 on Windows — and any non-ASCII
+        # transcript byte then crashes the whole recall_project_status path.
+        with jsonl_path.open(encoding="utf-8", errors="replace") as f:
             for i, line in enumerate(f):
                 if i >= _DRIFT_SCAN_LINE_LIMIT:
                     break
@@ -196,7 +199,7 @@ def _scan_jsonl(jsonl_path: Path, mtime: float) -> DriftCacheEntry | None:
                 root = find_project_root_strict(p)
                 if root is not None:
                     entry.resolved_roots.add(str(root))
-    except (OSError, PermissionError):
+    except (OSError, PermissionError, UnicodeDecodeError):
         return None
     return entry
 

--- a/longhand/storage/sqlite_store.py
+++ b/longhand/storage/sqlite_store.py
@@ -832,6 +832,7 @@ class SQLiteStore:
         until: str | None = None,
         status: str | None = None,
         keyword: str | None = None,
+        has_fix: bool | None = None,
         limit: int = 50,
     ) -> list[dict[str, Any]]:
         with self.connect() as conn:
@@ -845,6 +846,10 @@ class SQLiteStore:
             if session_id:
                 conditions.append("session_id = ?")
                 params.append(session_id)
+            if has_fix is not None:
+                # In SQL, before ORDER/LIMIT: filtering after the recency cut
+                # returned [] whenever the newest rows were all fixless.
+                conditions.append("fix_event_id IS NOT NULL" if has_fix else "fix_event_id IS NULL")
             if since:
                 conditions.append("ended_at >= ?")
                 params.append(since)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -146,6 +146,26 @@ def test_classify_stuck_session():
     assert outcome["outcome"] == "stuck"
 
 
+def test_classify_error_after_clean_is_stuck():
+    """error → clean → error must classify stuck — the session ENDED broken.
+
+    Regression: any clean result after SOME earlier error marked the session
+    "fixed", even when a later error was the last word.
+    """
+    session = _session()
+    events = [
+        _event("u1", EventType.USER_MESSAGE, 1, "Debug this"),
+        _event("c1", EventType.TOOL_CALL, 2, tool_name="Bash"),
+        _event("r1", EventType.TOOL_RESULT, 3, content="error: broke", error_detected=True),
+        _event("c2", EventType.TOOL_CALL, 4, tool_name="Bash"),
+        _event("r2", EventType.TOOL_RESULT, 5, content="looks fixed"),
+        _event("c3", EventType.TOOL_CALL, 6, tool_name="Bash"),
+        _event("r3", EventType.TOOL_RESULT, 7, content="error: broke again", error_detected=True),
+    ]
+    outcome = classify_session(session, events)
+    assert outcome["outcome"] == "stuck"
+
+
 def test_classify_shipped_session():
     session = _session()
     events = [

--- a/tests/test_drift_cache.py
+++ b/tests/test_drift_cache.py
@@ -146,3 +146,19 @@ def test_save_is_atomic(tmp_path):
 
     leftover_tmps = [p for p in tmp_path.iterdir() if p.name.startswith(".jsonl_project_map-")]
     assert leftover_tmps == []
+
+
+def test_scan_survives_non_utf8_bytes(tmp_path):
+    """A transcript with invalid-UTF-8 bytes must not crash the drift scan.
+
+    Regression: a bare open() decoded strictly (and with the platform default
+    encoding on Windows), so one bad byte raised UnicodeDecodeError through
+    recall_project_status. utf-8 + errors=replace matches the main parser.
+    """
+    p = tmp_path / "bad.jsonl"
+    good_line = json.dumps({"cwd": str(tmp_path)}).encode("utf-8")
+    p.write_bytes(b"\xff\xfe garbage bytes\n" + good_line + b"\n")
+
+    entry = _scan_jsonl(p, 1.0)
+    assert entry is not None
+    assert str(tmp_path) in entry.raw_cwds

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -505,6 +505,42 @@ def test_tool_find_episodes(sample_session_file, temp_store):
     assert isinstance(payload, list)
 
 
+def test_tool_find_episodes_default_filters_in_sql(temp_store):
+    """has_fix (default true) must filter in SQL, not after the recency LIMIT.
+
+    Regression: 20+ recent fixless episodes pushed every with-fix episode past
+    the limit, so the tool's DEFAULT call returned [] on corpora whose newest
+    episodes are extraction noise.
+    """
+
+    def _ep(eid: str, day: int, month: int, fix: str | None) -> dict:
+        return {
+            "episode_id": eid,
+            "session_id": "s-eps",
+            "project_id": "p1",
+            "started_at": f"2026-{month:02d}-{day:02d}T10:00:00Z",
+            "ended_at": f"2026-{month:02d}-{day:02d}T10:30:00Z",
+            "problem_event_id": f"pe-{eid}",
+            "fix_event_id": fix,
+            "problem_description": "text",
+            "fix_summary": "fixed" if fix else "",
+            "touched_files": [],
+            "tags": [],
+            "status": "resolved" if fix else "unresolved",
+        }
+
+    older_with_fix = [_ep(f"ep-fix-{i}", day=1 + i, month=5, fix=f"fe-{i}") for i in range(5)]
+    recent_fixless = [_ep(f"ep-noise-{i}", day=1 + i, month=6, fix=None) for i in range(21)]
+    temp_store.sqlite.insert_episodes(older_with_fix + recent_fixless)
+
+    result = _call(mcp_server._tool_find_episodes, temp_store, {"limit": 20})
+    payload = _payload(result)
+
+    ids = {e["episode_id"] for e in payload}
+    assert {f"ep-fix-{i}" for i in range(5)} <= ids
+    assert all(e["fix_event_id"] for e in payload)
+
+
 def test_tool_get_episode_unknown(temp_store):
     result = _call(
         mcp_server._tool_get_episode,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -345,3 +345,25 @@ def test_tail_parse_skips_non_dict_json_lines(tmp_path):
     events, safe_offset = parser.parse_tail_from_offset(0)
     assert len(events) == 1
     assert safe_offset == len(content.encode("utf-8"))
+
+
+def test_is_subagent_transcript_cross_platform():
+    """The subagent filter must check path components, not a substring.
+
+    Regression: `"/subagents/" in str(path)` never matches on Windows
+    (backslash separators), so subagent transcripts were ingested as
+    standalone sessions and polluted the corpus.
+    """
+    from pathlib import PurePosixPath, PureWindowsPath
+
+    from longhand.parser import _is_subagent_transcript
+
+    posix = PurePosixPath("/Users/x/.claude/projects/p/sess/subagents/agent.jsonl")
+    win = PureWindowsPath(r"C:\Users\x\.claude\projects\p\sess\subagents\agent.jsonl")
+    plain = PurePosixPath("/Users/x/.claude/projects/p/sess.jsonl")
+    lookalike = PurePosixPath("/Users/x/projects/subagents-notes/sess.jsonl")
+
+    assert _is_subagent_transcript(posix) is True
+    assert _is_subagent_transcript(win) is True
+    assert _is_subagent_transcript(plain) is False
+    assert _is_subagent_transcript(lookalike) is False

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -244,3 +244,56 @@ def test_cli_redact_scan_and_apply(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     result = runner.invoke(app, ["redact", "--data-dir", str(data_dir)])
     assert result.exit_code == 0
     assert "clean" in result.stdout.lower()
+
+
+def test_retroactive_redact_covers_segments_and_git_commits(tmp_path: Path):
+    """`redact --apply` must reach conversation_segments and git_operations.
+
+    Regression: the table map said "segments" — a nonexistent table — so the
+    per-table except skipped ALL segment text (topic/summary/keywords)
+    silently, and git commit messages were never listed at all. topic holds
+    the segment's verbatim first user message.
+    """
+    data_dir = tmp_path / "lh"
+    store = LonghandStore(data_dir=data_dir)
+    store.sqlite.insert_segments(
+        [
+            {
+                "segment_id": "seg-1",
+                "session_id": "s1",
+                "started_at": "2026-07-01T10:00:00Z",
+                "ended_at": "2026-07-01T10:10:00Z",
+                "start_sequence": 1,
+                "end_sequence": 5,
+                "topic": f"set the key to {FAKE_ANTHROPIC} please",
+                "summary": "credentials discussion",
+            }
+        ]
+    )
+    store.sqlite.insert_git_operations(
+        [
+            {
+                "git_op_id": "g1",
+                "session_id": "s1",
+                "event_id": "e1",
+                "operation_type": "commit",
+                "commit_message": f"chore: rotate {FAKE_ANTHROPIC}",
+                "timestamp": "2026-07-01T10:05:00Z",
+            }
+        ]
+    )
+
+    local_runner = CliRunner()
+    result = local_runner.invoke(app, ["redact", "--apply", "--yes", "--data-dir", str(data_dir)])
+    assert result.exit_code == 0
+
+    fresh = LonghandStore(data_dir=data_dir)
+    with fresh.sqlite.connect() as conn:
+        topic = conn.execute(
+            "SELECT topic FROM conversation_segments WHERE segment_id = 'seg-1'"
+        ).fetchone()[0]
+        msg = conn.execute(
+            "SELECT commit_message FROM git_operations WHERE git_op_id = 'g1'"
+        ).fetchone()[0]
+    assert FAKE_ANTHROPIC not in topic
+    assert FAKE_ANTHROPIC not in msg

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -302,3 +302,33 @@ def test_busy_timeout_pragma(temp_store):
     """Write-lock waits must be generous — parallel hooks contend on one DB."""
     with temp_store.sqlite.connect() as conn:
         assert conn.execute("PRAGMA busy_timeout").fetchone()[0] == 30000
+
+
+def test_query_episodes_has_fix_in_sql(temp_store):
+    """has_fix filters inside the SQL WHERE (before ORDER BY/LIMIT)."""
+    base = {
+        "session_id": "s1",
+        "project_id": "p1",
+        "started_at": "2026-07-01T10:00:00Z",
+        "ended_at": "2026-07-01T10:30:00Z",
+        "problem_event_id": "pe",
+        "problem_description": "x",
+        "fix_summary": "",
+        "touched_files": [],
+        "tags": [],
+        "status": "unresolved",
+    }
+    temp_store.sqlite.insert_episodes(
+        [
+            {**base, "episode_id": "ep-f", "fix_event_id": "fe-1", "status": "resolved"},
+            {**base, "episode_id": "ep-n", "fix_event_id": None},
+        ]
+    )
+
+    with_fix = temp_store.sqlite.query_episodes(has_fix=True)
+    fixless = temp_store.sqlite.query_episodes(has_fix=False)
+    everything = temp_store.sqlite.query_episodes()
+
+    assert [e["episode_id"] for e in with_fix] == ["ep-f"]
+    assert [e["episode_id"] for e in fixless] == ["ep-n"]
+    assert {e["episode_id"] for e in everything} == {"ep-f", "ep-n"}


### PR DESCRIPTION
Part 2 of 2 of the v0.11.2 patch from the 2026-07-09 audit (part 1: #41).

## Fixes

1. **find_episodes default returned `[]`** — `has_fix=true` (the default) filtered in Python *after* the SQL `ORDER BY ended_at DESC LIMIT`, so corpora whose newest episodes are fixless noise got zero results despite hundreds of resolved episodes. The filter now lives in the SQL `WHERE` (`fix_event_id IS NOT NULL`) before the recency cut.
2. **Windows: subagent transcripts ingested as real sessions** — `"/subagents/" in str(path)` never matches backslash paths. New `_is_subagent_transcript()` checks `path.parts`; tested against both `PurePosixPath` and `PureWindowsPath`.
3. **Windows: drift scan crash on non-ASCII** — bare `.open()` used the platform encoding (cp1252) with strict decoding, and `UnicodeDecodeError` wasn't in the scan's except, so one bad byte crashed `recall_project_status`. Now `utf-8 + errors=replace` (matching the main parser) and the exception is handled.
4. **Outcome classifier over-reported "fixed"** — any clean result after *some* earlier error counted as "ended clean", so error → clean → error classified "fixed". A clean result now only counts if it came after the *last* error. Historical labels are unchanged unless `analyze --all` is re-run.
5. **redact --apply privacy gaps** — the table map named a nonexistent `segments` table (the per-table except silently skipped ALL segment text: topic/summary/keywords, where `topic` is the verbatim first user message), and git commit messages were never listed. Now covers `conversation_segments` and `git_operations`.

## Tests

+6 tests (338 total, all green); each is a regression test for the exact failure mode above. ruff check + format clean. No migrations (deliberate: the #41 migration-race fix must reach users one release before any new migration ships).

🤖 Generated with [Claude Code](https://claude.com/claude-code)