### PR TITLE
feat: update channel — --version flag + once-daily PyPI freshness check

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ Everything in Longhand's analysis is rules-based. Regex error detection. Hash-ba
 
 Your Claude Code history is yours. It goes into a SQLite file and a ChromaDB directory in `~/.longhand/`. No telemetry. No sync. No account. If your laptop is offline, Longhand works. If Anthropic goes down, Longhand works. If you delete the directory, it's gone.
 
+One boring exception, disclosed in full: the interactive CLI checks pypi.org for a newer Longhand version at most once a day. That request carries nothing but itself — no telemetry, no identifiers, nothing about your corpus — and a newer version just shows up as a dim one-line hint and a `doctor` row. It never runs from hooks or the MCP server, never blocks a command, and `LONGHAND_NO_UPDATE_CHECK=1` turns it off entirely. "Zero API calls" means what it always meant: no LLM or cloud service ever touches your data.
+
 ---
 
 ## What It Actually Does

--- a/longhand/cli/_commands.py
+++ b/longhand/cli/_commands.py
@@ -70,6 +70,53 @@ app = typer.Typer(
     add_completion=False,
 )
 
+# Hook/plumbing entry points where the update check must never run: hooks fire
+# on every Claude Code turn and the MCP server is a long-lived subprocess —
+# neither may gain network calls, extra output, or startup latency. Every
+# hidden command belongs here (enforced by test_update_check.py).
+_UPDATE_CHECK_EXCLUDED = {
+    "__prompt-hook-run",
+    "backfill-episodes",
+    "context",
+    "ingest-live",
+    "ingest-session",
+    "mcp-server",
+    "reanalyze",
+}
+
+
+def _version_callback(value: bool) -> None:
+    if not value:
+        return
+    from longhand import update_check
+    from longhand.version import __version__
+
+    console.print(f"longhand {__version__}")
+    hint = update_check.hint_from_cache()
+    if hint:
+        console.print(hint, style="dim")
+    raise typer.Exit()
+
+
+@app.callback()
+def _app_main(
+    ctx: typer.Context,
+    version: bool = typer.Option(
+        False,
+        "--version",
+        "-V",
+        callback=_version_callback,
+        is_eager=True,
+        help="Print the installed version and exit.",
+    ),
+):
+    if ctx.invoked_subcommand not in _UPDATE_CHECK_EXCLUDED:
+        from longhand import update_check
+
+        # Runs after the command finishes: prints the cache-only hint, then
+        # refreshes the cache (24h TTL) so the *next* run knows what's newest.
+        ctx.call_on_close(update_check.after_command)
+
 
 # -----------------------------------------------------------------------------
 # SETUP — one-command install wrapper

--- a/longhand/setup_commands.py
+++ b/longhand/setup_commands.py
@@ -981,6 +981,12 @@ def doctor() -> None:
             "[yellow]⚠[/yellow] not on PATH (run [bold]pip install longhand[/bold])",
         )
 
+    # 1b. Version freshness — the ONLY doctor check that goes online (a single
+    # HTTPS GET to pypi.org; opt-out via LONGHAND_NO_UPDATE_CHECK=1).
+    from longhand import update_check
+
+    table.add_row("Version", update_check.doctor_status())
+
     # 2. SessionEnd + Stop + UserPromptSubmit hooks installed?
     hook_installed = False
     hook_stale = False

--- a/longhand/update_check.py
+++ b/longhand/update_check.py
@@ -1,0 +1,184 @@
+"""Best-effort PyPI freshness check for the interactive CLI.
+
+Design constraints (v0.12 audit plan, "update channel"):
+
+- **Structurally excluded from hooks and the MCP server.** The only caller is
+  the CLI app callback in ``cli/_commands.py``, which skips every hidden
+  plumbing command (``ingest-session``, ``ingest-live``, ``mcp-server``,
+  ``__prompt-hook-run``, ...). Nothing in the hook or MCP code paths imports
+  this module's network functions.
+- **The hint never touches the network.** ``hint_from_cache`` reads the cache
+  file only; the network refresh happens after a command has already produced
+  its output, so a slow or offline PyPI can never delay real work.
+- **Never raises.** A missing, corrupt, or unwritable cache, a network
+  failure, or an unparseable version string all degrade to "no hint".
+- **Opt-out**: ``LONGHAND_NO_UPDATE_CHECK=1`` disables reads, hints, and the
+  network refresh entirely.
+
+The only data transmitted is the HTTPS request to pypi.org itself — no
+telemetry, no identifiers, nothing about the corpus.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+from longhand.version import __version__
+
+CACHE_TTL_SECONDS = 24 * 60 * 60
+PYPI_JSON_URL = "https://pypi.org/pypi/longhand/json"
+_TIMEOUT_SECONDS = 2.0
+
+
+def is_disabled() -> bool:
+    return os.environ.get("LONGHAND_NO_UPDATE_CHECK", "").strip() not in ("", "0")
+
+
+def cache_path(data_dir: str | Path | None = None) -> Path:
+    # Imported lazily: store pulls in chromadb-adjacent modules that this
+    # module must not load on the fast --version path.
+    from longhand.storage.store import DEFAULT_DATA_DIR
+
+    base = Path(data_dir) if data_dir else DEFAULT_DATA_DIR
+    return base / "update-check.json"
+
+
+def read_cache(data_dir: str | Path | None = None) -> dict | None:
+    """Return ``{"latest": str, "checked_at": float}`` or None. Never raises."""
+    try:
+        payload = json.loads(cache_path(data_dir).read_text(encoding="utf-8"))
+        if isinstance(payload.get("latest"), str) and isinstance(
+            payload.get("checked_at"), (int, float)
+        ):
+            return payload
+    except Exception:
+        pass
+    return None
+
+
+def _parse_version(text: str) -> tuple[int, ...] | None:
+    """X.Y.Z → (X, Y, Z). Local/dev suffixes are stripped; garbage → None."""
+    core = text.split("+")[0].strip()
+    parts = core.split(".")
+    try:
+        return tuple(int(p) for p in parts)
+    except ValueError:
+        return None
+
+
+def newer_available(installed: str, latest: str) -> bool:
+    """True only when both versions parse and latest is strictly newer."""
+    a = _parse_version(installed)
+    b = _parse_version(latest)
+    if a is None or b is None:
+        return False
+    if a == (0, 0, 0):
+        # Uninstalled/dev checkout (version.py falls back to "0.0.0+local") —
+        # never nag developers running from a repo.
+        return False
+    width = max(len(a), len(b))
+    return a + (0,) * (width - len(a)) < b + (0,) * (width - len(b))
+
+
+def hint_from_cache(data_dir: str | Path | None = None) -> str | None:
+    """One-line upgrade hint from the cache file only — no network, ever."""
+    if is_disabled():
+        return None
+    cached = read_cache(data_dir)
+    if cached and newer_available(__version__, cached["latest"]):
+        return (
+            f"longhand {cached['latest']} is available "
+            f"(installed {__version__}) — pip install -U longhand"
+        )
+    return None
+
+
+def refresh(data_dir: str | Path | None = None, *, force: bool = False) -> str | None:
+    """Fetch the latest version from PyPI and cache it. Never raises.
+
+    Respects the 24h TTL unless ``force``; returns the latest version string
+    when a fetch (or fresh cache) is available, else None.
+    """
+    if is_disabled():
+        return None
+    cached = read_cache(data_dir)
+    if not force and cached and time.time() - cached["checked_at"] < CACHE_TTL_SECONDS:
+        return cached["latest"]
+    try:
+        with urllib.request.urlopen(PYPI_JSON_URL, timeout=_TIMEOUT_SECONDS) as resp:
+            latest = json.load(resp)["info"]["version"]
+        if not isinstance(latest, str):
+            return None
+    except Exception:
+        return None
+    _write_cache(data_dir, latest)
+    return latest
+
+
+def _write_cache(data_dir: str | Path | None, latest: str) -> None:
+    """Atomic tempfile + rename write, mirroring drift_cache. Never raises."""
+    target = cache_path(data_dir)
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            prefix=".update-check-", suffix=".json.tmp", dir=str(target.parent)
+        )
+        try:
+            with os.fdopen(fd, "w") as f:
+                json.dump({"latest": latest, "checked_at": time.time()}, f)
+            os.replace(tmp_name, target)
+        except Exception:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+    except Exception:
+        pass
+
+
+def after_command(data_dir: str | Path | None = None) -> None:
+    """Post-command hook for interactive CLI runs. Never raises.
+
+    Prints the cache-only hint (TTY only, so piped output stays clean), then
+    refreshes the cache for the *next* run — the current command's output has
+    already been delivered, so the network wait costs the user nothing.
+    """
+    try:
+        if is_disabled():
+            return
+        hint = hint_from_cache(data_dir)
+        if hint and sys.stdout.isatty():
+            from rich.console import Console
+
+            Console(stderr=True).print(hint, style="dim")
+        refresh(data_dir)
+    except Exception:
+        pass
+
+
+def doctor_status(data_dir: str | Path | None = None) -> str:
+    """Rich-markup status line for the doctor table. Refreshes (forced)."""
+    if is_disabled():
+        return "[dim]disabled (LONGHAND_NO_UPDATE_CHECK)[/dim]"
+    latest = refresh(data_dir, force=True)
+    if latest is None:
+        cached = read_cache(data_dir)
+        if cached is None:
+            return "[yellow]⚠[/yellow] could not reach pypi.org (offline?)"
+        age_days = max(0.0, (time.time() - cached["checked_at"]) / 86400)
+        latest = cached["latest"]
+        suffix = f" [dim](cached {age_days:.0f}d ago; pypi.org unreachable)[/dim]"
+    else:
+        suffix = ""
+    if newer_available(__version__, latest):
+        return (
+            f"[yellow]⚠[/yellow] {latest} available (installed {__version__}) — "
+            f"run [bold]pip install -U longhand[/bold]{suffix}"
+        )
+    return f"[green]✓[/green] up to date ({__version__}){suffix}"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,14 @@ from typing import Any
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _no_update_check(monkeypatch):
+    """Keep the suite offline and deterministic: the CLI app callback would
+    otherwise refresh the PyPI update cache after every CliRunner invocation.
+    Tests that exercise the update check delete this env var explicitly."""
+    monkeypatch.setenv("LONGHAND_NO_UPDATE_CHECK", "1")
+
+
 def _line(entry: dict[str, Any]) -> str:
     return json.dumps(entry) + "\n"
 

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -1,0 +1,235 @@
+"""Tests for the PyPI update check: cache semantics, hints, doctor line, and
+the structural guarantee that hooks and the MCP server never touch it."""
+
+from __future__ import annotations
+
+import io
+import json
+import time
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from longhand import update_check
+from longhand.cli._commands import _UPDATE_CHECK_EXCLUDED, app
+from longhand.version import __version__
+
+runner = CliRunner()
+
+
+def _network_forbidden(*args, **kwargs):
+    raise AssertionError("update check touched the network when it must not")
+
+
+@pytest.fixture
+def enabled(monkeypatch, tmp_path: Path) -> Path:
+    """Enable the check (conftest disables it suite-wide) with an isolated
+    cache under tmp_path. Returns the data dir the cache lives in."""
+    monkeypatch.delenv("LONGHAND_NO_UPDATE_CHECK", raising=False)
+    import longhand.storage.store as store_mod
+
+    data_dir = tmp_path / "lh"
+    monkeypatch.setattr(store_mod, "DEFAULT_DATA_DIR", data_dir)
+    return data_dir
+
+
+def _seed_cache(data_dir: Path, latest: str, age_seconds: float = 0.0) -> None:
+    data_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "update-check.json").write_text(
+        json.dumps({"latest": latest, "checked_at": time.time() - age_seconds})
+    )
+
+
+# ─── version comparison ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("installed", "latest", "expected"),
+    [
+        ("0.11.2", "0.12.0", True),
+        ("0.11.2", "0.11.2", False),
+        ("0.12.0", "0.11.9", False),
+        ("0.11.2", "0.11.10", True),  # numeric compare, not lexicographic
+        ("0.11.2", "1.0", True),  # mixed lengths pad with zeros
+        ("1.0", "1.0.0", False),
+        ("0.0.0+local", "0.11.2", False),  # dev checkout — never nag
+        ("garbage", "0.12.0", False),
+        ("0.11.2", "not-a-version", False),
+    ],
+)
+def test_newer_available(installed: str, latest: str, expected: bool):
+    assert update_check.newer_available(installed, latest) is expected
+
+
+# ─── --version flag ──────────────────────────────────────────────────────────
+
+
+def test_version_flag_prints_version_without_network(monkeypatch):
+    monkeypatch.setattr("urllib.request.urlopen", _network_forbidden)
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert f"longhand {__version__}" in result.stdout
+
+
+def test_version_flag_shows_upgrade_hint_from_cache(enabled, monkeypatch):
+    monkeypatch.setattr("urllib.request.urlopen", _network_forbidden)
+    _seed_cache(enabled, "99.0.0")
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert "99.0.0" in result.stdout
+    assert "pip install -U longhand" in result.stdout
+
+
+# ─── cache-only hint ─────────────────────────────────────────────────────────
+
+
+def test_hint_none_without_cache(enabled):
+    assert update_check.hint_from_cache() is None
+
+
+def test_hint_none_on_corrupt_cache(enabled):
+    enabled.mkdir(parents=True, exist_ok=True)
+    (enabled / "update-check.json").write_text("{not json")
+    assert update_check.hint_from_cache() is None
+
+
+def test_hint_none_when_up_to_date(enabled):
+    _seed_cache(enabled, __version__)
+    assert update_check.hint_from_cache() is None
+
+
+def test_hint_when_newer_cached(enabled):
+    _seed_cache(enabled, "99.0.0")
+    hint = update_check.hint_from_cache()
+    assert hint is not None and "99.0.0" in hint
+
+
+# ─── refresh: TTL, network failure, opt-out ──────────────────────────────────
+
+
+def test_refresh_fresh_cache_skips_network(enabled, monkeypatch):
+    monkeypatch.setattr("urllib.request.urlopen", _network_forbidden)
+    _seed_cache(enabled, "0.11.9", age_seconds=60)
+    assert update_check.refresh() == "0.11.9"
+
+
+def test_refresh_expired_cache_fetches_and_writes(enabled, monkeypatch):
+    _seed_cache(enabled, "0.11.9", age_seconds=update_check.CACHE_TTL_SECONDS + 60)
+    body = io.StringIO(json.dumps({"info": {"version": "0.12.5"}}))
+    monkeypatch.setattr("urllib.request.urlopen", lambda url, timeout: body)
+    assert update_check.refresh() == "0.12.5"
+    cached = update_check.read_cache()
+    assert cached is not None and cached["latest"] == "0.12.5"
+
+
+def test_refresh_network_error_returns_none_and_keeps_cache(enabled, monkeypatch):
+    _seed_cache(enabled, "0.11.9", age_seconds=update_check.CACHE_TTL_SECONDS + 60)
+
+    def _down(*args, **kwargs):
+        raise OSError("network down")
+
+    monkeypatch.setattr("urllib.request.urlopen", _down)
+    assert update_check.refresh(force=True) is None
+    cached = update_check.read_cache()
+    assert cached is not None and cached["latest"] == "0.11.9"  # untouched
+
+
+def test_disabled_env_blocks_hint_and_refresh(monkeypatch, tmp_path):
+    # conftest sets LONGHAND_NO_UPDATE_CHECK=1; only isolate the data dir.
+    import longhand.storage.store as store_mod
+
+    data_dir = tmp_path / "lh"
+    monkeypatch.setattr(store_mod, "DEFAULT_DATA_DIR", data_dir)
+    monkeypatch.setattr("urllib.request.urlopen", _network_forbidden)
+    _seed_cache(data_dir, "99.0.0")
+
+    assert update_check.is_disabled() is True
+    assert update_check.hint_from_cache() is None
+    assert update_check.refresh(force=True) is None
+
+
+# ─── after_command (the CLI post-run hook) ───────────────────────────────────
+
+
+def test_after_command_prints_hint_on_tty(enabled, monkeypatch, capsys):
+    monkeypatch.setattr("urllib.request.urlopen", _network_forbidden)
+    _seed_cache(enabled, "99.0.0")  # fresh cache: refresh stays offline
+    monkeypatch.setattr("sys.stdout.isatty", lambda: True)
+    update_check.after_command()
+    assert "99.0.0" in capsys.readouterr().err  # hint goes to stderr, dim
+
+
+def test_after_command_silent_when_piped(enabled, monkeypatch, capsys):
+    monkeypatch.setattr("urllib.request.urlopen", _network_forbidden)
+    _seed_cache(enabled, "99.0.0")
+    monkeypatch.setattr("sys.stdout.isatty", lambda: False)
+    update_check.after_command()
+    captured = capsys.readouterr()
+    assert "99.0.0" not in captured.out
+    assert "99.0.0" not in captured.err
+
+
+def test_after_command_never_raises(enabled, monkeypatch):
+    monkeypatch.setattr(update_check, "hint_from_cache", _network_forbidden)  # any internal failure
+    update_check.after_command()  # must swallow, not raise
+
+
+# ─── structural exclusion: hooks and MCP never run the check ─────────────────
+
+
+def test_every_hidden_command_is_excluded():
+    """Hooks and the MCP server enter through hidden plumbing commands; any
+    new hidden command must be added to _UPDATE_CHECK_EXCLUDED explicitly."""
+    for info in app.registered_commands:
+        name = info.name or info.callback.__name__.replace("_", "-")
+        if info.hidden:
+            assert name in _UPDATE_CHECK_EXCLUDED, (
+                f"hidden command {name!r} is not excluded from the update check"
+            )
+
+
+def test_hook_entry_point_never_schedules_update_check(monkeypatch, tmp_path):
+    calls: list[int] = []
+    monkeypatch.setattr(update_check, "after_command", lambda *a, **k: calls.append(1))
+    runner.invoke(app, ["ingest-session", str(tmp_path / "missing.jsonl")])
+    assert calls == []
+
+
+def test_interactive_command_schedules_update_check(monkeypatch, tmp_path):
+    calls: list[int] = []
+    monkeypatch.setattr(update_check, "after_command", lambda *a, **k: calls.append(1))
+    result = runner.invoke(app, ["projects", "--data-dir", str(tmp_path / "lh")])
+    assert result.exit_code == 0
+    assert calls == [1]
+
+
+# ─── doctor line ─────────────────────────────────────────────────────────────
+
+
+def test_doctor_status_up_to_date(enabled, monkeypatch):
+    monkeypatch.setattr(update_check, "refresh", lambda *a, **k: __version__)
+    assert "up to date" in update_check.doctor_status()
+
+
+def test_doctor_status_update_available(enabled, monkeypatch):
+    monkeypatch.setattr(update_check, "refresh", lambda *a, **k: "99.0.0")
+    line = update_check.doctor_status()
+    assert "99.0.0" in line and "pip install -U longhand" in line
+
+
+def test_doctor_status_offline_without_cache(enabled, monkeypatch):
+    monkeypatch.setattr(update_check, "refresh", lambda *a, **k: None)
+    assert "could not reach" in update_check.doctor_status()
+
+
+def test_doctor_status_offline_falls_back_to_stale_cache(enabled, monkeypatch):
+    monkeypatch.setattr(update_check, "refresh", lambda *a, **k: None)
+    _seed_cache(enabled, "99.0.0", age_seconds=3 * 86400)
+    line = update_check.doctor_status()
+    assert "99.0.0" in line and "cached" in line
+
+
+def test_doctor_status_disabled(monkeypatch):
+    # conftest keeps LONGHAND_NO_UPDATE_CHECK=1 for this test.
+    assert "disabled" in update_check.doctor_status()


### PR DESCRIPTION
Tier 2 PR 1 of 7 from the 2026-07-09 audit roadmap (v0.12.0). Closes the "733 weekly installs never learn a fix shipped" gap — distribution-first.

## What

- **`longhand --version` / `-V`** — prints the installed version plus a cached upgrade hint when one is known. Never touches the network.
- **`longhand/update_check.py`** — once-daily (24h TTL) check of `pypi.org/pypi/longhand/json`, cached in the data dir with atomic writes, 2s timeout, never raises. `LONGHAND_NO_UPDATE_CHECK=1` disables reads, hints, and fetches entirely.
- **Dim CLI hint, cache-only** — interactive commands print a one-line hint (TTY only, to stderr) *after* their output via `ctx.call_on_close`, then refresh the cache for the next run — a slow or offline PyPI can never delay real work.
- **`doctor` Version row** — the only doctor check that goes online; reports up-to-date / update-available / offline-with-cached-fallback / disabled.
- **Structural exclusion from hooks + MCP** — the app callback skips every hidden plumbing command (`ingest-session`, `ingest-live`, `mcp-server`, `__prompt-hook-run`, …), and `test_every_hidden_command_is_excluded` makes forgetting to exclude a future hidden command a test failure.
- **README disclosure** (privacy section) — approved wording: the request carries nothing but itself; "Zero API calls" still means no LLM/cloud service touches your data.

## Tests

+30 (368 total, green): version-compare matrix (incl. dev-checkout never nags), TTL/offline/corrupt-cache semantics, opt-out, TTY-gated hint, never-raises, and the structural-exclusion guards. `tests/conftest.py` now sets `LONGHAND_NO_UPDATE_CHECK=1` suite-wide so CI stays offline-deterministic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)