### PR TITLE
feat: background the episode-embedding backfill out of the prompt hook

### DIFF
--- a/longhand/cli/_commands.py
+++ b/longhand/cli/_commands.py
@@ -2499,9 +2499,19 @@ def backfill_episodes(
 
     Needed once after upgrading to a version that added the episodes
     ChromaDB collection. Idempotent — safe to re-run. The recall pipeline
-    also triggers this automatically on first use, so most users never
-    need to call it directly.
+    spawns this in the background on first use, so most users never need
+    to call it directly.
+
+    Takes the ingest lock: the embedding pass writes ChromaDB, and a
+    concurrent ingest would race it. A locked-out run defers (success
+    exit) — the recall pipeline re-spawns it on the next query for as
+    long as the backfill is still needed.
     """
+    from longhand.recall.project_fallback import (
+        claim_ingest_lock,
+        release_ingest_lock,
+    )
+
     store = _get_store(data_dir)
 
     sql_count = store.sqlite.count_episodes()
@@ -2515,18 +2525,28 @@ def backfill_episodes(
         console.print(f"[green]✓[/green] All {sql_count} episodes already embedded.")
         return
 
-    console.print(
-        f"[cyan]Embedding {sql_count} episode(s)...[/cyan] [dim]({vector_count} already done)[/dim]"
-    )
+    if not claim_ingest_lock(store):
+        console.print(
+            "[yellow]Another Longhand ingest is running — deferring the episode "
+            "backfill; the next recall will retry it.[/yellow]"
+        )
+        return
 
-    def _progress(done: int, total: int) -> None:
-        console.print(f"   {done}/{total}...", end="\r")
+    try:
+        console.print(
+            f"[cyan]Embedding {sql_count} episode(s)...[/cyan] [dim]({vector_count} already done)[/dim]"
+        )
 
-    embedded = store.backfill_episode_embeddings(progress=_progress)
-    console.print(
-        f"[green]✓[/green] Embedded {embedded} episode(s). "
-        f"Vector collection now has {store.vectors.episode_count()} entries."
-    )
+        def _progress(done: int, total: int) -> None:
+            console.print(f"   {done}/{total}...", end="\r")
+
+        embedded = store.backfill_episode_embeddings(progress=_progress)
+        console.print(
+            f"[green]✓[/green] Embedded {embedded} episode(s). "
+            f"Vector collection now has {store.vectors.episode_count()} entries."
+        )
+    finally:
+        release_ingest_lock(store)
 
 
 if __name__ == "__main__":

--- a/longhand/recall/project_fallback.py
+++ b/longhand/recall/project_fallback.py
@@ -109,14 +109,15 @@ def infer_missing_projects(store: LonghandStore) -> list[dict[str, Any]]:
     return inferred
 
 
-def trigger_background_ingest(store: LonghandStore) -> bool:
-    """Fire a detached `longhand ingest` in the background.
+def spawn_background(store: LonghandStore, subcommand: list[str], log_prefix: str) -> bool:
+    """Fire a detached `longhand <subcommand>` in the background.
 
-    Returns True if a new ingest subprocess was spawned; False if one is
-    already running (lockfile owned by an alive PID) or we couldn't start.
+    Returns True if a subprocess was spawned; False if an ingest-lock holder
+    is already alive (the work is underway — don't stack another process) or
+    the spawn failed.
 
     The subprocess itself owns the lockfile — see `claim_ingest_lock` in
-    this module. This module never writes the lock; it just reads it to
+    this module. This function never writes the lock; it just reads it to
     decide whether to skip spawning.
     """
     lock = _lock_path(store)
@@ -133,7 +134,7 @@ def trigger_background_ingest(store: LonghandStore) -> bool:
         return False
 
     today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-    log_file = logs / f"background-ingest-{today}.log"
+    log_file = logs / f"{log_prefix}-{today}.log"
 
     try:
         # Open inside a `with` so the parent closes its FD as soon as Popen
@@ -143,8 +144,8 @@ def trigger_background_ingest(store: LonghandStore) -> bool:
             subprocess.Popen(
                 # "-m longhand" (the package __main__), NOT "-m longhand.cli":
                 # longhand.cli is a package with no __main__.py, so spawning
-                # it dies instantly and the background ingest never runs.
-                [sys.executable, "-m", "longhand", "ingest"],
+                # it dies instantly and the background work never runs.
+                [sys.executable, "-m", "longhand", *subcommand],
                 stdout=log_fh,
                 stderr=subprocess.STDOUT,
                 start_new_session=True,
@@ -153,6 +154,22 @@ def trigger_background_ingest(store: LonghandStore) -> bool:
         return True
     except Exception:
         return False
+
+
+def trigger_background_ingest(store: LonghandStore) -> bool:
+    """Fire a detached `longhand ingest` in the background."""
+    return spawn_background(store, ["ingest"], "background-ingest")
+
+
+def trigger_background_episode_backfill(store: LonghandStore) -> bool:
+    """Fire a detached `longhand backfill-episodes` in the background.
+
+    Used by the recall pipeline after an upgrade that added the episodes
+    vector collection: embedding the whole corpus inline would block the
+    user's prompt (recall runs in the UserPromptSubmit hook), so the work
+    happens in a detached process that claims the ingest lock.
+    """
+    return spawn_background(store, ["backfill-episodes"], "background-backfill")
 
 
 def claim_ingest_lock(store: LonghandStore) -> bool:

--- a/longhand/recall/recall_pipeline.py
+++ b/longhand/recall/recall_pipeline.py
@@ -21,6 +21,7 @@ from typing import Any
 from longhand.parser import discover_sessions
 from longhand.recall.episode_search import find_episodes
 from longhand.recall.narrative import build_narrative
+from longhand.recall.project_fallback import trigger_background_episode_backfill
 from longhand.recall.project_match import ProjectMatch, match_projects
 from longhand.recall.segment_search import find_segments
 from longhand.recall.time_parser import parse_time_phrase
@@ -167,12 +168,15 @@ def recall(
     if now is None:
         now = datetime.now(timezone.utc)
 
-    # 0. Transparent first-run backfill — if we're on a fresh upgrade and the
-    # episodes vector collection is empty while the SQLite episode table is
-    # populated, embed everything now so semantic episode search works.
-    # Idempotent and a no-op after the first call.
+    # 0. First-run backfill — after an upgrade the episodes vector collection
+    # can be empty while SQLite is populated. Embedding the whole corpus
+    # inline would block the user's prompt (recall runs inside the
+    # UserPromptSubmit hook), so spawn a detached `longhand backfill-episodes`
+    # (which claims the ingest lock) and serve this recall from SQLite;
+    # semantic episode search comes online once the backfill lands.
     try:
-        store.ensure_episode_embeddings()
+        if store.episode_backfill_needed():
+            trigger_background_episode_backfill(store)
     except Exception:
         pass
 

--- a/longhand/storage/store.py
+++ b/longhand/storage/store.py
@@ -424,18 +424,28 @@ class LonghandStore:
 
         return embedded
 
+    def episode_backfill_needed(self) -> bool:
+        """True when SQLite has episodes but the vector collection is empty —
+        i.e. a first run after upgrading to a version with episode embeddings.
+        Cheap (two counts); never raises.
+        """
+        try:
+            if self.vectors.episode_count() > 0:
+                return False
+            return self.sqlite.count_episodes() > 0
+        except Exception:
+            return False
+
     def ensure_episode_embeddings(self) -> int:
         """If the episodes vector collection is empty but SQLite has episodes,
         transparently backfill. Returns the number of episodes embedded
-        (0 if no backfill was needed). Safe to call on every recall.
+        (0 if no backfill was needed).
+
+        NB: this embeds inline — up to the whole corpus. The recall pipeline
+        deliberately does NOT call it (it spawns a detached
+        `longhand backfill-episodes` instead); this stays for the CLI and for
+        callers that want the synchronous behavior.
         """
-        try:
-            vector_count = self.vectors.episode_count()
-        except Exception:
-            return 0
-        if vector_count > 0:
-            return 0
-        sql_count = self.sqlite.count_episodes()
-        if sql_count == 0:
+        if not self.episode_backfill_needed():
             return 0
         return self.backfill_episode_embeddings()

--- a/tests/test_episode_search.py
+++ b/tests/test_episode_search.py
@@ -291,3 +291,55 @@ def test_ensure_episode_embeddings_noops_when_already_populated(temp_store: Long
 
     n = temp_store.ensure_episode_embeddings()
     assert n == 0
+
+
+def test_episode_backfill_needed_states(temp_store: LonghandStore):
+    """False on empty store, True with unembedded episodes, False after backfill."""
+    assert temp_store.episode_backfill_needed() is False
+
+    temp_store.sqlite.insert_episodes(
+        [_fixture_episode(episode_id="ep-need", problem="p", fix="f")]
+    )
+    assert temp_store.episode_backfill_needed() is True
+
+    temp_store.backfill_episode_embeddings()
+    assert temp_store.episode_backfill_needed() is False
+
+
+def test_backfill_cli_defers_when_lock_held(temp_store: LonghandStore):
+    """backfill-episodes must not race a running ingest for ChromaDB writes."""
+    import os
+
+    from typer.testing import CliRunner
+
+    from longhand.cli._commands import app
+
+    temp_store.sqlite.insert_episodes(
+        [_fixture_episode(episode_id="ep-lock", problem="p", fix="f")]
+    )
+    lock = temp_store.data_dir / ".ingest.lock"
+    lock.write_text(str(os.getppid()))  # an alive holder
+
+    result = CliRunner().invoke(app, ["backfill-episodes", "--data-dir", str(temp_store.data_dir)])
+    assert result.exit_code == 0  # deferral is success, not failure
+    assert "deferring" in result.stdout.lower()
+    assert temp_store.vectors.episode_count() == 0  # nothing embedded
+    assert lock.read_text().strip() == str(os.getppid())  # not ours; untouched
+    lock.unlink()
+
+
+def test_backfill_cli_reclaims_stale_lock_and_releases(temp_store: LonghandStore):
+    from typer.testing import CliRunner
+
+    from longhand.cli._commands import app
+
+    temp_store.sqlite.insert_episodes(
+        [_fixture_episode(episode_id="ep-stale", problem="p", fix="f")]
+    )
+    lock = temp_store.data_dir / ".ingest.lock"
+    lock.write_text("0")  # dead/invalid holder
+
+    result = CliRunner().invoke(app, ["backfill-episodes", "--data-dir", str(temp_store.data_dir)])
+    assert result.exit_code == 0
+    assert temp_store.vectors.episode_count() == 1
+    assert not lock.exists()  # released in the finally

--- a/tests/test_project_fallback.py
+++ b/tests/test_project_fallback.py
@@ -277,3 +277,95 @@ def test_ingest_single_session_reclaims_stale_lock_and_releases(sample_session_f
         n = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
     assert n == 1
     assert not lock.exists()  # released in the finally
+
+
+# ─── spawn_background generalization + episode-backfill trigger ──────────────
+
+
+def _with_fix_episode(episode_id: str = "ep-bg") -> dict:
+    return {
+        "episode_id": episode_id,
+        "session_id": "s-bg",
+        "project_id": "p-bg",
+        "started_at": "2026-07-01T10:00:00Z",
+        "ended_at": "2026-07-01T10:30:00Z",
+        "problem_event_id": f"{episode_id}-prob",
+        "fix_event_id": f"{episode_id}-fix",
+        "problem_description": "background backfill problem",
+        "fix_summary": "background backfill fix",
+        "touched_files": [],
+        "tags": [],
+        "status": "resolved",
+    }
+
+
+def test_trigger_background_episode_backfill_spawn_target(temp_store):
+    temp_store.data_dir.mkdir(parents=True, exist_ok=True)
+
+    with patch("subprocess.Popen") as mock_popen:
+        assert project_fallback.trigger_background_episode_backfill(temp_store) is True
+
+    argv = mock_popen.call_args[0][0]
+    assert argv == [sys.executable, "-m", "longhand", "backfill-episodes"]
+
+
+def test_spawn_background_skips_when_lock_holder_alive(temp_store):
+    temp_store.data_dir.mkdir(parents=True, exist_ok=True)
+    lock = temp_store.data_dir / ".ingest.lock"
+    lock.write_text(str(os.getppid()))  # an alive holder
+
+    with patch("subprocess.Popen") as mock_popen:
+        assert project_fallback.trigger_background_episode_backfill(temp_store) is False
+
+    mock_popen.assert_not_called()
+    lock.unlink()
+
+
+def test_recall_spawns_backfill_instead_of_embedding_inline(temp_store, monkeypatch):
+    """The recall pipeline runs inside the UserPromptSubmit hook — it must
+    never embed the corpus inline. When a backfill is needed it spawns the
+    detached worker and serves the current query from SQLite."""
+    from longhand.recall import recall_pipeline
+
+    temp_store.sqlite.insert_episodes([_with_fix_episode()])
+    assert temp_store.episode_backfill_needed() is True
+
+    spawned: list[int] = []
+    monkeypatch.setattr(
+        recall_pipeline,
+        "trigger_background_episode_backfill",
+        lambda store: spawned.append(1) or True,
+    )
+
+    def _no_inline(*args, **kwargs):
+        raise AssertionError("recall embedded episodes inline")
+
+    monkeypatch.setattr(temp_store, "backfill_episode_embeddings", _no_inline)
+    monkeypatch.setattr(temp_store, "ensure_episode_embeddings", _no_inline)
+    # Keep the match-miss fallback from scanning the real ~/.claude/projects.
+    monkeypatch.setattr(recall_pipeline, "match_projects", lambda *a, **k: [])
+
+    recall_pipeline.recall(temp_store, "background backfill problem")
+
+    assert spawned == [1]
+    assert temp_store.vectors.episode_count() == 0  # nothing embedded inline
+
+
+def test_recall_does_not_spawn_when_vectors_populated(temp_store, monkeypatch):
+    from longhand.recall import recall_pipeline
+
+    temp_store.sqlite.insert_episodes([_with_fix_episode("ep-done")])
+    temp_store.backfill_episode_embeddings()
+    assert temp_store.episode_backfill_needed() is False
+
+    spawned: list[int] = []
+    monkeypatch.setattr(
+        recall_pipeline,
+        "trigger_background_episode_backfill",
+        lambda store: spawned.append(1) or True,
+    )
+    monkeypatch.setattr(recall_pipeline, "match_projects", lambda *a, **k: [])
+
+    recall_pipeline.recall(temp_store, "background backfill problem")
+
+    assert spawned == []


### PR DESCRIPTION
Tier 2 PR 2 of 7 from the 2026-07-09 audit roadmap (v0.12.0).

## Problem

`recall()` called `ensure_episode_embeddings()` inline on every invocation. On the first recall after an upgrade that added the episodes vector collection, that embeds up to the whole corpus (100k-episode query cap) synchronously **inside the UserPromptSubmit hook** — blocking the user's prompt and racing the hook timeout.

## What

- **Recall spawns instead of embedding**: a cheap two-count `episode_backfill_needed()` check, then a detached `longhand backfill-episodes` via the new generalized `spawn_background(store, subcommand, log_prefix)` helper (same lockfile read, per-day log file, and detached-Popen path the background ingest uses — and the same spawn-target regression guard from v0.11.2). The current query serves from SQLite; semantic episode search comes online when the backfill lands.
- **`backfill-episodes` claims the ingest lock** — its ChromaDB writes would race a concurrent ingest. Locked-out runs defer with a success exit; the next recall re-spawns while the backfill is still needed.
- `ensure_episode_embeddings` remains for synchronous CLI callers.

## Tests

+7 (375 total, green): spawn-target argv, lock-holder-alive skips the spawn, recall-spawns-not-embeds (inline embedding is an AssertionError in the test), recall-no-spawn-when-populated, `episode_backfill_needed` state matrix, CLI defers on live lock / reclaims stale lock and releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)