### PR TITLE
feat: ingest atomicity — analysis_stage marker + reconcile partially_indexed bucket

### DIFF
--- a/longhand/cli/_commands.py
+++ b/longhand/cli/_commands.py
@@ -454,13 +454,15 @@ def reconcile(
     fix: bool = typer.Option(
         False,
         "--fix",
-        help="Re-ingest sessions that are missing or have NULL project_id",
+        help="Re-ingest sessions that are missing, partially indexed, or have NULL project_id",
     ),
 ):
     """Reconcile session transcripts on disk against the sessions table.
 
-    Finds three buckets:
-    - Fully indexed (session row exists, project_id set)
+    Finds four buckets:
+    - Fully indexed (session row exists, project_id set, analysis completed)
+    - Partially indexed (the ingest pipeline crashed mid-way — events landed
+      but analysis/vectors may be incomplete)
     - Ingested but project_id IS NULL (project inference failed — often because
       Claude Code launched from $HOME so the transcript's first-event cwd
       wasn't a project directory)
@@ -482,11 +484,14 @@ def reconcile(
 
     console.print(f"[bold]On disk:[/bold] {report.files_on_disk} JSONL files")
     console.print(f"  [green]{report.fully_indexed}[/green] fully indexed")
+    console.print(
+        f"  [yellow]{len(report.partially_indexed)}[/yellow] partially indexed (ingest crashed mid-pipeline)"
+    )
     console.print(f"  [yellow]{len(report.null_project)}[/yellow] ingested but project_id IS NULL")
     console.print(f"  [red]{len(report.missing)}[/red] missing from sessions")
 
     if not fix:
-        if report.missing or report.null_project:
+        if report.missing or report.null_project or report.partially_indexed:
             console.print("\n[dim]Run with --fix to re-ingest.[/dim]")
         return
 
@@ -494,13 +499,12 @@ def reconcile(
         console.print("[yellow]Another ingest is running — aborting reconcile.[/yellow]")
         raise typer.Exit(1)
 
-    if not (report.missing or report.null_project):
+    if not (report.missing or report.null_project or report.partially_indexed):
         console.print("\n[green]Nothing to fix.[/green]")
         return
 
-    console.print(
-        f"\n[cyan]Re-ingesting {len(report.missing) + len(report.null_project)} file(s)...[/cyan]"
-    )
+    n_fixable = len(report.missing) + len(report.null_project) + len(report.partially_indexed)
+    console.print(f"\n[cyan]Re-ingesting {n_fixable} file(s)...[/cyan]")
     for err in report.errors:
         console.print(f"  [red]✗[/red] {Path(err['path']).name}: {err['error']}")
     console.print(

--- a/longhand/mcp_server.py
+++ b/longhand/mcp_server.py
@@ -700,9 +700,13 @@ async def list_tools() -> list[Tool]:
             },
             outputSchema={
                 "type": "object",
-                "description": "Counts of fully-indexed, null-project, missing, ingested, and errors.",
+                "description": (
+                    "Counts of fully-indexed, partially-indexed, null-project, "
+                    "missing, ingested, and errors."
+                ),
                 "properties": {
                     "fully_indexed": {"type": "integer"},
+                    "partially_indexed": {"type": "integer"},
                     "null_project": {"type": "integer"},
                     "missing": {"type": "integer"},
                     "ingested": {"type": "integer"},

--- a/longhand/recall/reconcile.py
+++ b/longhand/recall/reconcile.py
@@ -24,6 +24,7 @@ class ReconcileReport:
     fully_indexed: int
     null_project: list[str] = field(default_factory=list)  # transcript paths
     missing: list[str] = field(default_factory=list)
+    partially_indexed: list[str] = field(default_factory=list)  # crashed mid-pipeline
     ingested: int = 0
     errors: list[dict[str, str]] = field(default_factory=list)  # [{path, error}]
     fix_applied: bool = False
@@ -35,8 +36,10 @@ class ReconcileReport:
             "fully_indexed": self.fully_indexed,
             "null_project_count": len(self.null_project),
             "missing_count": len(self.missing),
+            "partially_indexed_count": len(self.partially_indexed),
             "null_project": self.null_project,
             "missing": self.missing,
+            "partially_indexed": self.partially_indexed,
             "ingested": self.ingested,
             "errors": self.errors,
             "fix_applied": self.fix_applied,
@@ -48,9 +51,10 @@ def run_reconcile(store: LonghandStore, fix: bool = False) -> ReconcileReport:
     """Classify on-disk JSONLs vs. indexed sessions; optionally re-ingest problem buckets.
 
     Without `fix`: returns counts only.
-    With `fix=True`: acquires the ingest lock and re-ingests missing + null-project
-    entries using current project inference. If another ingest is running, returns
-    with `lock_unavailable=True` and zero ingested.
+    With `fix=True`: acquires the ingest lock and re-ingests missing,
+    null-project, and partially-indexed entries using current project
+    inference. If another ingest is running, returns with
+    `lock_unavailable=True` and zero ingested.
     """
     files = discover_sessions()
     if not files:
@@ -59,9 +63,11 @@ def run_reconcile(store: LonghandStore, fix: bool = False) -> ReconcileReport:
     with store.sqlite.connect() as conn:
         rows = conn.execute("SELECT transcript_path, project_id FROM sessions").fetchall()
     indexed: dict[str, str | None] = {r[0]: r[1] for r in rows}
+    stages = store.sqlite.analysis_stages()
 
     missing: list[Path] = []
     null_project: list[Path] = []
+    partial: list[Path] = []
     fully_indexed = 0
     for f in files:
         state = indexed.get(str(f), "__not_found__")
@@ -69,6 +75,14 @@ def run_reconcile(store: LonghandStore, fix: bool = False) -> ReconcileReport:
             missing.append(f)
         elif state is None:
             null_project.append(f)
+        elif stages.get(str(f)) == "pending":
+            # The ingest pipeline started but never finished — a crash left
+            # this session with events but possibly no analysis/vectors.
+            # Only 'pending' counts: NULL is a pre-v0.12 or live-tail row
+            # (unknown — treated as complete so upgrades don't stampede),
+            # and 'events' is a deliberate --skip-analysis defer owned by
+            # `longhand analyze --all`.
+            partial.append(f)
         else:
             fully_indexed += 1
 
@@ -77,12 +91,13 @@ def run_reconcile(store: LonghandStore, fix: bool = False) -> ReconcileReport:
         fully_indexed=fully_indexed,
         null_project=[str(p) for p in null_project],
         missing=[str(p) for p in missing],
+        partially_indexed=[str(p) for p in partial],
     )
 
     if not fix:
         return report
 
-    to_process = missing + null_project
+    to_process = missing + null_project + partial
     if not to_process:
         report.fix_applied = True
         return report

--- a/longhand/storage/migrations.py
+++ b/longhand/storage/migrations.py
@@ -167,6 +167,17 @@ MIGRATIONS: dict[int, str] = {
     -- The recompute UPDATE runs in _apply_alters with table-existence guards,
     -- since migrations may be applied before the base schema in standalone paths.
     """,
+    7: """
+    -- v7: ingest atomicity — track how far the ingest pipeline got per
+    -- transcript so reconcile can spot crashes that landed the session row
+    -- but not the analysis. Values:
+    --   NULL       pre-0.12 row or live-tail cursor row (unknown; treated as
+    --              complete so upgrades don't trigger a re-analysis stampede)
+    --   'pending'  pipeline started but did not finish (crash) — repairable
+    --   'events'   core data landed, analysis deliberately skipped
+    --   'analyzed' full pipeline completed
+    -- The guarded ALTER runs in _apply_alters.
+    """,
 }
 
 
@@ -209,6 +220,14 @@ def _apply_alters(conn: sqlite3.Connection, version: int) -> None:
                 "ALTER TABLE ingestion_log ADD COLUMN last_offset INTEGER NOT NULL DEFAULT 0"
             )
             conn.execute("UPDATE ingestion_log SET last_offset = file_size WHERE last_offset = 0")
+    if version == 7:
+        if _table_exists(conn, "ingestion_log") and not _column_exists(
+            conn, "ingestion_log", "analysis_stage"
+        ):
+            # NULL default on purpose: existing rows stay "unknown" and are
+            # treated as complete — flagging 300+ sessions as partial on
+            # upgrade would trigger a full re-analysis stampede.
+            conn.execute("ALTER TABLE ingestion_log ADD COLUMN analysis_stage TEXT")
     if version == 6:
         # One-time backfill: recompute the project rollups from the authoritative
         # sessions table. Guarded on table existence because migrations may run

--- a/longhand/storage/sqlite_store.py
+++ b/longhand/storage/sqlite_store.py
@@ -267,18 +267,77 @@ class SQLiteStore:
             )
         return pairs
 
-    def log_ingestion(
-        self, transcript_path: str, session_id: str, file_size: int, event_count: int
-    ) -> None:
+    def mark_ingest_started(self, transcript_path: str, session_id: str) -> None:
+        """Record intent before the ingest pipeline runs.
+
+        A crash anywhere in the pipeline leaves analysis_stage='pending',
+        which reconcile classifies as partially_indexed and --fix repairs.
+        Preserves an existing row's file_size/event_count/last_offset (the
+        live-tail cursor may already be mid-file).
+        """
         with self.connect() as conn:
             conn.execute(
                 """
-                INSERT OR REPLACE INTO ingestion_log
-                    (transcript_path, session_id, ingested_at, file_size, event_count)
-                VALUES (?, ?, ?, ?, ?)
+                INSERT INTO ingestion_log
+                    (transcript_path, session_id, ingested_at, file_size,
+                     event_count, analysis_stage)
+                VALUES (?, ?, ?, 0, 0, 'pending')
+                ON CONFLICT(transcript_path) DO UPDATE SET
+                    session_id = excluded.session_id,
+                    analysis_stage = 'pending'
                 """,
-                (transcript_path, session_id, _iso(datetime.now()), file_size, event_count),
+                (transcript_path, session_id, _iso(datetime.now())),
             )
+
+    def log_ingestion(
+        self, transcript_path: str, session_id: str, file_size: int, event_count: int
+    ) -> None:
+        """Record a completed core-data ingest (analysis may still follow).
+
+        Preserves the live-tail cursor: a full ingest consumed the whole file,
+        so last_offset advances to at least file_size instead of being reset
+        to 0 (which made the next Stop-hook tail re-parse from the start).
+        """
+        with self.connect() as conn:
+            conn.execute(
+                """
+                INSERT INTO ingestion_log
+                    (transcript_path, session_id, ingested_at, file_size,
+                     event_count, analysis_stage, last_offset)
+                VALUES (?, ?, ?, ?, ?, 'pending', ?)
+                ON CONFLICT(transcript_path) DO UPDATE SET
+                    session_id = excluded.session_id,
+                    ingested_at = excluded.ingested_at,
+                    file_size = excluded.file_size,
+                    event_count = excluded.event_count,
+                    analysis_stage = 'pending',
+                    last_offset = MAX(last_offset, excluded.file_size)
+                """,
+                (
+                    transcript_path,
+                    session_id,
+                    _iso(datetime.now()),
+                    file_size,
+                    event_count,
+                    file_size,
+                ),
+            )
+
+    def set_analysis_stage(self, transcript_path: str, stage: str) -> None:
+        """Advance the pipeline marker ('events' or 'analyzed') for a transcript."""
+        with self.connect() as conn:
+            conn.execute(
+                "UPDATE ingestion_log SET analysis_stage = ? WHERE transcript_path = ?",
+                (stage, transcript_path),
+            )
+
+    def analysis_stages(self) -> dict[str, str | None]:
+        """transcript_path → analysis_stage for every logged ingest."""
+        with self.connect() as conn:
+            rows = conn.execute(
+                "SELECT transcript_path, analysis_stage FROM ingestion_log"
+            ).fetchall()
+        return {r[0]: r[1] for r in rows}
 
     def already_ingested(self, transcript_path: str, current_size: int) -> bool:
         """Check if a file has been ingested at its current size (for skip on re-ingest)."""

--- a/longhand/storage/store.py
+++ b/longhand/storage/store.py
@@ -65,12 +65,21 @@ class LonghandStore:
         """Persist a parsed session and its events to both backends.
 
         Pipeline:
+        0. Mark intent (analysis_stage='pending' — a crash below leaves this
+           marker for reconcile's partially_indexed bucket)
         1. SQLite events + session
         2. Vector store embeddings
         3. Tool pair linking (call ↔ result)
         4. Ingestion log
-        5. (optional) Analysis: project inference, outcome, episodes, session embedding
+        5. (optional) Analysis: project inference, outcome, episodes, session
+           embedding — stamps analysis_stage='analyzed' on completion;
+           run_analysis=False stamps 'events' (deliberate defer, not a crash)
+
+        Each step commits separately; the stage marker is what makes a
+        mid-pipeline failure visible instead of silently under-analyzed.
         """
+        self.sqlite.mark_ingest_started(session.transcript_path, session.session_id)
+
         self.sqlite.upsert_session(session)
         sql_inserted = self.sqlite.insert_events(events)
         vec_inserted = self.vectors.add_events(events)
@@ -102,6 +111,8 @@ class LonghandStore:
         if run_analysis:
             analysis_result = self.analyze_session(session, events)
             result.update(analysis_result)
+        else:
+            self.sqlite.set_analysis_stage(session.transcript_path, "events")
 
         return result
 
@@ -302,6 +313,11 @@ class LonghandStore:
             text=session_text,
             metadata=session_meta,
         )
+
+        # Full pipeline done for this transcript — clears the 'pending' crash
+        # marker. Also covers `longhand analyze --all`, which calls this
+        # directly. No-op when the transcript has no ingestion_log row.
+        self.sqlite.set_analysis_stage(session.transcript_path, "analyzed")
 
         return {
             "project_id": project["project_id"],

--- a/tests/test_ingest_atomicity.py
+++ b/tests/test_ingest_atomicity.py
@@ -1,0 +1,144 @@
+"""Ingest atomicity: the analysis_stage marker and reconcile's
+partially_indexed bucket.
+
+The ingest pipeline commits each step separately; before v0.12 a crash after
+the session row landed left the session looking fully indexed to reconcile
+while analysis and vectors were silently missing. The stage marker makes the
+crash visible ('pending'), reconcile reports it, and --fix repairs it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from longhand.parser import JSONLParser
+from longhand.recall import reconcile as reconcile_mod
+from longhand.recall.reconcile import run_reconcile
+
+
+def _parse(fixture_path: Path):
+    parser = JSONLParser(fixture_path)
+    events = list(parser.parse_events())
+    return parser.build_session(events), events
+
+
+def _stage(store, transcript_path: str) -> str | None:
+    return store.sqlite.analysis_stages().get(transcript_path)
+
+
+def test_full_ingest_stamps_analyzed(sample_session_file, temp_store):
+    session, events = _parse(sample_session_file)
+    temp_store.ingest_session(session, events, run_analysis=True)
+    assert _stage(temp_store, str(sample_session_file)) == "analyzed"
+
+
+def test_skip_analysis_stamps_events(sample_session_file, temp_store):
+    session, events = _parse(sample_session_file)
+    temp_store.ingest_session(session, events, run_analysis=False)
+    assert _stage(temp_store, str(sample_session_file)) == "events"
+
+
+def test_crash_mid_pipeline_leaves_pending(sample_session_file, temp_store, monkeypatch):
+    session, events = _parse(sample_session_file)
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("chroma exploded mid-ingest")
+
+    monkeypatch.setattr(temp_store.vectors, "add_events", _boom)
+    with pytest.raises(RuntimeError):
+        temp_store.ingest_session(session, events, run_analysis=True)
+
+    assert _stage(temp_store, str(sample_session_file)) == "pending"
+
+
+def test_reconcile_flags_pending_as_partial_and_fix_repairs(
+    sample_session_file, temp_store, monkeypatch
+):
+    """A crash *after* project attribution is the blind spot this PR closes:
+    the session row has a project_id, so pre-v0.12 reconcile called it fully
+    indexed while episodes/segments/vectors were silently missing. (Crashes
+    *before* attribution leave project_id NULL and were always caught by the
+    null_project bucket.)"""
+    session, events = _parse(sample_session_file)
+
+    # Crash the first ingest mid-analysis (after attribute_session_project).
+    def _boom(*args, **kwargs):
+        raise RuntimeError("chroma exploded mid-analysis")
+
+    monkeypatch.setattr(temp_store.vectors, "add_episode_embeddings_batch", _boom)
+    with pytest.raises(RuntimeError):
+        temp_store.ingest_session(session, events, run_analysis=True)
+    monkeypatch.undo()
+
+    monkeypatch.setattr(reconcile_mod, "discover_sessions", lambda: [sample_session_file])
+
+    report = run_reconcile(temp_store, fix=False)
+    assert report.partially_indexed == [str(sample_session_file)]
+    assert report.fully_indexed == 0
+
+    # --fix re-ingests the partial; the repaired session is fully indexed.
+    fixed = run_reconcile(temp_store, fix=True)
+    assert fixed.ingested == 1
+    assert _stage(temp_store, str(sample_session_file)) == "analyzed"
+
+    after = run_reconcile(temp_store, fix=False)
+    assert after.partially_indexed == []
+    assert after.fully_indexed == 1
+
+
+def test_reconcile_tolerates_null_stage(sample_session_file, temp_store, monkeypatch):
+    """Pre-v0.12 rows have analysis_stage NULL — they must classify as fully
+    indexed, not partial (no re-analysis stampede on upgrade)."""
+    session, events = _parse(sample_session_file)
+    temp_store.ingest_session(session, events, run_analysis=True)
+
+    with temp_store.sqlite.connect() as conn:
+        conn.execute(
+            "UPDATE ingestion_log SET analysis_stage = NULL WHERE transcript_path = ?",
+            (str(sample_session_file),),
+        )
+
+    monkeypatch.setattr(reconcile_mod, "discover_sessions", lambda: [sample_session_file])
+    report = run_reconcile(temp_store, fix=False)
+    assert report.partially_indexed == []
+    assert report.fully_indexed == 1
+
+
+def test_reconcile_leaves_deliberate_skip_analysis_alone(
+    sample_session_file, temp_store, monkeypatch
+):
+    """'events' is an intentional --skip-analysis defer — the new partial
+    bucket must not claim it as a crash. (Skip-analysis sessions have NULL
+    project_id, so they stay in the pre-existing null_project bucket exactly
+    as before this change.)"""
+    session, events = _parse(sample_session_file)
+    temp_store.ingest_session(session, events, run_analysis=False)
+    assert _stage(temp_store, str(sample_session_file)) == "events"
+
+    monkeypatch.setattr(reconcile_mod, "discover_sessions", lambda: [sample_session_file])
+    report = run_reconcile(temp_store, fix=False)
+    assert report.partially_indexed == []
+    assert report.null_project == [str(sample_session_file)]
+
+
+def test_analyze_all_path_clears_events_stage(sample_session_file, temp_store):
+    """analyze_session (the `analyze --all` entry point) stamps 'analyzed'."""
+    session, events = _parse(sample_session_file)
+    temp_store.ingest_session(session, events, run_analysis=False)
+    assert _stage(temp_store, str(sample_session_file)) == "events"
+
+    temp_store.analyze_session(session, events)
+    assert _stage(temp_store, str(sample_session_file)) == "analyzed"
+
+
+def test_full_ingest_advances_live_offset(sample_session_file, temp_store):
+    """A full ingest consumed the whole file, so the live-tail cursor must
+    advance to file_size — resetting it to 0 made the next Stop hook
+    re-parse the entire transcript for nothing."""
+    session, events = _parse(sample_session_file)
+    temp_store.ingest_session(session, events, run_analysis=False)
+
+    size = sample_session_file.stat().st_size
+    assert temp_store.sqlite.get_live_offset(str(sample_session_file)) == size

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -381,3 +381,43 @@ def test_concurrent_store_init_does_not_crash(tmp_path: Path):
     ).fetchall()
     conn.close()
     assert dupes == []
+
+
+def test_v7_adds_analysis_stage_null_for_existing_rows(tmp_path: Path):
+    """Upgrading a pre-v7 database adds the column with NULL for existing
+    rows — NULL means "unknown, treat as complete" so the upgrade never
+    triggers a re-analysis stampede."""
+    db_path = tmp_path / "test.db"
+    conn = sqlite3.connect(str(db_path))
+    # Minimal base tables so migrations 1-6 apply (matches
+    # test_apply_migrations_from_empty), plus the pre-v7 ingestion_log shape.
+    conn.execute(
+        "CREATE TABLE sessions (session_id TEXT PRIMARY KEY, project_path TEXT, transcript_path TEXT, started_at TEXT, ended_at TEXT, event_count INTEGER, user_message_count INTEGER, assistant_message_count INTEGER, tool_call_count INTEGER, file_edit_count INTEGER, git_branch TEXT, cwd TEXT, model TEXT, ingested_at TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE events (event_id TEXT PRIMARY KEY, session_id TEXT, parent_event_id TEXT, event_type TEXT, sequence INTEGER, timestamp TEXT, cwd TEXT, git_branch TEXT, model TEXT, content TEXT, is_sidechain INTEGER, tool_name TEXT, tool_use_id TEXT, tool_input_json TEXT, tool_output TEXT, tool_success INTEGER, file_path TEXT, file_operation TEXT, old_content TEXT, new_content TEXT, raw_json TEXT)"
+    )
+    conn.execute(
+        "CREATE TABLE ingestion_log (transcript_path TEXT PRIMARY KEY, "
+        "session_id TEXT NOT NULL, ingested_at TEXT NOT NULL, "
+        "file_size INTEGER NOT NULL, event_count INTEGER NOT NULL)"
+    )
+    conn.execute("INSERT INTO ingestion_log VALUES ('/t/old.jsonl', 's-old', '2026-01-01', 100, 5)")
+    conn.commit()
+
+    apply_migrations(conn)
+
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(ingestion_log)")}
+    assert "analysis_stage" in cols
+    stage = conn.execute(
+        "SELECT analysis_stage FROM ingestion_log WHERE transcript_path = '/t/old.jsonl'"
+    ).fetchone()[0]
+    assert stage is None
+    conn.close()
+
+
+def test_fresh_store_has_analysis_stage(tmp_path: Path):
+    store = SQLiteStore(tmp_path / "lh" / "longhand.db")
+    with store.connect() as conn:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(ingestion_log)")}
+    assert "analysis_stage" in cols


### PR DESCRIPTION
Tier 2 PR 3 of 7 from the 2026-07-09 audit roadmap (v0.12.0). First new migration since the migration-race fix shipped in v0.11.2 — exactly the sequencing the risk register required.

## Problem

`ingest_session` commits each step separately. A crash after the session row + project attribution landed (e.g. ChromaDB failing during episode embedding) left the session classified **fully_indexed** by reconcile while its analysis and vectors were silently missing — permanent, invisible under-analysis.

## What

- **Migration 7**: `ingestion_log.analysis_stage` — `NULL` (pre-v0.12 / live-tail rows: unknown, treated as complete so upgrades don't stampede into re-analyzing the whole corpus), `'pending'` (pipeline started, didn't finish), `'events'` (deliberate `--skip-analysis` defer), `'analyzed'` (complete). Guarded ALTER, O(1).
- **Pipeline stamps**: intent recorded before step 1; `analyze_session` stamps `'analyzed'` at its end (covers `analyze --all` too); `run_analysis=False` stamps `'events'`.
- **Reconcile**: new `partially_indexed` bucket (`'pending'` only); `--fix` re-ingests it alongside missing/null-project. CLI summary line + MCP `outputSchema` updated (`to_dict` passthrough).
- **Bonus fix surfaced by the work**: `log_ingestion`'s `INSERT OR REPLACE` reset the live-tail cursor to 0 on every full ingest, making the next Stop hook re-parse the entire transcript for nothing. It now advances `last_offset` to at least `file_size`.

## Tests

+10 (385 total, green): stage transitions (analyzed/events/pending on crash), crash-after-attribution → partial → `--fix` repairs → fully indexed, NULL tolerance (no stampede), deliberate-skip stays in null_project as before, `analyze --all` clears 'events', live-offset advance, migration on pre-v7 DB + fresh store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)