### PR TITLE
feat: attribution overhaul — git-root-first walk, junk-project guard, case-dupe merge, dry-run reattribute

### DIFF
--- a/longhand/analysis/project_inference.py
+++ b/longhand/analysis/project_inference.py
@@ -11,11 +11,20 @@ from __future__ import annotations
 
 import hashlib
 import re
+import tempfile
 from pathlib import Path
 from typing import Any
 
 from longhand.extractors.topics import extract_extensions, extract_keywords
 from longhand.types import Event, Session
+
+# Reserved bucket for sessions that can't honestly be attributed to a project:
+# no cwd at all, or a markerless cwd in a location that must never mint a
+# project (home root, temp dirs, plugin caches, tool-results, pytest dirs).
+# Fixed id — NOT derived from _project_id_for — so every such session lands in
+# one stable bucket instead of minting junk projects per path.
+UNATTRIBUTED_PROJECT_ID = "p_unattributed"
+UNATTRIBUTED_CANONICAL_PATH = "unattributed://"
 
 # Map file extensions → language names
 _EXT_TO_LANGUAGE = {
@@ -117,9 +126,10 @@ _CATEGORY_SIGNALS: list[tuple[str, list[str]]] = [
 ]
 
 
-# Files/directories that indicate a project root
-_PROJECT_ROOT_MARKERS = (
-    ".git",  # git repo
+# Files/directories that indicate a project root. `.git` is handled
+# separately in the walk (highest .git wins over any nearer non-git marker —
+# monorepo packages must not split into per-package projects).
+_NON_GIT_ROOT_MARKERS = (
     "package.json",  # node
     "pyproject.toml",  # python (modern)
     "setup.py",  # python (legacy)
@@ -132,6 +142,7 @@ _PROJECT_ROOT_MARKERS = (
     "mix.exs",  # elixir
     "pubspec.yaml",  # dart/flutter
 )
+_PROJECT_ROOT_MARKERS = (".git", *_NON_GIT_ROOT_MARKERS)
 
 
 def _find_project_root(path: Path, max_walk: int = 8) -> Path:
@@ -147,22 +158,35 @@ def _find_project_root(path: Path, max_walk: int = 8) -> Path:
 def find_project_root_strict(path: Path, max_walk: int = 8) -> Path | None:
     """Walk up from `path` looking for a project marker; return None if none found.
 
+    `.git` outranks every other marker, and the HIGHEST `.git` within the walk
+    wins: in a monorepo (`repo/.git` + `repo/apps/web/package.json`), sessions
+    in `apps/web` must attribute to `repo`, not split into a per-package
+    project. Nested repos likewise collapse into the outermost one. Only when
+    no `.git` is found does the nearest non-git marker decide.
+
     Unlike `_find_project_root`, this returns None instead of falling back to
     the input path. Callers that need to distinguish "real project" from
     "arbitrary directory" should use this.
     """
     current = path
+    git_root: Path | None = None
+    marker_root: Path | None = None
     for _ in range(max_walk):
         try:
-            for marker in _PROJECT_ROOT_MARKERS:
-                if (current / marker).exists():
-                    return current
-            # Also match *.xcodeproj wildcard
-            try:
-                if any(current.glob("*.xcodeproj")):
-                    return current
-            except (OSError, PermissionError):
-                pass
+            if (current / ".git").exists():
+                git_root = current  # keep walking — a higher .git wins
+            elif marker_root is None:
+                for marker in _NON_GIT_ROOT_MARKERS:
+                    if (current / marker).exists():
+                        marker_root = current
+                        break
+                else:
+                    # Also match *.xcodeproj wildcard
+                    try:
+                        if any(current.glob("*.xcodeproj")):
+                            marker_root = current
+                    except (OSError, PermissionError):
+                        pass
         except (OSError, PermissionError):
             break
 
@@ -171,7 +195,82 @@ def find_project_root_strict(path: Path, max_walk: int = 8) -> Path | None:
             break
         current = parent
 
-    return None
+    return git_root or marker_root
+
+
+def _true_case(path: Path) -> Path:
+    """Recover the on-disk casing of an existing path, component by component.
+
+    On case-insensitive filesystems (macOS APFS), `~/projects/Foo` and
+    `~/Projects/foo` are the same directory but hash to different project ids.
+    Normalizing to the filesystem's own casing makes every spelling of a path
+    mint the same project. Non-existent components (and case-sensitive
+    filesystems, where only the exact casing exists) pass through unchanged.
+    """
+    try:
+        out = Path(path.anchor)
+        for comp in path.parts[len(out.parts) :]:
+            candidate = out / comp
+            if candidate.exists():
+                # Fast path — but on a case-insensitive FS this matches any
+                # casing, so recover the real name from the parent listing.
+                match = next(
+                    (c for c in out.iterdir() if c.name.lower() == comp.lower()),
+                    None,
+                )
+                out = match if match is not None else candidate
+            else:
+                out = candidate
+        return out
+    except (OSError, PermissionError):
+        return path
+
+
+def _is_reserved_path(path: Path) -> bool:
+    """True for locations that must never mint a project of their own.
+
+    Only consulted when NO project marker was found — a real repo checked out
+    under /tmp still attributes normally. These are the junk-project sources
+    observed on real corpora: the $HOME catch-all, temp/scratch dirs, pytest
+    tmpdirs, and Claude Code's own internal directories (plugin caches,
+    tool-results, the transcript store itself).
+    """
+    home = Path.home()
+    if path == home:
+        return True
+    claude_dir = home / ".claude"
+    if path == claude_dir or claude_dir in path.parents:
+        return True
+    parts = path.parts
+    if any(p.startswith("pytest-") for p in parts):
+        return True
+    if "plugin-cache" in parts or "tool-results" in parts:
+        return True
+    tmp_roots = {
+        Path(tempfile.gettempdir()).resolve(),
+        Path("/tmp"),
+        Path("/private/tmp"),
+        Path("/var/folders"),
+        Path("/private/var/folders"),
+    }
+    return any(path == root or root in path.parents for root in tmp_roots)
+
+
+def _unattributed_fingerprint(session: Session) -> dict[str, Any]:
+    """The reserved bucket fingerprint. Keywords/languages deliberately empty —
+    hundreds of unrelated sessions share this row, and merging their keywords
+    would turn it into an alias magnet that hijacks fuzzy project matching."""
+    return {
+        "project_id": UNATTRIBUTED_PROJECT_ID,
+        "canonical_path": UNATTRIBUTED_CANONICAL_PATH,
+        "display_name": "unattributed",
+        "aliases": ["unattributed"],
+        "keywords": [],
+        "languages": [],
+        "category": None,
+        "first_seen": session.started_at.isoformat(),
+        "last_seen": session.ended_at.isoformat(),
+    }
 
 
 def _canonicalize_path(path: str | None) -> str | None:
@@ -183,7 +282,7 @@ def _canonicalize_path(path: str | None) -> str | None:
         if resolved.is_file():
             resolved = resolved.parent
         root = _find_project_root(resolved)
-        return str(root)
+        return str(_true_case(root))
     except Exception:
         return path
 
@@ -241,11 +340,30 @@ def _infer_category(
 
 
 def infer_project(session: Session, events: list[Event]) -> dict[str, Any]:
-    """Build a ProjectFingerprint dict from a session and its events."""
-    canonical = _canonicalize_path(session.cwd or session.project_path)
-    if not canonical:
-        # No cwd — use a synthetic project keyed on the transcript file's parent
-        canonical = str(Path(session.transcript_path).parent.resolve())
+    """Build a ProjectFingerprint dict from a session and its events.
+
+    Sessions with no cwd, or a markerless cwd in a reserved location (home
+    root, temp/pytest dirs, Claude Code internals), land in the reserved
+    `unattributed` bucket instead of minting a junk project. Everything else
+    keys off the (case-normalized) project root as before.
+    """
+    raw = session.cwd or session.project_path
+    if not raw:
+        # Pre-v0.12 this minted a synthetic project from the transcript file's
+        # parent — i.e. Claude Code's own storage dir — which is exactly the
+        # "launch slug" junk-project source.
+        return _unattributed_fingerprint(session)
+
+    try:
+        resolved = Path(raw).resolve()
+        if resolved.is_file():
+            resolved = resolved.parent
+        root = find_project_root_strict(resolved)
+        if root is None and _is_reserved_path(resolved):
+            return _unattributed_fingerprint(session)
+        canonical = str(_true_case(root if root is not None else resolved))
+    except Exception:
+        canonical = raw
 
     project_id = _project_id_for(canonical)
     display_name = _display_name(canonical)

--- a/longhand/cli/_commands.py
+++ b/longhand/cli/_commands.py
@@ -1036,23 +1036,52 @@ def analyze(
 
 @app.command(rich_help_panel="Data")
 def reattribute(
+    fix: bool = typer.Option(
+        False,
+        "--fix",
+        help="Apply the moves. Without it, print what would change (dry-run).",
+    ),
     data_dir: str | None = typer.Option(None, "--data-dir"),
 ):
     """Repair project misattribution.
 
     Re-derives each session's project from its events in the database (not the
-    transcript file, which may have been rotated away) and re-attaches it. Fixes
-    sessions that drifted to the wrong project — e.g. work filed under the home
-    catch-all because cwd and project_id desynced. Idempotent.
+    transcript file, which may have been rotated away). Fixes sessions that
+    drifted to the wrong project — the home catch-all, monorepo splits,
+    case-duplicate paths, and junk projects minted from temp dirs. Idempotent.
+
+    DRY-RUN BY DEFAULT: prints the moves grouped by destination and touches
+    nothing. Review, then re-run with --fix to apply.
     """
     store = _get_store(data_dir)
-    console.print("[cyan]Re-attributing sessions from the events table...[/cyan]")
-    result = store.reattribute_sessions()
+    mode = "Re-attributing" if fix else "Dry-run: re-deriving"
+    console.print(f"[cyan]{mode} sessions from the events table...[/cyan]")
+    result = store.reattribute_sessions(apply=fix)
     console.print(
         f"[bold]Scanned {result['scanned']}[/bold] sessions, "
-        f"[bold]{result['reattributed']}[/bold] re-attributed "
+        f"[bold]{result['reattributed']}[/bold] "
+        f"{'re-attributed' if fix else 'would move'} "
         f"([dim]{result['skipped']} skipped — no events[/dim])"
     )
+
+    if result["changes"]:
+        by_move: dict[tuple[str | None, str], int] = {}
+        names: dict[str, str] = {}
+        for c in result["changes"]:
+            key = (c["old_project_id"], c["new_project_id"])
+            by_move[key] = by_move.get(key, 0) + 1
+            names[c["new_project_id"]] = c["new_display_name"]
+        for (old_pid, new_pid), n in sorted(by_move.items(), key=lambda kv: -kv[1]):
+            old_proj = store.sqlite.get_project(old_pid) if old_pid else None
+            old_name = (old_proj or {}).get("display_name") or old_pid or "(none)"
+            console.print(f"  {n:>4} session(s): {old_name} → {names[new_pid]}")
+
+    if result["pruned"]:
+        verb = "pruned" if fix else "would be pruned"
+        console.print(f"  [dim]{result['pruned']} emptied project row(s) {verb}[/dim]")
+
+    if not fix and result["changes"]:
+        console.print("\n[dim]Run with --fix to apply.[/dim]")
 
 
 def _deprecated(old: str, new: str) -> None:

--- a/longhand/storage/sqlite_store.py
+++ b/longhand/storage/sqlite_store.py
@@ -747,6 +747,25 @@ class SQLiteStore:
                 (project_id,),
             )
 
+    def prune_empty_projects(self) -> int:
+        """Delete project rows with no attached sessions. Returns the count.
+
+        Completes a reattribution: when every session moves out of a junk or
+        case-dupe project, the emptied row would otherwise linger forever in
+        `longhand projects` and fuzzy matching.
+        """
+        with self.connect() as conn:
+            cur = conn.execute(
+                """
+                DELETE FROM projects
+                WHERE project_id NOT IN (
+                    SELECT DISTINCT project_id FROM sessions
+                    WHERE project_id IS NOT NULL
+                )
+                """
+            )
+            return cur.rowcount
+
     def get_project(self, project_id: str) -> dict[str, Any] | None:
         with self.connect() as conn:
             row = conn.execute(

--- a/longhand/storage/store.py
+++ b/longhand/storage/store.py
@@ -132,15 +132,23 @@ class LonghandStore:
         self.sqlite.recompute_project_stats(project["project_id"])
         return project
 
-    def reattribute_sessions(self, session_ids: list[str] | None = None) -> dict:
+    def reattribute_sessions(
+        self, session_ids: list[str] | None = None, apply: bool = True
+    ) -> dict:
         """Re-derive each session's project (and corrected cwd) from its events in
         the events table — independent of the transcript file, which may have been
         rotated off disk — and re-attach it.
 
         Repairs project_id↔cwd drift (the F2 misattribution bug, where sessions
-        ended up filed under the home catch-all). Returns counts:
-        ``{scanned, reattributed, skipped}``.
+        ended up filed under the home catch-all). With ``apply=False`` nothing
+        is written — the returned ``changes`` list shows what would move.
+
+        Returns ``{scanned, reattributed, skipped, applied, changes, pruned}``;
+        ``changes`` is ``[{session_id, old_project_id, new_project_id,
+        new_display_name}]``, ``pruned`` counts project rows deleted because
+        the moves left them with zero sessions (dry-run: would-be count).
         """
+        from longhand.analysis.project_inference import infer_project
         from longhand.parser import _pick_best_project_cwd
 
         rows = self.sqlite.list_sessions(limit=1_000_000)
@@ -148,7 +156,8 @@ class LonghandStore:
             wanted = set(session_ids)
             rows = [r for r in rows if r["session_id"] in wanted]
 
-        scanned = reattributed = skipped = 0
+        scanned = skipped = 0
+        changes: list[dict] = []
         for row in rows:
             sid = row["session_id"]
             events = self._events_for_session(sid)
@@ -158,24 +167,57 @@ class LonghandStore:
             best_cwd = _pick_best_project_cwd(events) or row.get("cwd") or row.get("project_path")
             session = self._session_from_row(row, best_cwd)
             old_pid = row.get("project_id")
-            project = self.attribute_session_project(session, events)
-            if best_cwd and best_cwd != row.get("cwd"):
-                with self.sqlite.connect() as conn:
-                    conn.execute(
-                        "UPDATE sessions SET cwd = ? WHERE session_id = ?", (best_cwd, sid)
-                    )
+
+            if apply:
+                project = self.attribute_session_project(session, events)
+                if best_cwd and best_cwd != row.get("cwd"):
+                    with self.sqlite.connect() as conn:
+                        conn.execute(
+                            "UPDATE sessions SET cwd = ? WHERE session_id = ?", (best_cwd, sid)
+                        )
+            else:
+                project = infer_project(session, events)
+
             scanned += 1
             if project["project_id"] != old_pid:
-                reattributed += 1
+                changes.append(
+                    {
+                        "session_id": sid,
+                        "old_project_id": old_pid,
+                        "new_project_id": project["project_id"],
+                        "new_display_name": project["display_name"],
+                    }
+                )
 
-        # Sessions may have moved between projects — re-derive every project's
-        # rollups so counts stay accurate (emptied projects drop to 0).
-        with self.sqlite.connect() as conn:
-            pids = [r[0] for r in conn.execute("SELECT project_id FROM projects").fetchall()]
-        for pid in pids:
-            self.sqlite.recompute_project_stats(pid)
+        pruned = 0
+        if apply:
+            # Sessions may have moved between projects — re-derive every project's
+            # rollups so counts stay accurate, then drop rows the moves emptied
+            # (completes case-dupe/junk-project merges).
+            with self.sqlite.connect() as conn:
+                pids = [r[0] for r in conn.execute("SELECT project_id FROM projects").fetchall()]
+            for pid in pids:
+                self.sqlite.recompute_project_stats(pid)
+            pruned = self.sqlite.prune_empty_projects()
+        elif changes:
+            moved_from = {c["old_project_id"] for c in changes if c["old_project_id"]}
+            with self.sqlite.connect() as conn:
+                for pid in moved_from:
+                    remaining = conn.execute(
+                        "SELECT COUNT(*) FROM sessions WHERE project_id = ?", (pid,)
+                    ).fetchone()[0]
+                    moving = sum(1 for c in changes if c["old_project_id"] == pid)
+                    if remaining - moving <= 0:
+                        pruned += 1
 
-        return {"scanned": scanned, "reattributed": reattributed, "skipped": skipped}
+        return {
+            "scanned": scanned,
+            "reattributed": len(changes),
+            "skipped": skipped,
+            "applied": apply,
+            "changes": changes,
+            "pruned": pruned,
+        }
 
     def _events_for_session(self, session_id: str) -> list[Event]:
         """Rebuild Event objects from the events table — only the fields project

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ def sample_session_file(tmp_path: Path) -> Path:
             "parentUuid": None,
             "sessionId": "test-session-1",
             "timestamp": "2026-04-09T10:00:01.000Z",
-            "cwd": "/tmp/test-project",
+            "cwd": "/Users/tester/test-project",
             "gitBranch": "main",
             "isSidechain": False,
             "message": {"role": "user", "content": "Edit the readme"},
@@ -53,7 +53,7 @@ def sample_session_file(tmp_path: Path) -> Path:
             "parentUuid": "user-1",
             "sessionId": "test-session-1",
             "timestamp": "2026-04-09T10:00:02.000Z",
-            "cwd": "/tmp/test-project",
+            "cwd": "/Users/tester/test-project",
             "isSidechain": False,
             "message": {
                 "model": "claude-sonnet-4-6",
@@ -82,7 +82,7 @@ def sample_session_file(tmp_path: Path) -> Path:
             "parentUuid": "asst-1",
             "sessionId": "test-session-1",
             "timestamp": "2026-04-09T10:00:03.000Z",
-            "cwd": "/tmp/test-project",
+            "cwd": "/Users/tester/test-project",
             "isSidechain": False,
             "message": {
                 "role": "user",
@@ -103,7 +103,7 @@ def sample_session_file(tmp_path: Path) -> Path:
             "parentUuid": "result-1",
             "sessionId": "test-session-1",
             "timestamp": "2026-04-09T10:00:04.000Z",
-            "cwd": "/tmp/test-project",
+            "cwd": "/Users/tester/test-project",
             "isSidechain": False,
             "message": {
                 "model": "claude-sonnet-4-6",
@@ -142,7 +142,7 @@ def multi_edit_session_file(tmp_path: Path) -> Path:
             "parentUuid": parent,
             "sessionId": "edit-session",
             "timestamp": ts,
-            "cwd": "/tmp/test",
+            "cwd": "/Users/tester/test",
             "isSidechain": False,
             "message": {
                 "model": "claude-sonnet-4-6",
@@ -171,7 +171,7 @@ def multi_edit_session_file(tmp_path: Path) -> Path:
             "parentUuid": None,
             "sessionId": "edit-session",
             "timestamp": "2026-04-09T12:00:00.000Z",
-            "cwd": "/tmp/test",
+            "cwd": "/Users/tester/test",
             "isSidechain": False,
             "message": {
                 "model": "claude-sonnet-4-6",

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -10,7 +10,7 @@ from longhand.analysis.project_inference import infer_project
 from longhand.types import Event, EventType, FileOperation, Session
 
 
-def _session(cwd: str = "/tmp/cosmic-game") -> Session:
+def _session(cwd: str = "/Users/tester/cosmic-game") -> Session:
     return Session(
         session_id="test-session",
         project_path=cwd,
@@ -61,7 +61,7 @@ def _event(
 
 
 def test_infer_project_basic():
-    session = _session("/tmp/cosmic-game")
+    session = _session("/Users/tester/cosmic-game")
     events = [
         _event("e1", EventType.USER_MESSAGE, 1, "I'm building a game with phaser"),
         _event(
@@ -81,7 +81,7 @@ def test_infer_project_basic():
 
 
 def test_infer_project_category_from_keywords():
-    session = _session("/tmp/my-thing")
+    session = _session("/Users/tester/my-thing")
     events = [
         _event("e1", EventType.USER_MESSAGE, 1, "Fix the phaser sprite rendering bug"),
         _event(

--- a/tests/test_attribution.py
+++ b/tests/test_attribution.py
@@ -208,3 +208,179 @@ def test_live_tail_sets_cwd_to_project_not_lexicographic_max(tmp_path):
     row = store.sqlite.get_session("live-attr")
     assert row is not None
     assert row["cwd"] == proj
+
+
+# ─── v0.12 attribution overhaul ──────────────────────────────────────────────
+
+
+def _mini_session(cwd: str | None, tmp_path: Path):
+    """Session + events with a given cwd, without touching disk transcripts."""
+    from datetime import datetime, timezone
+
+    from longhand.types import Session
+
+    return Session(
+        session_id="s-attr",
+        project_path=cwd or "",
+        transcript_path=str(tmp_path / "t.jsonl"),
+        started_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        ended_at=datetime(2026, 7, 1, 1, tzinfo=timezone.utc),
+        event_count=1,
+        user_message_count=1,
+        assistant_message_count=0,
+        tool_call_count=0,
+        file_edit_count=0,
+        git_branch=None,
+        cwd=cwd,
+        model=None,
+    )
+
+
+def test_monorepo_package_attributes_to_git_root(tmp_path):
+    """repo/.git outranks repo/apps/web/package.json — sessions in the package
+    dir must not split into a separate per-package project."""
+    from longhand.analysis.project_inference import infer_project
+
+    repo = tmp_path / "repo"
+    (repo / ".git").mkdir(parents=True)
+    web = repo / "apps" / "web"
+    web.mkdir(parents=True)
+    (web / "package.json").write_text("{}")
+
+    at_root = infer_project(_mini_session(str(repo), tmp_path), [])
+    in_package = infer_project(_mini_session(str(web), tmp_path), [])
+    assert in_package["canonical_path"] == str(repo)
+    assert in_package["project_id"] == at_root["project_id"]
+
+
+def test_nested_git_collapses_to_outermost(tmp_path):
+    from longhand.analysis.project_inference import infer_project
+
+    outer = tmp_path / "outer"
+    (outer / ".git").mkdir(parents=True)
+    inner = outer / "vendor" / "lib"
+    inner.mkdir(parents=True)
+    (inner / ".git").mkdir()
+
+    fp = infer_project(_mini_session(str(inner), tmp_path), [])
+    assert fp["canonical_path"] == str(outer)
+
+
+def test_nearest_non_git_marker_still_wins_without_git(tmp_path):
+    from longhand.analysis.project_inference import infer_project
+
+    pkg = tmp_path / "plain" / "pkg"
+    sub = pkg / "src"
+    sub.mkdir(parents=True)
+    (pkg / "package.json").write_text("{}")
+
+    fp = infer_project(_mini_session(str(sub), tmp_path), [])
+    assert fp["canonical_path"] == str(pkg)
+
+
+def test_case_dupe_spellings_mint_one_project(tmp_path):
+    """~/Projects/Foo and ~/projects/foo are the same dir on a case-insensitive
+    filesystem — both spellings must hash to one project_id."""
+    import pytest
+
+    from longhand.analysis.project_inference import infer_project
+
+    proj = tmp_path / "CamelCase"
+    (proj / ".git").mkdir(parents=True)
+    alt = Path(str(proj).replace("CamelCase", "camelcase"))
+    if not alt.exists():
+        pytest.skip("case-sensitive filesystem — dupe spellings are distinct dirs")
+
+    a = infer_project(_mini_session(str(proj), tmp_path), [])
+    b = infer_project(_mini_session(str(alt), tmp_path), [])
+    assert a["project_id"] == b["project_id"]
+    assert a["canonical_path"] == b["canonical_path"] == str(proj)
+
+
+def test_reserved_paths_go_to_unattributed_bucket(tmp_path):
+    from longhand.analysis.project_inference import (
+        UNATTRIBUTED_PROJECT_ID,
+        infer_project,
+    )
+
+    home = str(Path.home())
+    claude_internal = str(Path.home() / ".claude" / "projects" / "some-slug")
+    markerless_pytest_dir = str(tmp_path)  # under pytest-of-*, no markers
+    tmp_scratch = "/tmp/scratch-abc123"
+
+    for cwd in (home, claude_internal, markerless_pytest_dir, tmp_scratch, None):
+        fp = infer_project(_mini_session(cwd, tmp_path), [])
+        assert fp["project_id"] == UNATTRIBUTED_PROJECT_ID, cwd
+        assert fp["display_name"] == "unattributed"
+        assert fp["keywords"] == [] and fp["aliases"] == ["unattributed"]
+
+
+def test_markered_dir_under_tmp_is_a_real_project(tmp_path):
+    """The reserved-path guard only applies to MARKERLESS paths — a real repo
+    checked out under a temp dir still attributes normally."""
+    from longhand.analysis.project_inference import (
+        UNATTRIBUTED_PROJECT_ID,
+        infer_project,
+    )
+
+    repo = tmp_path / "real-work"
+    (repo / ".git").mkdir(parents=True)
+
+    fp = infer_project(_mini_session(str(repo), tmp_path), [])
+    assert fp["project_id"] != UNATTRIBUTED_PROJECT_ID
+    assert fp["canonical_path"] == str(repo)
+
+
+def test_reattribute_dry_run_reports_without_writing(tmp_path):
+    """Dry-run (the new default) lists the moves and touches nothing; --fix
+    applies them and prunes the emptied project row."""
+    store = LonghandStore(data_dir=tmp_path / "lh")
+
+    repo = tmp_path / "realproj"
+    (repo / ".git").mkdir(parents=True)
+    session_file = _write_session_file(tmp_path / "s.jsonl", str(tmp_path / "noise"), str(repo))
+    parser = JSONLParser(session_file)
+    events = list(parser.parse_events())
+    session = parser.build_session(events)
+    store.ingest_session(session, events, run_analysis=True)
+
+    # Simulate legacy drift: force the session onto a fake junk project.
+    store.sqlite.upsert_project(
+        {
+            "project_id": "p_junk",
+            "canonical_path": "/tmp/junk",
+            "display_name": "junk",
+            "aliases": ["junk"],
+            "keywords": [],
+            "languages": [],
+            "category": None,
+            "first_seen": "2026-07-01T00:00:00+00:00",
+            "last_seen": "2026-07-01T00:00:00+00:00",
+        }
+    )
+    with store.sqlite.connect() as conn:
+        conn.execute(
+            "UPDATE sessions SET project_id = 'p_junk' WHERE session_id = ?",
+            (session.session_id,),
+        )
+    store.sqlite.recompute_project_stats("p_junk")
+
+    dry = store.reattribute_sessions(apply=False)
+    assert dry["applied"] is False
+    assert dry["reattributed"] == 1
+    assert dry["changes"][0]["old_project_id"] == "p_junk"
+    assert dry["pruned"] == 1  # p_junk would be emptied
+    with store.sqlite.connect() as conn:
+        still = conn.execute(
+            "SELECT project_id FROM sessions WHERE session_id = ?", (session.session_id,)
+        ).fetchone()[0]
+    assert still == "p_junk"  # nothing written
+
+    fixed = store.reattribute_sessions(apply=True)
+    assert fixed["applied"] is True and fixed["reattributed"] == 1
+    with store.sqlite.connect() as conn:
+        moved = conn.execute(
+            "SELECT project_id FROM sessions WHERE session_id = ?", (session.session_id,)
+        ).fetchone()[0]
+    assert moved != "p_junk"
+    assert store.sqlite.get_project("p_junk") is None  # pruned

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -83,7 +83,7 @@ def test_tool_search_auto_scopes_on_project_name_match(sample_session_file, temp
     events, and the response should advertise the auto-scoping so agents can
     override it."""
     _ingest(sample_session_file, temp_store)
-    # sample_session_file's cwd is /tmp/test-project, so the project becomes
+    # sample_session_file's cwd is /Users/tester/test-project, so the project becomes
     # "test project" after canonicalization.
     result = _call(
         mcp_server._tool_search,

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -122,7 +122,7 @@ def test_session_summary(sample_session_file):
     session = parser.build_session(events)
 
     assert session.session_id == "test-session-1"
-    assert session.project_path == "/tmp/test-project"
+    assert session.project_path == "/Users/tester/test-project"
     assert session.git_branch == "main"
     assert session.user_message_count >= 1
     assert session.tool_call_count >= 2


### PR DESCRIPTION
Tier 2 PR 4 of 7 from the 2026-07-09 audit roadmap (v0.12.0). Root-causes the audit's attribution-scatter finding: 113-session home catch-all, BSOI-RMF split across 3 projects, duplicate shipwright, junk projects minted from temp/plugin-cache/tool-results/pytest dirs.

## What

- **Git-root-first marker walk** — the highest `.git` within the walk outranks any nearer non-git marker: monorepo packages stop splitting into per-package projects, nested repos collapse to the outermost. No `.git` → nearest non-git marker, exactly as before.
- **Reserved `unattributed` bucket** (`p_unattributed`, fixed id — `_project_id_for` hashing untouched) — no-cwd sessions and MARKERLESS cwds at $HOME root, temp dirs, pytest tmpdirs, plugin caches, tool-results, or `~/.claude` internals land here instead of minting junk projects. Marker presence exempts: a real repo under /tmp attributes normally. The bucket carries no keywords/aliases so hundreds of unrelated sessions can't turn it into a fuzzy-match magnet. This also retires the old no-cwd fallback that minted projects from the transcript's parent dir — the 'launch slug' junk source.
- **Case-dupe merge at canonicalization** — `_true_case()` recovers on-disk casing component-by-component, so every spelling of a path mints one project on case-insensitive filesystems (pass-through on case-sensitive ones + non-existent paths).
- **`longhand reattribute` is dry-run by default** — prints moves grouped by destination (`N session(s): old → new`) and a would-prune count; `--fix` applies and deletes emptied project rows (completing junk/case-dupe merges). `reattribute_sessions()` returns the full change list.

## Tests

+7 (392 total, green): monorepo → git root, nested git → outermost, non-git nearest still wins, case-dupe single id (skips on case-sensitive FS), reserved-path matrix (home/claude-internals/pytest/tmp/no-cwd), markered-tmp exemption, dry-run-reports-without-writing → --fix moves + prunes. Existing fixtures moved off markerless /tmp cwds — the guard was correctly flagging them.

## Dogfood next (not in this PR)

After merge: `longhand reattribute` (dry-run) on the maintainer corpus → review the move list → `--fix`. Expected: home catch-all redistributed, BSOI-RMF unified, one shipwright, zero tmp/junk projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)