### PR TITLE
feat: episode precision — real verification, hard error boundaries, plumbing filter, confidence floor

### DIFF
--- a/longhand/analysis/episode_extraction.py
+++ b/longhand/analysis/episode_extraction.py
@@ -15,7 +15,24 @@ from pathlib import Path
 from typing import Any
 
 from longhand.extractors.file_refs import extract_file_references
+from longhand.parser import COMMAND_EXECUTING_TOOLS
 from longhand.types import Event
+
+# Harness plumbing that can appear as user_message content. None of it is a
+# human ask — anchoring an episode's problem text to it produces the
+# "<task-notification> fragments minted as problems" noise class.
+_PLUMBING_PREFIXES = (
+    "<task-notification>",
+    "<command-name>",
+    "<command-message>",
+    "<local-command-stdout>",
+    "<system-reminder>",
+)
+
+
+def _is_plumbing_text(text: str) -> bool:
+    return text.lstrip().startswith(_PLUMBING_PREFIXES)
+
 
 # Events we consider "edits" (candidate fixes)
 _FIX_OPERATIONS = {"edit", "write", "multi_edit", "notebook_edit"}
@@ -89,6 +106,15 @@ def extract_episodes(
     4. Close episode at verification, at the next independent error, or at session end.
     """
     episodes: list[dict[str, Any]] = []
+
+    # tool_result events don't carry tool_name — pair them back to their
+    # tool_call so the verification gate can tell Bash output from Read output.
+    tool_by_use_id: dict[str, str] = {
+        e.tool_use_id: e.tool_name or ""
+        for e in events
+        if _get_type(e) == "tool_call" and e.tool_use_id
+    }
+
     i = 0
 
     while i < len(events):
@@ -109,7 +135,8 @@ def extract_episodes(
         preceding_user = None
         lookback_start = max(i - _USER_LOOKBACK_EVENTS, -1)
         for j in range(i - 1, lookback_start, -1):
-            if _get_type(events[j]) == "user_message" and (events[j].content or "").strip():
+            text = (events[j].content or "").strip()
+            if _get_type(events[j]) == "user_message" and text and not _is_plumbing_text(text):
                 preceding_user = events[j]
                 break
 
@@ -141,13 +168,12 @@ def extract_episodes(
             cand = events[j]
             ctype = _get_type(cand)
 
-            # Another independent error → close current episode
-            if ctype == "tool_result" and cand.error_detected and j > i + 1:
-                # Only treat as independent if we haven't found a fix yet
-                # OR if the error is in a different file
-                new_files = set(extract_file_references(cand.content or ""))
-                if not fix_event or (new_files and new_files.isdisjoint(touched_files)):
-                    break
+            # Any subsequent error closes the current episode — a new error is
+            # a new episode (the outer loop re-opens at j). The old same-file
+            # exemption let one episode swallow every later error after a fix,
+            # blurring problem boundaries and inflating resolved status.
+            if ctype == "tool_result" and cand.error_detected:
+                break
 
             # Accumulate diagnosis material — any thinking or substantive
             # assistant_text between problem and fix. Collected BEFORE the
@@ -218,9 +244,14 @@ def extract_episodes(
                             if intent_text:
                                 fix_intent_text = intent_text
 
-            # Verification: a clean tool_result after a fix
+            # Verification: a clean tool_result after a fix — but only from a
+            # signal that can actually verify: an explicit success flag, or an
+            # error-free result from a command-executing tool (tests, builds).
+            # Read/Grep results carry tool_success=None and prove nothing;
+            # the old `is not False` gate let them mark episodes "resolved".
             if ctype == "tool_result" and not cand.error_detected and fix_event is not None:
-                if cand.tool_success is not False:
+                paired_tool = tool_by_use_id.get(cand.tool_use_id or "", "")
+                if cand.tool_success is True or paired_tool in COMMAND_EXECUTING_TOOLS:
                     verification_event = cand
                     j += 1
                     break
@@ -351,10 +382,11 @@ def _compose_problem_description(
     """Combine the user's ask (if found) with the error signal into a single
     semantically rich description.
 
-    Format: "Ask: <user request truncated>. Error: <error content truncated>"
+    Format: "<user request truncated>. Error: <error content truncated>"
 
-    Either piece can be missing — degrade to the other. Labels are kept
-    explicit so the embedding carries structural cues.
+    Either piece can be missing — degrade to the other. The user ask leads
+    bare — the old "Ask:" scaffold leaked into every displayed problem
+    description (same class as the "Intent:" leak fixed in v0.8).
     """
     parts: list[str] = []
 
@@ -363,7 +395,7 @@ def _compose_problem_description(
         if ask:
             # Give the user ask ~60% of the budget
             ask_budget = int(max_chars * 0.6)
-            parts.append(f"Ask: {ask[:ask_budget]}")
+            parts.append(ask[:ask_budget])
 
     # Always include an error signal — prefer the dedicated error_snippet
     # field over the raw content (shorter, more focused).

--- a/longhand/mcp_server.py
+++ b/longhand/mcp_server.py
@@ -787,6 +787,14 @@ async def list_tools() -> list[Tool]:
                         "default": True,
                         "description": "If True, return only episodes that have a resolved fix",
                     },
+                    "min_confidence": {
+                        "type": "number",
+                        "default": 0.5,
+                        "description": (
+                            "Minimum extraction confidence (0-1). Low-confidence "
+                            "episodes are noise-prone probes; pass 0 to include all."
+                        ),
+                    },
                     "limit": {
                         "type": "integer",
                         "default": 20,
@@ -1611,12 +1619,19 @@ async def _tool_match_project(store: LonghandStore, arguments: dict[str, Any]) -
 async def _tool_find_episodes(store: LonghandStore, arguments: dict[str, Any]) -> list[TextContent]:
     # has_fix=True (the default) filters in SQL; False means "no filter",
     # matching the old post-filter semantics (include fixless episodes too).
+    # min_confidence defaults to 0.5 — the extractor's floor for episodes
+    # with real structural evidence; pass 0 to see everything.
+    try:
+        min_conf = float(arguments.get("min_confidence", 0.5))
+    except (TypeError, ValueError):
+        min_conf = 0.5
     episodes = store.sqlite.query_episodes(
         project_ids=arguments.get("project_ids"),
         since=arguments.get("since"),
         until=arguments.get("until"),
         keyword=arguments.get("keyword"),
         has_fix=True if _bool(arguments.get("has_fix"), True) else None,
+        min_confidence=min_conf if min_conf > 0 else None,
         limit=_limit(arguments.get("limit"), 20),
     )
     return [TextContent(type="text", text=json.dumps(episodes, indent=2, default=str))]

--- a/longhand/storage/migrations.py
+++ b/longhand/storage/migrations.py
@@ -178,6 +178,16 @@ MIGRATIONS: dict[int, str] = {
     --   'analyzed' full pipeline completed
     -- The guarded ALTER runs in _apply_alters.
     """,
+    8: """
+    -- v8: strip the leaked "Ask: " scaffold from stored problem descriptions.
+    -- The extractor prefixed every user ask with "Ask: " (embedding cue) and
+    -- it leaked into displayed text — same class as the v4 "Intent: " fix.
+    -- New extractions no longer write the prefix.
+
+    UPDATE episodes
+    SET problem_description = substr(problem_description, 6)
+    WHERE problem_description LIKE 'Ask: %';
+    """,
 }
 
 

--- a/longhand/storage/sqlite_store.py
+++ b/longhand/storage/sqlite_store.py
@@ -911,6 +911,7 @@ class SQLiteStore:
         status: str | None = None,
         keyword: str | None = None,
         has_fix: bool | None = None,
+        min_confidence: float | None = None,
         limit: int = 50,
     ) -> list[dict[str, Any]]:
         with self.connect() as conn:
@@ -928,6 +929,11 @@ class SQLiteStore:
                 # In SQL, before ORDER/LIMIT: filtering after the recency cut
                 # returned [] whenever the newest rows were all fixless.
                 conditions.append("fix_event_id IS NOT NULL" if has_fix else "fix_event_id IS NULL")
+            if min_confidence is not None:
+                # Same rule as has_fix: filter before the recency cut, or a
+                # run of low-confidence noise starves the result set.
+                conditions.append("confidence >= ?")
+                params.append(min_confidence)
             if since:
                 conditions.append("ended_at >= ?")
                 params.append(since)

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -37,6 +37,7 @@ def _event(
     tool_use_id: str | None = None,
     old_content: str | None = None,
     new_content: str | None = None,
+    tool_success: bool | None = None,
 ) -> Event:
     return Event(
         event_id=event_id,
@@ -47,6 +48,7 @@ def _event(
         content=content,
         tool_name=tool_name,
         tool_use_id=tool_use_id,
+        tool_success=tool_success,
         file_path=file_path,
         file_operation=file_operation,
         old_content=old_content,
@@ -228,7 +230,16 @@ def test_extract_episode_with_full_chain():
             old_content="x.foo()",
             new_content="x?.foo()",
         ),
-        _event("r2", EventType.TOOL_RESULT, 6, content="All tests passed"),
+        # Verification must come from an execution-shaped tool (or carry an
+        # explicit success flag) — a bare unpaired result no longer counts.
+        _event("c3", EventType.TOOL_CALL, 6, tool_name="Bash", tool_use_id="bash-1"),
+        _event(
+            "r2",
+            EventType.TOOL_RESULT,
+            7,
+            content="All tests passed",
+            tool_use_id="bash-1",
+        ),
     ]
     episodes = extract_episodes("sess1", "proj1", events)
     assert len(episodes) == 1
@@ -268,3 +279,129 @@ def test_no_episodes_for_clean_session():
     ]
     episodes = extract_episodes("sess1", "proj1", events)
     assert episodes == []
+
+
+# ─── v0.12 episode precision ─────────────────────────────────────────────────
+
+
+def _error_fix_events(verify_events: list[Event]) -> list[Event]:
+    """error in main.ts → thinking → Edit fix, then caller-supplied tail."""
+    return [
+        _event("u1", EventType.USER_MESSAGE, 1, "Fix the crash"),
+        _event("c1", EventType.TOOL_CALL, 2, tool_name="Bash", tool_use_id="bash-0"),
+        _event(
+            "r1",
+            EventType.TOOL_RESULT,
+            3,
+            content="FAIL /tmp/game/src/main.ts: TypeError",
+            error_detected=True,
+            error_category="test",
+            tool_use_id="bash-0",
+        ),
+        _event("t1", EventType.ASSISTANT_THINKING, 4, "main.ts is missing a null check"),
+        _event(
+            "c2",
+            EventType.TOOL_CALL,
+            5,
+            tool_name="Edit",
+            file_path="/tmp/game/src/main.ts",
+            file_operation=FileOperation.EDIT,
+        ),
+        *verify_events,
+    ]
+
+
+def test_read_result_does_not_verify():
+    """Read/Grep results (tool_success=None, not execution-shaped) must not
+    mark an episode resolved — the old `is not False` gate let them."""
+    events = _error_fix_events(
+        [
+            _event("c3", EventType.TOOL_CALL, 6, tool_name="Read", tool_use_id="read-1"),
+            _event(
+                "r2",
+                EventType.TOOL_RESULT,
+                7,
+                content="def main(): ...",
+                tool_use_id="read-1",
+            ),
+        ]
+    )
+    episodes = extract_episodes("sess1", "proj1", events)
+    assert len(episodes) == 1
+    assert episodes[0]["verification_event_id"] is None
+    assert episodes[0]["status"] == "partial"
+
+
+def test_explicit_success_flag_verifies():
+    events = _error_fix_events(
+        [
+            _event(
+                "r2",
+                EventType.TOOL_RESULT,
+                6,
+                content="file updated",
+                tool_success=True,
+            ),
+        ]
+    )
+    episodes = extract_episodes("sess1", "proj1", events)
+    assert episodes[0]["verification_event_id"] == "r2"
+    assert episodes[0]["status"] == "resolved"
+
+
+def test_new_error_opens_new_episode():
+    """A later error — even in the SAME file — closes the episode and opens a
+    new one. The old same-file exemption swallowed every follow-on error."""
+    events = _error_fix_events(
+        [
+            _event("c3", EventType.TOOL_CALL, 6, tool_name="Bash", tool_use_id="bash-2"),
+            _event(
+                "r2",
+                EventType.TOOL_RESULT,
+                7,
+                content="FAIL /tmp/game/src/main.ts: still TypeError",
+                error_detected=True,
+                tool_use_id="bash-2",
+            ),
+        ]
+    )
+    episodes = extract_episodes("sess1", "proj1", events)
+    assert len(episodes) == 2
+    assert episodes[0]["verification_event_id"] is None  # first ended at error #2
+    assert episodes[1]["problem_event_id"] == "r2"
+
+
+def test_plumbing_user_message_not_problem_anchor():
+    """Harness plumbing (<task-notification> etc.) is never a human ask —
+    the problem anchors to the nearest REAL user message instead."""
+    events = [
+        _event("u1", EventType.USER_MESSAGE, 1, "Fix the login timeout bug"),
+        _event(
+            "u2",
+            EventType.USER_MESSAGE,
+            2,
+            "<task-notification>\n<task-id>abc</task-id>\ncompleted\n</task-notification>",
+        ),
+        _event("c1", EventType.TOOL_CALL, 3, tool_name="Bash", tool_use_id="bash-0"),
+        _event(
+            "r1",
+            EventType.TOOL_RESULT,
+            4,
+            content="error: timeout in auth.py",
+            error_detected=True,
+            tool_use_id="bash-0",
+        ),
+    ]
+    episodes = extract_episodes("sess1", "proj1", events)
+    assert len(episodes) == 1
+    desc = episodes[0]["problem_description"]
+    assert "task-notification" not in desc
+    assert "login timeout" in desc
+
+
+def test_problem_description_has_no_ask_scaffold():
+    events = _error_fix_events([])
+    episodes = extract_episodes("sess1", "proj1", events)
+    desc = episodes[0]["problem_description"]
+    assert not desc.startswith("Ask: ")
+    assert desc.startswith("Fix the crash")

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -803,3 +803,33 @@ def test_query_is_bounded_and_coerced():
 
 # ensure pytest doesn't collect the Any import as a test
 _ = pytest, Any
+
+
+def test_tool_find_episodes_default_filters_low_confidence(temp_store):
+    """min_confidence (default 0.5) keeps extraction noise out of the default
+    call; min_confidence=0 opts back in to everything."""
+    base = {
+        "session_id": "s-conf",
+        "project_id": "p1",
+        "started_at": "2026-06-01T10:00:00Z",
+        "ended_at": "2026-06-01T10:30:00Z",
+        "problem_event_id": "pe",
+        "fix_event_id": "fe",
+        "problem_description": "text",
+        "fix_summary": "fixed",
+        "touched_files": [],
+        "tags": [],
+        "status": "resolved",
+    }
+    temp_store.sqlite.insert_episodes(
+        [
+            {**base, "episode_id": "ep-solid", "confidence": 0.8},
+            {**base, "episode_id": "ep-noise", "confidence": 0.3},
+        ]
+    )
+
+    default = _payload(_call(mcp_server._tool_find_episodes, temp_store, {}))
+    assert {e["episode_id"] for e in default} == {"ep-solid"}
+
+    everything = _payload(_call(mcp_server._tool_find_episodes, temp_store, {"min_confidence": 0}))
+    assert {e["episode_id"] for e in everything} == {"ep-solid", "ep-noise"}

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -421,3 +421,28 @@ def test_fresh_store_has_analysis_stage(tmp_path: Path):
     with store.connect() as conn:
         cols = {r[1] for r in conn.execute("PRAGMA table_info(ingestion_log)")}
     assert "analysis_stage" in cols
+
+
+def test_v8_strips_ask_prefix_from_problem_descriptions(tmp_path: Path):
+    """Migration 8 removes the leaked 'Ask: ' scaffold from stored episodes
+    (same class as the v4 'Intent: ' strip)."""
+    store = SQLiteStore(tmp_path / "lh" / "longhand.db")
+    with store.connect() as conn:
+        conn.execute(
+            "INSERT INTO episodes (episode_id, session_id, started_at, ended_at,"
+            " problem_event_id, problem_description, confidence, status)"
+            " VALUES ('ep-a', 's1', '2026-01-01', '2026-01-01', 'pe',"
+            " 'Ask: fix the bug. Error: boom', 0.8, 'resolved'),"
+            " ('ep-b', 's1', '2026-01-01', '2026-01-01', 'pe',"
+            " 'Task keeps failing', 0.8, 'resolved')"
+        )
+        # Roll back v8 so we can watch it apply to the seeded rows.
+        conn.execute("DELETE FROM schema_version WHERE version = 8")
+        conn.execute(
+            "UPDATE episodes SET problem_description = 'Ask: fix the bug. Error: boom'"
+            " WHERE episode_id = 'ep-a'"
+        )
+        apply_migrations(conn)
+        rows = dict(conn.execute("SELECT episode_id, problem_description FROM episodes").fetchall())
+    assert rows["ep-a"] == "fix the bug. Error: boom"
+    assert rows["ep-b"] == "Task keeps failing"  # untouched

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -332,3 +332,32 @@ def test_query_episodes_has_fix_in_sql(temp_store):
     assert [e["episode_id"] for e in with_fix] == ["ep-f"]
     assert [e["episode_id"] for e in fixless] == ["ep-n"]
     assert {e["episode_id"] for e in everything} == {"ep-f", "ep-n"}
+
+
+def test_query_episodes_min_confidence_in_sql(temp_store):
+    """min_confidence filters inside the SQL WHERE (before ORDER BY/LIMIT)."""
+    base = {
+        "session_id": "s1",
+        "project_id": "p1",
+        "started_at": "2026-07-01T10:00:00Z",
+        "ended_at": "2026-07-01T10:30:00Z",
+        "problem_event_id": "pe",
+        "fix_event_id": "fe",
+        "problem_description": "x",
+        "fix_summary": "y",
+        "touched_files": [],
+        "tags": [],
+        "status": "resolved",
+    }
+    temp_store.sqlite.insert_episodes(
+        [
+            {**base, "episode_id": "ep-hi", "confidence": 0.8},
+            {**base, "episode_id": "ep-lo", "confidence": 0.3},
+        ]
+    )
+
+    confident = temp_store.sqlite.query_episodes(min_confidence=0.5)
+    everything = temp_store.sqlite.query_episodes()
+
+    assert [e["episode_id"] for e in confident] == ["ep-hi"]
+    assert {e["episode_id"] for e in everything} == {"ep-hi", "ep-lo"}


### PR DESCRIPTION
Tier 2 PR 5 of 7 from the 2026-07-09 audit roadmap (v0.12.0). Root-causes the audit's episode-quality finding (598/925 = 65% low-confidence; recent episodes dominated by noise).

## What

- **Verification requires a real signal** — `tool_success is True`, or an error-free result from a command-executing tool (results paired back to their tool_call via `tool_use_id`; single source of truth is the parser's `COMMAND_EXECUTING_TOOLS`). Read/Grep results carry `tool_success=None` and prove nothing — the old `is not False` gate let them mark episodes resolved (systematic optimistic bias).
- **New error = new episode** — any subsequent error closes the current episode and the scan re-opens at it. The same-file exemption previously let one episode swallow every later error once a fix was found.
- **Plumbing filter** — `<task-notification>`, `<command-name>`, `<command-message>`, `<local-command-stdout>`, `<system-reminder>` user messages are never problem anchors; the walk-back finds the nearest real ask.
- **'Ask: ' scaffold removed** from problem descriptions (regression cousin of the v0.8 'Intent:' fix) + **migration 8** strips it from stored episodes — existing installs read clean without re-analysis.
- **Confidence floor, default-filtered, never deleted** — `query_episodes(min_confidence=...)` in SQL before ORDER/LIMIT; the `find_episodes` MCP tool defaults to 0.5 with a documented `min_confidence: 0` opt-out. Recall's vector path is untouched (fixless episodes were already excluded from embedding).

No auto-reprocessing: historical labels change only via `longhand analyze --all` (the dogfood arc runs it on the maintainer corpus with a recall_diff baseline gate).

## Tests

+8 (400 total, green): Read-result-doesn't-verify, explicit-success verifies, Bash-paired verification (updated full-chain fixture), new-error-splits-episodes, plumbing-anchor skip, no-Ask-scaffold, migration 8 strip (seeded rows, untouched control), SQL + MCP min_confidence matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)