### PR TITLE
feat: DB hygiene — aux entry skip-set, doctor storage section, db vacuum --prune-aux

### DIFF
--- a/.fieldnotes/notes/0002-project-inference-cwd-mode.md
+++ b/.fieldnotes/notes/0002-project-inference-cwd-mode.md
@@ -5,8 +5,8 @@ references:
 - advisory: false
   lines: null
   path: longhand/parser.py
-  pinned_at: '2026-07-10T18:16:27.059400Z'
-  sha: c052aa5aa88c5e0f001f5013869d95316ec638ae0cad7fb445060bfb6f4e9c97
+  pinned_at: '2026-07-10T20:55:48.344557Z'
+  sha: 611a1710fa576229caba133d4e7563eb63d14027ab5917eaf6c6f4a205f3b7c7
   symbol: null
 session_id: null
 superseded_by: '0006'
@@ -20,6 +20,8 @@ title: Project attribution uses MODE of cwds, not first-event cwd
 topic: project-inference-cwd-mode
 validations:
 - at: '2026-07-10T18:16:41.805585Z'
+  by: unknown
+- at: '2026-07-10T20:55:48.497843Z'
   by: unknown
 written_at: '2026-04-26T05:28:36.808901Z'
 written_by: claude-opus-4-7

--- a/longhand/cli/_commands.py
+++ b/longhand/cli/_commands.py
@@ -1142,6 +1142,84 @@ plans_app = typer.Typer(name="plans", help="Plan files written across all sessio
 app.add_typer(plans_app, name="plans", rich_help_panel="Plumbing")
 
 
+# -----------------------------------------------------------------------------
+# DB MAINTENANCE
+# -----------------------------------------------------------------------------
+
+db_app = typer.Typer(name="db", help="Storage maintenance (opt-in, never automatic)")
+
+
+@db_app.command("vacuum")
+def db_vacuum(
+    prune_aux: bool = typer.Option(
+        False,
+        "--prune-aux",
+        help=(
+            "First delete stored aux/unknown events (harness orchestration "
+            "noise — mode changes, attachments, UI titles). Source JSONLs "
+            "remain the recovery path."
+        ),
+    ),
+    data_dir: str | None = typer.Option(None, "--data-dir"),
+):
+    """Reclaim disk space from the SQLite store.
+
+    VACUUM rewrites the whole database file, so it needs free disk at least
+    the size of the current DB and must not race a concurrent ingest — the
+    command checks both and aborts (exit 1) rather than proceeding unsafely.
+    """
+    import shutil as _shutil
+
+    from longhand.recall.project_fallback import (
+        claim_ingest_lock,
+        release_ingest_lock,
+    )
+
+    store = _get_store(data_dir)
+    db_file = store.data_dir / "longhand.db"
+    if not db_file.exists():
+        console.print("[yellow]No database found — nothing to vacuum.[/yellow]")
+        return
+    before = db_file.stat().st_size
+
+    free = _shutil.disk_usage(str(store.data_dir)).free
+    if free < before:
+        console.print(
+            f"[red]✗[/red] Not enough free disk: VACUUM needs ~{before:,} bytes "
+            f"free (a full copy of the DB), only {free:,} available."
+        )
+        raise typer.Exit(1)
+
+    if not claim_ingest_lock(store):
+        console.print("[yellow]Another Longhand ingest is running — try again later.[/yellow]")
+        raise typer.Exit(1)
+
+    try:
+        if prune_aux:
+            with store.sqlite.connect() as conn:
+                cur = conn.execute("DELETE FROM events WHERE event_type = 'unknown'")
+                console.print(f"Pruned [bold]{cur.rowcount:,}[/bold] aux/unknown event(s).")
+
+        # VACUUM must run outside a transaction — plain connection, no
+        # context-manager commit wrapper.
+        import sqlite3 as _sqlite3
+
+        conn = _sqlite3.connect(str(db_file))
+        try:
+            conn.execute("VACUUM")
+        finally:
+            conn.close()
+    finally:
+        release_ingest_lock(store)
+
+    after = db_file.stat().st_size
+    saved = before - after
+    console.print(
+        f"[green]✓[/green] VACUUM complete: {before:,} → {after:,} bytes "
+        f"([bold]{saved:,}[/bold] reclaimed)."
+    )
+
+
 @plans_app.command("list")
 def plans_list(
     limit: int = typer.Option(50, "--limit"),
@@ -2338,6 +2416,7 @@ schedule_app = typer.Typer(
     help="Background reconciler (launchd) — catches sessions when hooks miss",
 )
 
+app.add_typer(db_app, name="db", rich_help_panel="Data")
 app.add_typer(hook_app, name="hook", rich_help_panel="Plumbing")
 app.add_typer(mcp_app, name="mcp", rich_help_panel="Plumbing")
 app.add_typer(schedule_app, name="schedule", rich_help_panel="Plumbing")

--- a/longhand/parser.py
+++ b/longhand/parser.py
@@ -353,8 +353,20 @@ class JSONLParser:
         if entry_type == "file-history-snapshot":
             return [self._file_snapshot_event(entry, base_sequence)]
 
-        # Queue operations and progress — skip (internal orchestration)
-        if entry_type in {"queue-operation", "progress"}:
+        # Internal orchestration and auxiliary UI state — skip. Each of these
+        # would otherwise be stored as an "unknown" event carrying its full
+        # raw_json (12,238 rows — the 3rd-largest event type on a real
+        # corpus) while containing nothing recallable.
+        if entry_type in {
+            "queue-operation",
+            "progress",
+            "last-prompt",
+            "mode",
+            "permission-mode",
+            "attachment",
+            "ai-title",
+            "agent-name",
+        }:
             return []
 
         # User messages

--- a/longhand/setup_commands.py
+++ b/longhand/setup_commands.py
@@ -965,6 +965,15 @@ def _freshness_status(store: LonghandStore) -> str | None:
     )
 
 
+def _human_size(n: int) -> str:
+    size = float(n)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if size < 1024 or unit == "TB":
+            return f"{size:.1f} {unit}" if unit != "B" else f"{int(size)} B"
+        size /= 1024
+    return f"{size:.1f} TB"
+
+
 def doctor() -> None:
     """Diagnose Longhand installation and data."""
     table = Table(title="Longhand Doctor", show_header=False, border_style="cyan")
@@ -1116,6 +1125,29 @@ def doctor() -> None:
         table.add_row(
             "Sessions needing analysis",
             f"[yellow]{sessions_needing_analysis}[/yellow] (run [bold]longhand analyze --all[/bold])",
+        )
+
+    # 7. Storage footprint — the corpus grows forever by design, but nothing
+    # surfaced how big it had gotten (3 GB observed in the wild).
+    db_file = store.data_dir / "longhand.db"
+    db_size = db_file.stat().st_size if db_file.exists() else 0
+    chroma_dir = store.data_dir / "chroma"
+    chroma_size = (
+        sum(f.stat().st_size for f in chroma_dir.rglob("*") if f.is_file())
+        if chroma_dir.exists()
+        else 0
+    )
+    table.add_row("Storage", f"SQLite {_human_size(db_size)} · vectors {_human_size(chroma_size)}")
+
+    with store.sqlite.connect() as conn:
+        aux_events = conn.execute(
+            "SELECT COUNT(*) FROM events WHERE event_type = 'unknown'"
+        ).fetchone()[0]
+    if aux_events > 0:
+        table.add_row(
+            "Aux/unknown events",
+            f"[yellow]{aux_events:,}[/yellow] stored orchestration noise "
+            "(reclaim: [bold]longhand db vacuum --prune-aux[/bold])",
         )
 
     console.print(table)

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -362,3 +362,78 @@ def test_cli_recall_json_flag_emits_valid_json(
     assert "narrative" in payload
     # Artifacts key should be absent on an empty store (matches MCP behavior)
     assert "artifacts" not in payload
+
+
+# ─── v0.12 DB hygiene ────────────────────────────────────────────────────────
+
+
+def _seed_unknown_events(store, n: int) -> None:
+    with store.sqlite.connect() as conn:
+        for k in range(n):
+            conn.execute(
+                "INSERT INTO events (event_id, session_id, event_type, sequence,"
+                " timestamp, content, raw_json) VALUES (?, 's-aux', 'unknown', ?,"
+                " '2026-07-01T00:00:00Z', '', ?)",
+                (f"unk-{k}", k, '{"type": "mode", "payload": "' + "x" * 200 + '"}'),
+            )
+
+
+def test_parser_skips_aux_entry_types(tmp_path: Path):
+    """last-prompt/mode/permission-mode/attachment/ai-title/agent-name entries
+    must not be stored as unknown events (they were the 3rd-largest event
+    type on a real corpus); genuinely unrecognized types are still kept."""
+    from longhand.parser import JSONLParser
+
+    entries = [
+        {"type": t, "uuid": f"u-{t}", "sessionId": "s1", "timestamp": "2026-07-01T00:00:00Z"}
+        for t in ("last-prompt", "mode", "permission-mode", "attachment", "ai-title", "agent-name")
+    ]
+    entries.append(
+        {
+            "type": "some-future-type",
+            "uuid": "u-future",
+            "sessionId": "s1",
+            "timestamp": "2026-07-01T00:00:00Z",
+        }
+    )
+    f = tmp_path / "aux.jsonl"
+    f.write_text("".join(json.dumps(e) + "\n" for e in entries))
+
+    events = list(JSONLParser(f).parse_events())
+    types = [e.event_type.value if hasattr(e.event_type, "value") else e.event_type for e in events]
+    assert types == ["unknown"]  # only the genuinely unrecognized one survives
+    assert events[0].event_id == "u-future"
+
+
+def test_db_vacuum_prune_aux_removes_unknown_events(runner: CliRunner, tmp_path: Path):
+    from longhand.storage import LonghandStore
+
+    store = LonghandStore(data_dir=tmp_path / "lh")
+    _seed_unknown_events(store, 5)
+
+    result = runner.invoke(app, ["db", "vacuum", "--prune-aux", "--data-dir", str(tmp_path / "lh")])
+    assert result.exit_code == 0, result.output
+    assert "Pruned" in result.output and "5" in result.output
+    with store.sqlite.connect() as conn:
+        left = conn.execute("SELECT COUNT(*) FROM events WHERE event_type='unknown'").fetchone()[0]
+    assert left == 0
+    lock = tmp_path / "lh" / ".ingest.lock"
+    assert not lock.exists()  # released
+
+
+def test_db_vacuum_defers_to_running_ingest(runner: CliRunner, tmp_path: Path):
+    import os
+
+    from longhand.storage import LonghandStore
+
+    store = LonghandStore(data_dir=tmp_path / "lh")
+    _seed_unknown_events(store, 1)
+    lock = tmp_path / "lh" / ".ingest.lock"
+    lock.write_text(str(os.getppid()))  # alive holder
+
+    result = runner.invoke(app, ["db", "vacuum", "--data-dir", str(tmp_path / "lh")])
+    assert result.exit_code == 1
+    with store.sqlite.connect() as conn:
+        left = conn.execute("SELECT COUNT(*) FROM events WHERE event_type='unknown'").fetchone()[0]
+    assert left == 1  # untouched
+    lock.unlink()


### PR DESCRIPTION
Tier 2 PR 6 of 7 from the 2026-07-09 audit roadmap (v0.12.0). Targets the unmanaged-growth finding (3.0 GB main DB + 499 MB chroma, nothing surfaced anywhere).

## What

- **Parser skip-set** += `last-prompt`, `mode`, `permission-mode`, `attachment`, `ai-title`, `agent-name` — auxiliary Claude Code entry types that were stored as `unknown` events with their full `raw_json` (12,238 rows, the 3rd-largest event type on the maintainer corpus) while containing nothing recallable. Genuinely unrecognized future types are still preserved.
- **`doctor` storage section** — SQLite + vector-store sizes, plus an aux/unknown-events row with the reclaim hint when stored noise exists.
- **`longhand db vacuum`** (new `db` group; opt-in, never automatic) — free-disk ≥ DB-size preflight (VACUUM rewrites the whole file), claims the ingest lock and aborts with exit 1 rather than racing a live ingest, `--prune-aux` deletes stored aux/unknown rows first. Source JSONLs remain the recovery path per the audit risk register.

## Tests

+3 (403 total, green): skip-set drops all six types while a genuinely unknown type survives; `db vacuum --prune-aux` removes seeded rows and releases the lock; a live lock holder makes vacuum abort untouched with exit 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)