### PR TITLE
chore: P3 sweep — MCP singleton + envelope, SQL prefix resolve, redaction pre-check, oversize reporting, coverage

### DIFF
--- a/longhand/cli/_commands.py
+++ b/longhand/cli/_commands.py
@@ -489,6 +489,11 @@ def reconcile(
     )
     console.print(f"  [yellow]{len(report.null_project)}[/yellow] ingested but project_id IS NULL")
     console.print(f"  [red]{len(report.missing)}[/red] missing from sessions")
+    if report.skipped_oversize:
+        console.print(
+            f"  [dim]{len(report.skipped_oversize)} skipped — over the parser size cap "
+            "(not ingestable by any path)[/dim]"
+        )
 
     if not fix:
         if report.missing or report.null_project or report.partially_indexed:

--- a/longhand/cli/helpers.py
+++ b/longhand/cli/helpers.py
@@ -20,12 +20,20 @@ def _get_store(data_dir: str | None = None) -> LonghandStore:
 
 
 def _resolve_prefix(store: LonghandStore, prefix: str) -> str | None:
-    """Resolve a session ID prefix to a full session ID."""
-    rows = store.sqlite.list_sessions(limit=1000)
-    for row in rows:
-        if row["session_id"].startswith(prefix):
-            return row["session_id"]
-    return None
+    """Resolve a session ID prefix to a full session ID.
+
+    SQL LIKE over the whole table — the old approach scanned only the 1,000
+    most recent sessions in Python, so prefixes of older sessions silently
+    failed to resolve. Most-recent match wins on ambiguity (unchanged).
+    """
+    escaped = prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    with store.sqlite.connect() as conn:
+        row = conn.execute(
+            "SELECT session_id FROM sessions WHERE session_id LIKE ? ESCAPE '\\'"
+            " ORDER BY started_at DESC LIMIT 1",
+            (escaped + "%",),
+        ).fetchone()
+    return row[0] if row else None
 
 
 def _format_timestamp(iso: str) -> str:

--- a/longhand/mcp_server.py
+++ b/longhand/mcp_server.py
@@ -707,6 +707,7 @@ async def list_tools() -> list[Tool]:
                 "properties": {
                     "fully_indexed": {"type": "integer"},
                     "partially_indexed": {"type": "integer"},
+                    "skipped_oversize": {"type": "integer"},
                     "null_project": {"type": "integer"},
                     "missing": {"type": "integer"},
                     "ingested": {"type": "integer"},
@@ -1789,13 +1790,30 @@ _DISPATCH: dict[str, Any] = {
 }
 
 
+_STORE: LonghandStore | None = None
+
+
+def _shared_store() -> LonghandStore:
+    """One store for the server's lifetime — constructing per call re-ran
+    migrations and re-opened ChromaDB on every tool invocation."""
+    global _STORE
+    if _STORE is None:
+        _STORE = LonghandStore()
+    return _STORE
+
+
 @server.call_tool()
 async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
     handler = _DISPATCH.get(name)
     if handler is None:
         return [TextContent(type="text", text=f"Unknown tool: {name}")]
-    store = LonghandStore()
-    return await handler(store, arguments)
+    try:
+        return await handler(_shared_store(), arguments)
+    except Exception as e:
+        # Top-level envelope: a failing tool must hand the agent a readable
+        # error instead of surfacing a raw traceback through the MCP layer.
+        payload = {"error": f"{type(e).__name__}: {e}", "tool": name}
+        return [TextContent(type="text", text=json.dumps(payload))]
 
 
 async def main():

--- a/longhand/recall/reconcile.py
+++ b/longhand/recall/reconcile.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from longhand.parser import JSONLParser, discover_sessions
+from longhand.parser import MAX_FILE_SIZE_BYTES, JSONLParser, discover_sessions
 from longhand.recall.project_fallback import (
     claim_ingest_lock,
     release_ingest_lock,
@@ -25,6 +25,7 @@ class ReconcileReport:
     null_project: list[str] = field(default_factory=list)  # transcript paths
     missing: list[str] = field(default_factory=list)
     partially_indexed: list[str] = field(default_factory=list)  # crashed mid-pipeline
+    skipped_oversize: list[str] = field(default_factory=list)  # > parser size cap
     ingested: int = 0
     errors: list[dict[str, str]] = field(default_factory=list)  # [{path, error}]
     fix_applied: bool = False
@@ -37,6 +38,8 @@ class ReconcileReport:
             "null_project_count": len(self.null_project),
             "missing_count": len(self.missing),
             "partially_indexed_count": len(self.partially_indexed),
+            "skipped_oversize_count": len(self.skipped_oversize),
+            "skipped_oversize": self.skipped_oversize,
             "null_project": self.null_project,
             "missing": self.missing,
             "partially_indexed": self.partially_indexed,
@@ -68,8 +71,18 @@ def run_reconcile(store: LonghandStore, fix: bool = False) -> ReconcileReport:
     missing: list[Path] = []
     null_project: list[Path] = []
     partial: list[Path] = []
+    oversize: list[Path] = []
     fully_indexed = 0
     for f in files:
+        # Files past the parser's size cap can't be ingested by ANY path —
+        # report them instead of erroring on every --fix pass (or worse,
+        # sitting silently in the missing bucket forever).
+        try:
+            if f.stat().st_size > MAX_FILE_SIZE_BYTES:
+                oversize.append(f)
+                continue
+        except OSError:
+            pass
         state = indexed.get(str(f), "__not_found__")
         if state == "__not_found__":
             missing.append(f)
@@ -92,6 +105,7 @@ def run_reconcile(store: LonghandStore, fix: bool = False) -> ReconcileReport:
         null_project=[str(p) for p in null_project],
         missing=[str(p) for p in missing],
         partially_indexed=[str(p) for p in partial],
+        skipped_oversize=[str(p) for p in oversize],
     )
 
     if not fix:

--- a/longhand/redaction.py
+++ b/longhand/redaction.py
@@ -59,6 +59,9 @@ PATTERNS: list[tuple[str, re.Pattern[str]]] = [
 ]
 
 
+_CARD_PRECHECK = re.compile(r"\d(?:[ -]?\d){12}")
+
+
 def _luhn_ok(digits: str) -> bool:
     total = 0
     for i, ch in enumerate(reversed(digits)):
@@ -96,6 +99,11 @@ def redact_text(text: str) -> tuple[str, int]:
     count = 0
 
     for name, pattern in PATTERNS:
+        # The card pattern is the CPU hog on numeric-heavy transcripts; a
+        # cheap pre-check (is there any 13-digit-ish run at all?) skips it
+        # for the overwhelmingly common case.
+        if name == "credit_card" and not _CARD_PRECHECK.search(text):
+            continue
 
         def _sub(m: re.Match[str], _name: str = name) -> str:
             nonlocal count

--- a/longhand/setup_commands.py
+++ b/longhand/setup_commands.py
@@ -115,7 +115,7 @@ def hook_install() -> None:
     settings = _load_json(CLAUDE_SETTINGS_PATH)
     backup = _backup(CLAUDE_SETTINGS_PATH)
 
-    longhand_bin = shutil.which("longhand") or f"{sys.executable} -m longhand.cli"
+    longhand_bin = shutil.which("longhand") or f"{sys.executable} -m longhand"
     # Bare commands — both read `transcript_path` from stdin JSON.
     session_end_cmd = f"{longhand_bin} ingest-session"
     stop_cmd = f"{longhand_bin} ingest-live"
@@ -193,7 +193,7 @@ def prompt_hook_install() -> None:
     settings = _load_json(CLAUDE_SETTINGS_PATH)
     backup = _backup(CLAUDE_SETTINGS_PATH)
 
-    longhand_bin = shutil.which("longhand") or f"{sys.executable} -m longhand.cli"
+    longhand_bin = shutil.which("longhand") or f"{sys.executable} -m longhand"
     command = f"{longhand_bin} __prompt-hook-run"
 
     hooks = settings.setdefault("hooks", {})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,12 @@ include = ["longhand*"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
+filterwarnings = [
+    # Third-party deprecation noise, triaged 2026-07-10 (audit P3). Both come
+    # from chromadb's internals, not our code; re-check on chromadb upgrades.
+    "ignore:asyncio.iscoroutinefunction:DeprecationWarning",
+    "ignore:Accessing the 'model_fields' attribute:DeprecationWarning",
+]
 
 [tool.ruff]
 line-length = 100

--- a/tests/test_p3_sweep.py
+++ b/tests/test_p3_sweep.py
@@ -1,0 +1,271 @@
+"""P3 sweep (v0.12): MCP store singleton + error envelope, SQL prefix
+resolution, redaction card pre-check, oversize reporting, hook-command
+spawn targets, and first direct coverage for four previously untested
+modules (session_summary_embedding, segment_search, vector_store,
+cli/helpers)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timezone
+
+from longhand import mcp_server
+from longhand.cli.helpers import _format_timestamp, _resolve_prefix
+from longhand.redaction import _CARD_PRECHECK
+from longhand.types import Event, EventType, Session
+
+# ─── MCP: store singleton + top-level error envelope ─────────────────────────
+
+
+def test_call_tool_reuses_one_store(monkeypatch, tmp_path):
+    built: list[int] = []
+
+    class _FakeStore:
+        def __init__(self, *args, **kwargs):
+            built.append(1)
+
+    async def _ok(store, arguments):
+        return [mcp_server.TextContent(type="text", text="ok")]
+
+    monkeypatch.setattr(mcp_server, "LonghandStore", _FakeStore)
+    monkeypatch.setattr(mcp_server, "_STORE", None)
+    monkeypatch.setitem(mcp_server._DISPATCH, "fake_tool", _ok)
+
+    asyncio.run(mcp_server.call_tool("fake_tool", {}))
+    asyncio.run(mcp_server.call_tool("fake_tool", {}))
+    assert built == [1]  # constructed once, reused
+
+
+def test_call_tool_wraps_handler_errors(monkeypatch):
+    async def _boom(store, arguments):
+        raise RuntimeError("db exploded")
+
+    monkeypatch.setattr(mcp_server, "_STORE", object())  # skip construction
+    monkeypatch.setitem(mcp_server._DISPATCH, "boom_tool", _boom)
+
+    result = asyncio.run(mcp_server.call_tool("boom_tool", {}))
+    payload = json.loads(result[0].text)
+    assert payload["tool"] == "boom_tool"
+    assert "RuntimeError" in payload["error"] and "db exploded" in payload["error"]
+
+
+# ─── cli/helpers: SQL prefix resolution + timestamp formatting ────────────────
+
+
+def _seed_session(store, session_id: str, started: str) -> None:
+    with store.sqlite.connect() as conn:
+        conn.execute(
+            "INSERT INTO sessions (session_id, project_path, transcript_path,"
+            " started_at, ended_at, event_count, user_message_count,"
+            " assistant_message_count, tool_call_count, file_edit_count,"
+            " ingested_at) VALUES (?, '', '', ?, ?, 0, 0, 0, 0, 0, ?)",
+            (session_id, started, started, started),
+        )
+
+
+def test_resolve_prefix_matches_and_prefers_recent(temp_store):
+    _seed_session(temp_store, "abc111-old", "2026-01-01T00:00:00Z")
+    _seed_session(temp_store, "abc222-new", "2026-06-01T00:00:00Z")
+    _seed_session(temp_store, "zzz999", "2026-06-02T00:00:00Z")
+
+    assert _resolve_prefix(temp_store, "zzz") == "zzz999"
+    assert _resolve_prefix(temp_store, "abc") == "abc222-new"  # most recent wins
+    assert _resolve_prefix(temp_store, "nope") is None
+
+
+def test_resolve_prefix_escapes_like_wildcards(temp_store):
+    _seed_session(temp_store, "a_b-real", "2026-06-01T00:00:00Z")
+    _seed_session(temp_store, "axb-decoy", "2026-06-02T00:00:00Z")
+
+    # '_' must match literally, not as the LIKE single-char wildcard —
+    # otherwise the newer decoy would win.
+    assert _resolve_prefix(temp_store, "a_b") == "a_b-real"
+
+
+def test_format_timestamp_valid_and_garbage():
+    assert _format_timestamp("2026-07-10T18:30:00+00:00") == "2026-07-10 18:30"
+    assert _format_timestamp("not-a-date") == "not-a-date"
+
+
+# ─── redaction: card pre-check ────────────────────────────────────────────────
+
+
+def test_card_precheck_matches_card_shapes_only():
+    assert _CARD_PRECHECK.search("pay with 4111 1111 1111 1111 thanks")
+    assert _CARD_PRECHECK.search("4111111111111111")
+    assert not _CARD_PRECHECK.search("call 555-1234 or 867-5309")
+    assert not _CARD_PRECHECK.search("port 8080, exit code 1, 42 items")
+
+
+def test_card_still_masked_through_precheck():
+    from longhand.redaction import redact_text
+
+    # 4012-8888-8888-1881: Luhn-valid with varied digits — passes the
+    # plausibility gate (unlike the classic 4111... test number, which is
+    # rejected by design).
+    masked, n = redact_text("card: 4012-8888-8888-1881")
+    assert n == 1
+    assert "4012-8888-8888-1881" not in masked
+
+
+# ─── reconcile: oversize bucket ───────────────────────────────────────────────
+
+
+def test_reconcile_reports_oversize_files(temp_store, tmp_path, monkeypatch):
+    from longhand.recall import reconcile as reconcile_mod
+    from longhand.recall.reconcile import run_reconcile
+
+    big = tmp_path / "huge.jsonl"
+    big.write_text('{"type": "user"}\n' * 5)
+
+    monkeypatch.setattr(reconcile_mod, "discover_sessions", lambda: [big])
+    monkeypatch.setattr(reconcile_mod, "MAX_FILE_SIZE_BYTES", 10)
+
+    report = run_reconcile(temp_store, fix=True)
+    assert report.skipped_oversize == [str(big)]
+    assert report.missing == []  # not misfiled as re-ingestable
+    assert report.ingested == 0
+    assert report.to_dict()["skipped_oversize_count"] == 1
+
+
+# ─── hook install: spawn target must be runnable ──────────────────────────────
+
+
+def test_hook_install_fallback_never_uses_longhand_cli(monkeypatch, tmp_path):
+    """`-m longhand.cli` is a package with no __main__.py — a hook installed
+    with that fallback dies on every session end. Same bug class as the
+    v0.11.2 background-spawn fix."""
+    import longhand.setup_commands as sc
+
+    settings = tmp_path / "settings.json"
+    monkeypatch.setattr(sc, "CLAUDE_SETTINGS_PATH", settings)
+    monkeypatch.setattr(sc.shutil, "which", lambda name: None)
+
+    sc.hook_install()
+    sc.prompt_hook_install()
+
+    text = settings.read_text()
+    assert "longhand.cli" not in text
+    assert "-m longhand ingest-session" in text
+    assert "-m longhand ingest-live" in text
+    assert "-m longhand __prompt-hook-run" in text
+
+
+# ─── coverage: session_summary_embedding ─────────────────────────────────────
+
+
+def _mini_session() -> Session:
+    return Session(
+        session_id="s-sum",
+        project_path="/Users/tester/proj",
+        transcript_path="/Users/tester/t.jsonl",
+        started_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+        ended_at=datetime(2026, 7, 1, 1, tzinfo=timezone.utc),
+        event_count=2,
+        user_message_count=1,
+        assistant_message_count=1,
+        tool_call_count=0,
+        file_edit_count=1,
+        git_branch="main",
+        cwd="/Users/tester/proj",
+        model="claude-sonnet-4-6",
+    )
+
+
+def _msg(event_id: str, seq: int, content: str) -> Event:
+    return Event(
+        event_id=event_id,
+        session_id="s-sum",
+        event_type=EventType.USER_MESSAGE,
+        sequence=seq,
+        timestamp=datetime(2026, 7, 1, 0, seq, tzinfo=timezone.utc),
+        content=content,
+    )
+
+
+def test_build_session_text_and_metadata():
+    from longhand.analysis.session_summary_embedding import (
+        build_session_metadata,
+        build_session_text,
+    )
+
+    session = _mini_session()
+    events = [_msg("u1", 1, "Fix the auth middleware timeout")]
+    outcome = {"outcome": "fixed", "summary": "Fixed a timeout", "topics": ["auth"]}
+    project = {
+        "project_id": "p-sum",
+        "display_name": "proj",
+        "category": "web",
+        "keywords": ["auth"],
+    }
+
+    text = build_session_text(session, events, outcome, project)
+    assert "Project: proj" in text
+    assert "Asked: Fix the auth middleware timeout" in text
+    assert "Outcome: fixed" in text
+
+    meta = build_session_metadata(session, outcome, project)
+    assert meta["session_id"] == "s-sum"
+    assert meta["outcome"] == "fixed"
+
+
+def test_build_project_text():
+    from longhand.analysis.session_summary_embedding import build_project_text
+
+    text = build_project_text(
+        {"display_name": "proj", "category": "web", "keywords": ["auth"], "aliases": ["proj"]}
+    )
+    assert "proj" in text and "web" in text
+
+
+# ─── coverage: segment_search + vector_store round trip ─────────────────────
+
+
+def test_find_segments_roundtrip(temp_store):
+    from longhand.recall.segment_search import find_segments
+
+    temp_store.sqlite.insert_segments(
+        [
+            {
+                "segment_id": "seg-p3",
+                "session_id": "s-seg",
+                "started_at": "2026-07-01T10:00:00Z",
+                "ended_at": "2026-07-01T10:10:00Z",
+                "start_sequence": 1,
+                "end_sequence": 5,
+                "topic": "configuring the resend email domain",
+                "summary": "walked through DNS records for the email domain",
+            }
+        ]
+    )
+    temp_store.vectors.add_segment_embeddings_batch(
+        [
+            {
+                "segment_id": "seg-p3",
+                "text": "configuring the resend email domain DNS records",
+                "metadata": {"segment_type": "discussion", "session_id": "s-seg"},
+            }
+        ]
+    )
+
+    hits = find_segments(temp_store, "email domain dns setup")
+    assert any(h.get("segment_id") == "seg-p3" for h in hits)
+
+
+def test_vector_store_episode_roundtrip(temp_store):
+    assert temp_store.vectors.episode_count() == 0
+    temp_store.vectors.add_episode_embedding(
+        episode_id="ep-vs",
+        text="database lock error fixed by increasing busy timeout",
+        metadata={
+            "session_id": "s-vs",
+            "project_id": "p",
+            "ended_at": "2026-07-01",
+            "status": "resolved",
+            "has_fix": True,
+        },
+    )
+    assert temp_store.vectors.episode_count() == 1
+    hits = temp_store.vectors.search_episodes(query="sqlite lock timeout", n_results=3)
+    assert any(h.get("episode_id") == "ep-vs" for h in hits)


### PR DESCRIPTION
Tier 2 PR 7 of 7 from the 2026-07-09 audit roadmap (v0.12.0) — the P3 grab-bag, plus one bonus find.

## What

- **MCP store singleton + top-level error envelope** — `call_tool` constructed a fresh `LonghandStore` per invocation (migrations + ChromaDB open every call) and had no error boundary. Now one store per server lifetime, and handler exceptions return `{"error": "...", "tool": "..."}` instead of a raw traceback.
- **`_resolve_prefix` via SQL LIKE** (escaped, most-recent-first) — the old Python scan covered only the 1,000 newest sessions, so prefixes of older sessions silently failed to resolve.
- **Redaction card pre-check** — the credit-card regex (the CPU hog on numeric-heavy transcripts) is skipped unless a cheap 13-digit-run pre-check fires. Masking behavior unchanged.
- **Oversize transcripts surfaced** — files over the parser's 500 MB cap can't be ingested by any path; reconcile now reports them as `skipped_oversize` (CLI + MCP schema) instead of erroring or hiding them.
- **Bonus (same class as the v0.11.2 dead-spawn fix):** the hook installer's no-PATH fallback wrote `-m longhand.cli` — a module that dies instantly — into installed hooks. Now `-m longhand`, with a regression test on the installed commands.
- **Coverage** — first direct tests for `session_summary_embedding`, `segment_search`, `vector_store`, and `cli/helpers` (4 of the 5 audit-flagged untested modules; `demo/runner.py` left for v1.0).
- **Deprecation triage** — chromadb's third-party warnings filtered in pytest config with a re-check note: suite warnings 6,426 → 95, ours stay visible.

## Tests

+13 (413 total, green): singleton reuse, envelope shape, prefix matrix (recent-wins, wildcard escaping, miss), pre-check matrix + mask-through, oversize bucket, hook-command spawn targets, and the four coverage modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)