### PR TITLE
fix: segment id collisions on duplicate event sequences fail the whole Chroma batch

### DIFF
--- a/longhand/analysis/segment_extraction.py
+++ b/longhand/analysis/segment_extraction.py
@@ -232,9 +232,16 @@ def extract_segments(
         all_text = " ".join(user_texts)
         keywords = sorted(_extract_simple_keywords(all_text))[:20]
 
+        # Id includes the segment ordinal: events rebuilt from the DB can
+        # carry duplicate sequence numbers (live-tail + full-ingest rows),
+        # and two segments hashing to one id fails the whole ChromaDB batch.
+        # Re-analysis deletes-then-reinserts a session's segments, so id
+        # stability across extractor versions is not required.
         seg_id = (
             "seg_"
-            + hashlib.sha256(f"{session_id}:{seg_events[0].sequence}".encode()).hexdigest()[:16]
+            + hashlib.sha256(
+                f"{session_id}:{len(segments)}:{seg_events[0].sequence}".encode()
+            ).hexdigest()[:16]
         )
 
         segments.append(

--- a/longhand/storage/vector_store.py
+++ b/longhand/storage/vector_store.py
@@ -378,12 +378,23 @@ class VectorStore:
         """Upsert multiple segment embeddings in one ONNX batch.
 
         Each item: ``{"segment_id": str, "text": str, "metadata": dict}``.
-        Items with empty or whitespace-only text are dropped. Chunked at
-        CHROMA_BATCH_SIZE for Chroma stability. Returns the number of
-        embeddings upserted.
+        Items with empty or whitespace-only text are dropped, and duplicate
+        ids keep only the first occurrence — Chroma rejects a batch wholesale
+        when it contains a repeated id. Chunked at CHROMA_BATCH_SIZE for
+        Chroma stability. Returns the number of embeddings upserted.
         """
         if not items:
             return 0
+
+        seen_ids: set[str] = set()
+        deduped: list[dict[str, Any]] = []
+        for item in items:
+            sid = item.get("segment_id")
+            if sid in seen_ids:
+                continue
+            seen_ids.add(sid)
+            deduped.append(item)
+        items = deduped
 
         ids: list[str] = []
         documents: list[str] = []

--- a/longhand/storage/vector_store.py
+++ b/longhand/storage/vector_store.py
@@ -389,7 +389,7 @@ class VectorStore:
         seen_ids: set[str] = set()
         deduped: list[dict[str, Any]] = []
         for item in items:
-            sid = item.get("segment_id")
+            sid = str(item.get("segment_id") or "")
             if sid in seen_ids:
                 continue
             seen_ids.add(sid)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -437,3 +437,46 @@ def test_load_session_from_db_round_trips_analysis_fields(sample_session_file, t
         assert re.tool_success == orig.tool_success
         assert re.error_detected == orig.error_detected
         assert re.tool_name == orig.tool_name
+
+
+def test_segment_ids_unique_even_with_duplicate_sequences(temp_store):
+    """Events rebuilt from the DB can carry duplicate sequence numbers
+    (live-tail + full-ingest rows) — two segments starting at the same
+    sequence must not hash to one id, which fails the whole Chroma batch."""
+    from datetime import datetime, timezone
+
+    from longhand.analysis.segment_extraction import extract_segments
+    from longhand.types import Event, EventType
+
+    def _user(eid: str, seq: int, text: str) -> Event:
+        return Event(
+            event_id=eid,
+            session_id="s-dup",
+            event_type=EventType.USER_MESSAGE,
+            sequence=seq,
+            timestamp=datetime(2026, 7, 1, 0, min(seq, 59), tzinfo=timezone.utc),
+            content=text,
+        )
+
+    # Two conversation clusters, both starting at sequence 1 (duplicated).
+    events = [
+        _user("u1", 1, "first topic about the login flow and sessions"),
+        _user("u2", 1, "more about login"),
+        _user("u3", 40, "totally different second topic about deployment"),
+    ]
+    # Force a second cluster by making the timestamps far apart if the
+    # extractor splits on gaps; regardless, ids must be unique.
+    segments = extract_segments("s-dup", "p1", events)
+    ids = [s["segment_id"] for s in segments]
+    assert len(ids) == len(set(ids))
+
+
+def test_segment_batch_dedupes_duplicate_ids(temp_store):
+    items = [
+        {"segment_id": "seg-x", "text": "first version", "metadata": {"segment_type": "d"}},
+        {"segment_id": "seg-x", "text": "duplicate id", "metadata": {"segment_type": "d"}},
+        {"segment_id": "seg-y", "text": "another segment", "metadata": {"segment_type": "d"}},
+    ]
+    # Must not raise (Chroma rejects batches with repeated ids wholesale).
+    n = temp_store.vectors.add_segment_embeddings_batch(items)
+    assert n == 2


### PR DESCRIPTION
Second dogfood find. The events-table fallback (#53) exposed that DB-rebuilt events can carry duplicate sequence numbers (live-tail and full-ingest rows number independently). Segment ids hashed `(session_id, start_sequence)`, so two segments starting at the same sequence collided — and ChromaDB rejects a batch containing a repeated id wholesale. **66 of 331 sessions** failed re-analysis on the maintainer corpus this way.

## What

- Segment ids include the segment ordinal (`session_id:ordinal:start_sequence`). Re-analysis deletes-then-reinserts a session's segments (#53), so cross-version id stability is explicitly not a requirement.
- `add_segment_embeddings_batch` dedupes ids defensively (first occurrence wins) so a repeated id can never fail a batch again.

## Tests

+2 (421 total, green): duplicate-sequence events produce unique segment ids; a batch with a repeated id upserts the deduped remainder instead of raising.

🤖 Generated with [Claude Code](https://claude.com/claude-code)