### PR TITLE
Safety pair: newer-schema downgrade guard + Windows lock-liveness fix

### DIFF
--- a/longhand/recall/project_fallback.py
+++ b/longhand/recall/project_fallback.py
@@ -41,10 +41,41 @@ def _logs_dir(store: LonghandStore) -> Path:
     return store.data_dir / "logs"
 
 
+# Win32 constants for the liveness probe (values from the Windows SDK).
+_PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+_STILL_ACTIVE = 259
+
+
+def _win32_pid_alive(pid: int) -> bool:
+    """Liveness probe for Windows, where the POSIX signal-0 idiom is lethal.
+
+    On Windows, os.kill(pid, 0) does not probe: CPython maps every non-CTRL
+    signal value to TerminateProcess, so the usual "signal 0 existence check"
+    kills the lock holder. Query the process handle instead.
+    """
+    import ctypes
+
+    kernel32 = ctypes.windll.kernel32  # type: ignore[attr-defined]
+    handle = kernel32.OpenProcess(_PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+    if not handle:
+        # PID gone, or a process this user cannot query — treat as dead,
+        # matching the POSIX branch's PermissionError handling. The lock
+        # holder always runs as the same user, so the distinction is moot.
+        return False
+    try:
+        exit_code = ctypes.c_ulong()
+        ok = kernel32.GetExitCodeProcess(handle, ctypes.byref(exit_code))
+        return bool(ok) and exit_code.value == _STILL_ACTIVE
+    finally:
+        kernel32.CloseHandle(handle)
+
+
 def _lock_holder_alive(pid: int) -> bool:
     """Return True if a process with `pid` is still alive on this system."""
     if pid <= 0:
         return False
+    if sys.platform == "win32":
+        return _win32_pid_alive(pid)
     try:
         # Signal 0 just checks existence without delivering a signal.
         os.kill(pid, 0)

--- a/longhand/storage/migrations.py
+++ b/longhand/storage/migrations.py
@@ -191,6 +191,13 @@ MIGRATIONS: dict[int, str] = {
 }
 
 
+class SchemaTooNewError(RuntimeError):
+    """The database schema is newer than this longhand understands."""
+
+
+MAX_KNOWN_MIGRATION = max(MIGRATIONS)
+
+
 def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
     rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
     return any(r[1] == column for r in rows)
@@ -275,9 +282,22 @@ def _applied_versions(conn: sqlite3.Connection) -> set[int]:
 
 
 def apply_migrations(conn: sqlite3.Connection) -> list[int]:
-    """Apply any unapplied migrations. Returns the list of versions applied this run."""
+    """Apply any unapplied migrations. Returns the list of versions applied this run.
+
+    Raises SchemaTooNewError when the database records a migration this build
+    has never heard of: operating blind against a newer schema risks silent
+    data damage, so downgraded code must refuse loudly instead.
+    """
     _ensure_version_table(conn)
     applied = _applied_versions(conn)
+
+    newest = max(applied, default=0)
+    if newest > MAX_KNOWN_MIGRATION:
+        raise SchemaTooNewError(
+            f"This database is at schema version {newest}, but this longhand only "
+            f"knows version {MAX_KNOWN_MIGRATION} — it was written by a newer longhand. "
+            "Refusing to operate blind. Upgrade with: pip install -U longhand"
+        )
 
     newly_applied: list[int] = []
     for version in sorted(MIGRATIONS.keys()):

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 
-from longhand.storage.migrations import MIGRATIONS, apply_migrations
+import pytest
+
+from longhand.storage.migrations import (
+    MAX_KNOWN_MIGRATION,
+    MIGRATIONS,
+    SchemaTooNewError,
+    apply_migrations,
+)
 from longhand.storage.sqlite_store import SQLiteStore
 
 
@@ -446,3 +453,53 @@ def test_v8_strips_ask_prefix_from_problem_descriptions(tmp_path: Path):
         rows = dict(conn.execute("SELECT episode_id, problem_description FROM episodes").fetchall())
     assert rows["ep-a"] == "fix the bug. Error: boom"
     assert rows["ep-b"] == "Task keeps failing"  # untouched
+
+
+# ─── downgrade guard: refuse databases written by a newer longhand ────────────
+
+
+def test_apply_migrations_refuses_too_new_schema(tmp_path: Path):
+    """A DB stamped by a newer longhand refuses loudly instead of operating blind."""
+    conn = sqlite3.connect(str(tmp_path / "future.db"))
+    conn.execute(
+        "CREATE TABLE schema_version (version INTEGER PRIMARY KEY, applied_at TEXT NOT NULL)"
+    )
+    conn.execute(
+        "INSERT INTO schema_version (version, applied_at) VALUES (?, ?)",
+        (MAX_KNOWN_MIGRATION + 1, "2027-01-01T00:00:00Z"),
+    )
+    conn.commit()
+
+    with pytest.raises(SchemaTooNewError) as excinfo:
+        apply_migrations(conn)
+
+    msg = str(excinfo.value)
+    assert "written by a newer longhand" in msg
+    assert "pip install -U longhand" in msg
+    conn.close()
+
+
+def test_store_construction_refuses_too_new_db(tmp_path: Path):
+    """The guard covers every construction path — SQLiteStore init raises too."""
+    db = tmp_path / "future-store.db"
+    store = SQLiteStore(db)
+    with store.connect() as conn:
+        conn.execute(
+            "INSERT INTO schema_version (version, applied_at) VALUES (?, ?)",
+            (MAX_KNOWN_MIGRATION + 1, "2027-01-01T00:00:00Z"),
+        )
+        conn.commit()
+
+    with pytest.raises(SchemaTooNewError):
+        SQLiteStore(db)
+
+
+def test_equal_version_db_reopens_fine(tmp_path: Path):
+    """A DB at exactly the newest known version opens without complaint."""
+    db = tmp_path / "current.db"
+    SQLiteStore(db)
+
+    store = SQLiteStore(db)  # second open: fully migrated, must not raise
+    with store.connect() as conn:
+        newest = conn.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
+    assert newest == MAX_KNOWN_MIGRATION

--- a/tests/test_project_fallback.py
+++ b/tests/test_project_fallback.py
@@ -6,6 +6,7 @@ import importlib.util
 import os
 import subprocess
 import sys
+import types
 from pathlib import Path
 from unittest.mock import patch
 
@@ -369,3 +370,101 @@ def test_recall_does_not_spawn_when_vectors_populated(temp_store, monkeypatch):
     recall_pipeline.recall(temp_store, "background backfill problem")
 
     assert spawned == []
+
+
+# ─── lock-holder liveness ─────────────────────────────────────────────────────
+
+
+def test_lock_holder_alive_for_own_pid():
+    assert project_fallback._lock_holder_alive(os.getpid()) is True
+
+
+def test_lock_holder_dead_for_exited_child():
+    child = subprocess.Popen([sys.executable, "-c", "pass"])
+    child.wait()
+    assert project_fallback._lock_holder_alive(child.pid) is False
+
+
+def test_lock_holder_invalid_pids_are_dead():
+    assert project_fallback._lock_holder_alive(0) is False
+    assert project_fallback._lock_holder_alive(-7) is False
+
+
+class _FakeKernel32:
+    """Just enough of kernel32 for the Windows liveness probe.
+
+    Mirrors the Win32 calling convention: OpenProcess returns a handle (0 on
+    failure); GetExitCodeProcess writes through the byref pointer and returns
+    nonzero on success.
+    """
+
+    def __init__(self, handle: int, exit_code: int | None = None, get_ok: bool = True):
+        self._handle = handle
+        self._exit_code = exit_code
+        self._get_ok = get_ok
+        self.open_calls: list[tuple[int, object, int]] = []
+        self.closed: list[int] = []
+
+    def OpenProcess(self, access, inherit, pid):  # noqa: N802 — Win32 API name
+        self.open_calls.append((access, inherit, pid))
+        return self._handle
+
+    def GetExitCodeProcess(self, handle, code_ref):  # noqa: N802 — Win32 API name
+        if not self._get_ok:
+            return 0
+        code_ref._obj.value = self._exit_code
+        return 1
+
+    def CloseHandle(self, handle):  # noqa: N802 — Win32 API name
+        self.closed.append(handle)
+        return 1
+
+
+def _patch_win32(monkeypatch, fake: _FakeKernel32) -> None:
+    import ctypes
+
+    monkeypatch.setattr(sys, "platform", "win32")
+    monkeypatch.setattr(ctypes, "windll", types.SimpleNamespace(kernel32=fake), raising=False)
+
+    # Prove liveness never routes through os.kill on Windows: there,
+    # os.kill(pid, 0) TERMINATES the target instead of probing it.
+    def _lethal(pid, sig):
+        raise AssertionError("os.kill reached on win32 — this kills the lock holder")
+
+    monkeypatch.setattr(os, "kill", _lethal)
+
+
+def test_win32_liveness_running_process_is_alive(monkeypatch):
+    fake = _FakeKernel32(handle=42, exit_code=259)  # STILL_ACTIVE
+    _patch_win32(monkeypatch, fake)
+    assert project_fallback._lock_holder_alive(1234) is True
+    assert fake.closed == [42]
+
+
+def test_win32_liveness_exited_process_is_dead(monkeypatch):
+    fake = _FakeKernel32(handle=42, exit_code=0)  # exited normally
+    _patch_win32(monkeypatch, fake)
+    assert project_fallback._lock_holder_alive(1234) is False
+    assert fake.closed == [42]  # handle released even for dead processes
+
+
+def test_win32_liveness_unopenable_pid_is_dead(monkeypatch):
+    fake = _FakeKernel32(handle=0)  # OpenProcess failed: gone or unqueryable
+    _patch_win32(monkeypatch, fake)
+    assert project_fallback._lock_holder_alive(99999) is False
+    assert fake.closed == []  # no handle was opened, none to close
+
+
+def test_win32_liveness_queries_with_limited_information_access(monkeypatch):
+    """The probe must request PROCESS_QUERY_LIMITED_INFORMATION (0x1000) —
+    broader access rights fail against processes the user doesn't own."""
+    fake = _FakeKernel32(handle=7, exit_code=259)
+    _patch_win32(monkeypatch, fake)
+
+    assert project_fallback._lock_holder_alive(4321) is True
+
+    assert len(fake.open_calls) == 1
+    access, inherit, pid = fake.open_calls[0]
+    assert access == 0x1000
+    assert not inherit
+    assert pid == 4321


### PR DESCRIPTION
First PR of the v0.13.0 hardening train (v1.0 roadmap PR 1 — safety pair).

## Downgrade guard (Promise 2 groundwork)
- \`apply_migrations\` now raises \`SchemaTooNewError\` when the DB records a migration newer than \`MAX_KNOWN_MIGRATION\`, with explicit \`pip install -U longhand\` advice — older code refuses a newer DB loudly instead of operating blind.
- Covers every construction path: \`SQLiteStore._init_schema\` is the sole \`apply_migrations\` caller and only swallows/retries \`database is locked\` errors.

## Windows lock-liveness fix (mandatory before any Windows CI)
- \`_lock_holder_alive\` used \`os.kill(pid, 0)\` — on Windows CPython maps every non-CTRL signal to **TerminateProcess**, so the "existence check" killed live lock holders on Windows installs shipping today.
- win32 now routes through \`OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION)\` + \`GetExitCodeProcess == STILL_ACTIVE\` (ctypes, lazy import). POSIX path unchanged.

## Tests (TDD, red first)
- Too-new DB refuses with the upgrade message, at both the \`apply_migrations\` and \`SQLiteStore\` construction layers; equal-version DB reopens clean.
- win32 branch: alive (STILL_ACTIVE), exited, unopenable-PID, and access-rights cases against a faked kernel32 — plus a patched \`os.kill\` that raises if liveness ever routes through it on win32 (the exact bug, pinned). Behavioral proof on real Windows lands with the PR 10 CI leg.
- POSIX pins: own PID alive, exited child dead, invalid PIDs dead.

Gate: ruff + format + mypy + version-sync + full pytest (431 passed, 76% cov) all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)