### PR TITLE
SessionEnd never-raise: hook mode exits 0, breadcrumbs failures for doctor + reconcile

### DIFF
--- a/longhand/cli/_commands.py
+++ b/longhand/cli/_commands.py
@@ -2538,7 +2538,10 @@ def ingest_session_cmd(
     Dual-mode: accepts `--transcript <path>` for direct CLI use, OR reads
     `{"transcript_path": "..."}` JSON from stdin when invoked by Claude Code's
     SessionEnd hook (modern Claude Code passes hook data via stdin, not env vars).
+    Stdin-invoked runs are hook mode: they never exit nonzero — failures become
+    hook-error log breadcrumbs (see `longhand doctor`) for reconcile to heal.
     """
+    hook_mode = transcript is None
     if not transcript:
         import json as _json
         import sys as _sys
@@ -2557,7 +2560,7 @@ def ingest_session_cmd(
             # crash the Claude Code hook chain.
             return
 
-    _ingest_single(transcript, data_dir)
+    _ingest_single(transcript, data_dir, hook_mode=hook_mode)
 
 
 @app.command("ingest-live", hidden=True)

--- a/longhand/setup_commands.py
+++ b/longhand/setup_commands.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import shutil
 import sys
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 import typer
@@ -577,17 +578,48 @@ def mcp_uninstall() -> None:
 # ─── Ingest single session (for hook) ──────────────────────────────────────
 
 
+def _hook_data_dir(data_dir: str | None) -> Path:
+    """Mirror LonghandStore's data-dir choice without constructing a store —
+    store-open failures still need somewhere to leave a breadcrumb."""
+    from longhand.storage.store import DEFAULT_DATA_DIR
+
+    return Path(data_dir) if data_dir else DEFAULT_DATA_DIR
+
+
+def _log_hook_error(data_dir: Path, message: str) -> None:
+    """Append one line to the daily hook-error log. Never raises — the log is
+    best-effort breadcrumbs for doctor, not another way for a hook to fail."""
+    try:
+        logs = data_dir / "logs"
+        logs.mkdir(parents=True, exist_ok=True, mode=0o700)
+        now = datetime.now(timezone.utc)
+        line = f"{now.isoformat(timespec='seconds')} {message}\n"
+        with (logs / f"hook-errors-{now.strftime('%Y-%m-%d')}.log").open("a") as fh:
+            fh.write(line)
+    except Exception:
+        pass
+
+
 def ingest_single_session(
     transcript: str,
     data_dir: str | None = None,
     run_analysis: bool = True,
+    hook_mode: bool = False,
 ) -> None:
     """Ingest a single Claude Code JSONL file.
 
-    Called by the SessionEnd hook. Non-blocking, fast (~1-2s) when analysis
-    runs; even faster when skipped. Pass ``run_analysis=False`` to populate
-    SQLite only (no episodes, segments, or vectors). Power users can defer
-    the analysis pass via ``longhand analyze --all``.
+    Called by the SessionEnd hook (``hook_mode=True``, transcript from stdin)
+    and by humans passing an explicit ``--transcript`` (``hook_mode=False``).
+    Non-blocking, fast (~1-2s) when analysis runs; even faster when skipped.
+    Pass ``run_analysis=False`` to populate SQLite only (no episodes,
+    segments, or vectors). Power users can defer the analysis pass via
+    ``longhand analyze --all``.
+
+    Hook mode never exits nonzero: a failing hook must not crash the Claude
+    Code hook chain, so every failure becomes a one-line stderr note plus a
+    breadcrumb in ``logs/hook-errors-YYYY-MM-DD.log`` (surfaced by ``longhand
+    doctor``), and the transcript is left for reconcile to heal. Explicit CLI
+    use keeps loud exit-1 failures — human misuse deserves an error.
 
     Takes the ingest lock: parallel sessions ending together would otherwise
     open concurrent ChromaDB writers on the same directory, which ChromaDB
@@ -599,14 +631,26 @@ def ingest_single_session(
         release_ingest_lock,
     )
 
+    def _hook_fail(bucket: str, detail: str) -> None:
+        """One stderr line + one log breadcrumb; the caller returns exit-0."""
+        line = f"ingest-session {bucket}: {detail}"
+        print(f"longhand: {line}", file=sys.stderr)
+        _log_hook_error(_hook_data_dir(data_dir), line)
+
     path = Path(transcript).expanduser()
     if not path.exists():
+        if hook_mode:
+            _hook_fail("missing-transcript", str(path))
+            return
         console.print(f"[red]Transcript not found: {transcript}[/red]")
         raise typer.Exit(1)
 
     try:
         store = LonghandStore(data_dir=data_dir)
     except Exception as e:
+        if hook_mode:
+            _hook_fail("store-open-failed", f"{type(e).__name__}: {e}")
+            return
         console.print(f"[red]✗[/red] Could not open the Longhand store: {e}")
         raise typer.Exit(1) from e
 
@@ -618,7 +662,17 @@ def ingest_single_session(
         return
 
     try:
-        parser = JSONLParser(path)
+        try:
+            # The parser constructor enforces the oversize cap (ValueError).
+            # Distinct bucket: reconcile books these under skipped_oversize,
+            # and the breadcrumb should say why the session never appears.
+            parser = JSONLParser(path)
+        except ValueError as e:
+            if hook_mode:
+                _hook_fail("oversize-transcript", str(e))
+                return
+            console.print(f"[red]✗[/red] {e}")
+            raise typer.Exit(1) from e
         events = list(parser.parse_events())
         if not events:
             console.print(f"[yellow]No events in {path.name}[/yellow]")
@@ -630,7 +684,12 @@ def ingest_single_session(
             f"{result['events_stored']} events, "
             f"{result['episodes']} episodes"
         )
+    except typer.Exit:
+        raise
     except Exception as e:
+        if hook_mode:
+            _hook_fail("ingest-failed", f"{path.name}: {type(e).__name__}: {e}")
+            return
         console.print(f"[red]✗[/red] Failed to ingest {path.name}: {e}")
         raise typer.Exit(1) from e
     finally:
@@ -965,6 +1024,37 @@ def _freshness_status(store: LonghandStore) -> str | None:
     )
 
 
+def _hook_errors_status(store: LonghandStore, days: int = 7) -> str:
+    """Rich-formatted count of hook-error breadcrumbs in the last `days` days.
+
+    Complements _freshness_status: freshness says "something is missing";
+    this row says why — every hook-mode ingest failure leaves one line in
+    logs/hook-errors-YYYY-MM-DD.log (see _log_hook_error).
+    """
+    logs = store.data_dir / "logs"
+    window_start = datetime.now(timezone.utc).date() - timedelta(days=days - 1)
+    count = 0
+    for f in logs.glob("hook-errors-*.log"):
+        try:
+            day = date.fromisoformat(f.stem.removeprefix("hook-errors-"))
+        except ValueError:
+            continue  # unrecognized filename — not ours to count
+        if day < window_start:
+            continue
+        try:
+            with f.open() as fh:
+                count += sum(1 for line in fh if line.strip())
+        except OSError:
+            continue
+    if count == 0:
+        return f"[green]✓[/green] none in the last {days} days"
+    return (
+        f"[yellow]⚠[/yellow] {count} in the last {days} days — see "
+        f"[bold]{logs}/hook-errors-*.log[/bold]; "
+        "[bold]longhand reconcile --fix[/bold] heals missed ingests"
+    )
+
+
 def _human_size(n: int) -> str:
     size = float(n)
     for unit in ("B", "KB", "MB", "GB", "TB"):
@@ -1112,6 +1202,10 @@ def doctor() -> None:
     freshness_row = _freshness_status(store)
     if freshness_row:
         table.add_row("Recent ingest (7d)", freshness_row)
+
+    # 5b. Hook failures breadcrumbed by ingest-session's hook mode — freshness
+    # says "something is missing"; this row says why.
+    table.add_row("Hook errors (7d)", _hook_errors_status(store))
 
     # 6. Stats
     stats = store.stats()

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -248,6 +248,45 @@ def test_cli_reconcile_detects_null_project_rows(
     assert "1 ingested but project_id IS NULL" in result.stdout
 
 
+# ─── doctor hook-error visibility ───────────────────────────────────────────
+
+
+def test_hook_errors_status_green_when_no_errors(tmp_path: Path):
+    from longhand.setup_commands import _hook_errors_status
+    from longhand.storage import LonghandStore
+
+    store = LonghandStore(data_dir=tmp_path / "longhand")
+    status = _hook_errors_status(store)
+    assert "green" in status
+    assert "none" in status
+
+
+def test_hook_errors_status_counts_recent_and_ignores_old(tmp_path: Path):
+    from datetime import datetime, timedelta, timezone
+
+    from longhand.setup_commands import _hook_errors_status
+    from longhand.storage import LonghandStore
+
+    store = LonghandStore(data_dir=tmp_path / "longhand")
+    logs = store.data_dir / "logs"
+    logs.mkdir(parents=True, exist_ok=True)
+
+    today = datetime.now(timezone.utc).date()
+    recent = logs / f"hook-errors-{today.isoformat()}.log"
+    recent.write_text(
+        "2026-07-11T18:00:00+00:00 ingest-session missing-transcript: /tmp/gone.jsonl\n"
+        "2026-07-11T18:05:00+00:00 ingest-session ingest-failed: boom\n"
+    )
+    old = logs / f"hook-errors-{(today - timedelta(days=30)).isoformat()}.log"
+    old.write_text("ancient failure, outside the window\n")
+    (logs / "hook-errors-not-a-date.log").write_text("garbage name, must not crash\n")
+
+    status = _hook_errors_status(store)
+    assert "yellow" in status
+    assert "2 in the last 7 days" in status
+    assert "hook-errors-*.log" in status
+
+
 # ─── doctor freshness ──────────────────────────────────────────────────────
 
 

--- a/tests/test_ingest_session_stdin.py
+++ b/tests/test_ingest_session_stdin.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
 from typer.testing import CliRunner
 
 from longhand.cli import app
@@ -89,3 +90,155 @@ def test_hook_command_is_stale_detects_env_var_version() -> None:
 
     unrelated = {"hooks": [{"type": "command", "command": "echo hello"}]}
     assert _hook_command_is_stale(unrelated) is False
+
+
+# ─── hook mode never exits nonzero (v0.13 hardening) ─────────────────────────
+#
+# stdin-invoked = hook mode: every failure becomes a one-line stderr note plus
+# a breadcrumb in logs/hook-errors-YYYY-MM-DD.log (surfaced by doctor), and the
+# command exits 0 so it can never crash the SessionEnd hook chain. Explicit
+# --transcript keeps loud exit-1 failures — human misuse deserves an error.
+
+
+def _stdin_payload(path: Path) -> str:
+    return json.dumps({"transcript_path": str(path), "session_id": "s-hook"})
+
+
+def _hook_error_lines(data_dir: Path) -> list[str]:
+    logs = data_dir / "logs"
+    lines: list[str] = []
+    for f in sorted(logs.glob("hook-errors-*.log")):
+        lines.extend(f.read_text().splitlines())
+    return lines
+
+
+def test_hook_mode_missing_transcript_exits_zero_and_logs(tmp_path: Path) -> None:
+    runner = CliRunner()
+    data_dir = tmp_path / "lh"
+
+    result = runner.invoke(
+        app,
+        ["ingest-session", "--data-dir", str(data_dir)],
+        input=_stdin_payload(tmp_path / "gone.jsonl"),
+    )
+
+    assert result.exit_code == 0, result.output
+    lines = _hook_error_lines(data_dir)
+    assert len(lines) == 1
+    assert "missing-transcript" in lines[0]
+    assert "gone.jsonl" in lines[0]
+
+
+def test_hook_mode_too_new_db_exits_zero_and_logs(tmp_path: Path) -> None:
+    """Store-open failures (incl. SchemaTooNewError from the downgrade guard)
+    must never crash the hook — the breadcrumb carries the upgrade advice."""
+    from longhand.storage.migrations import MAX_KNOWN_MIGRATION
+    from longhand.storage.sqlite_store import SQLiteStore
+
+    data_dir = tmp_path / "lh"
+    seeded = SQLiteStore(data_dir / "longhand.db")
+    with seeded.connect() as conn:
+        conn.execute(
+            "INSERT INTO schema_version (version, applied_at) VALUES (?, ?)",
+            (MAX_KNOWN_MIGRATION + 1, "2027-01-01T00:00:00Z"),
+        )
+        conn.commit()
+
+    transcript = tmp_path / "some.jsonl"
+    transcript.write_text(json.dumps({"type": "user", "uuid": "u1"}) + "\n")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["ingest-session", "--data-dir", str(data_dir)],
+        input=_stdin_payload(transcript),
+    )
+
+    assert result.exit_code == 0, result.output
+    lines = _hook_error_lines(data_dir)
+    assert len(lines) == 1
+    assert "store-open-failed" in lines[0]
+    assert "SchemaTooNewError" in lines[0]
+
+
+def test_hook_mode_oversize_transcript_exits_zero_and_logs(
+    sample_session_file: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The parser's size cap becomes a distinct breadcrumb, not a crash."""
+    import longhand.parser as parser_mod
+
+    monkeypatch.setattr(parser_mod, "MAX_FILE_SIZE_BYTES", 1)
+
+    runner = CliRunner()
+    data_dir = tmp_path / "lh"
+    result = runner.invoke(
+        app,
+        ["ingest-session", "--data-dir", str(data_dir)],
+        input=_stdin_payload(sample_session_file),
+    )
+
+    assert result.exit_code == 0, result.output
+    lines = _hook_error_lines(data_dir)
+    assert len(lines) == 1
+    assert "oversize-transcript" in lines[0]
+
+
+def test_hook_mode_ingest_failure_exits_zero_logs_and_releases_lock(
+    sample_session_file: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An exploding pipeline stage becomes a breadcrumb; reconcile heals later."""
+    from longhand.storage import LonghandStore
+
+    def _boom(self, *args, **kwargs):
+        raise RuntimeError("pipeline exploded mid-ingest")
+
+    monkeypatch.setattr(LonghandStore, "ingest_session", _boom)
+
+    runner = CliRunner()
+    data_dir = tmp_path / "lh"
+    result = runner.invoke(
+        app,
+        ["ingest-session", "--data-dir", str(data_dir)],
+        input=_stdin_payload(sample_session_file),
+    )
+
+    assert result.exit_code == 0, result.output
+    lines = _hook_error_lines(data_dir)
+    assert len(lines) == 1
+    assert "ingest-failed" in lines[0]
+    assert "RuntimeError" in lines[0]
+    assert not (data_dir / ".ingest.lock").exists()  # released in the finally
+
+
+def test_explicit_transcript_missing_still_exits_one(tmp_path: Path) -> None:
+    """Human misuse keeps its loud exit — only hook mode is silenced."""
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        [
+            "ingest-session",
+            "--transcript",
+            str(tmp_path / "gone.jsonl"),
+            "--data-dir",
+            str(tmp_path / "lh"),
+        ],
+    )
+
+    assert result.exit_code == 1
+    assert not (tmp_path / "lh" / "logs").exists()  # breadcrumbs are hook-mode only
+
+
+def test_hook_error_logging_failure_is_swallowed(tmp_path: Path) -> None:
+    """Even when the breadcrumb log cannot be written, hook mode exits 0."""
+    data_dir = tmp_path / "lh"
+    data_dir.mkdir(parents=True)
+    (data_dir / "logs").write_text("i am a file, not a directory")
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ["ingest-session", "--data-dir", str(data_dir)],
+        input=_stdin_payload(tmp_path / "gone.jsonl"),
+    )
+
+    assert result.exit_code == 0, result.output


### PR DESCRIPTION
v0.13.0 train, PR 2 of 10 (v1.0 roadmap — Promise 3 groundwork).

## What
- \`ingest_single_session\` gains \`hook_mode\`; the CLI passes \`hook_mode=True\` exactly when the transcript arrived via stdin (the SessionEnd hook path). \`--transcript\` keeps loud exit-1 failures.
- In hook mode every failure exits 0: one-line stderr note + append to \`logs/hook-errors-YYYY-MM-DD.log\` (same daily-file convention as the background-ingest logs; the log write itself never raises).
- Failure table covered: missing transcript / store-open fail (incl. \`SchemaTooNewError\` from PR 1) / oversize transcript (parser-ctor \`ValueError\`, distinct bucket since reconcile books those as \`skipped_oversize\`) / any parse-or-ingest raise. Lock still released in the \`finally\`.
- \`doctor\` gains a **Hook errors (7d)** row — counts breadcrumb lines from the daily logs, green when none, yellow with a pointer to the logs + \`reconcile --fix\` otherwise. Complements the freshness row: freshness says something is missing, this says why.

## Tests (TDD, red first)
Failure-table matrix end-to-end via CliRunner (exit 0 + breadcrumb asserted per bucket, incl. a real too-new DB from PR 1's guard), lock-release-after-failure, breadcrumb-log-unwritable still exits 0, explicit \`--transcript\` still exits 1, and unit tests for the doctor row (green zero-state; recent counted, old + garbage filenames ignored).

Gate: ruff + format + mypy + version-sync + full pytest (439 passed, 76.7% cov) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)