### PR TITLE
Lock coverage completion: wait-claim for analyze / reattribute --fix / redact --apply

### DIFF
--- a/longhand/cli/_commands.py
+++ b/longhand/cli/_commands.py
@@ -971,7 +971,17 @@ def analyze(
     ),
     data_dir: str | None = typer.Option(None, "--data-dir"),
 ):
-    """Re-run analysis (projects, outcomes, episodes) on already-ingested sessions."""
+    """Re-run analysis (projects, outcomes, episodes) on already-ingested sessions.
+
+    Holds the ingest lock while it runs: analysis rewrites episodes, segments,
+    and embeddings — the same stores the session hooks write — so hooks defer
+    until it finishes (their reconcile heal path picks up anything deferred).
+    """
+    from longhand.recall.project_fallback import (
+        claim_ingest_lock_with_wait,
+        release_ingest_lock,
+    )
+
     store = _get_store(data_dir)
 
     if not all_sessions and not session:
@@ -986,66 +996,78 @@ def analyze(
         console.print("[yellow]No matching sessions.[/yellow]")
         return
 
-    console.print(f"[cyan]Analyzing {len(sessions)} session(s)...[/cyan]")
-    analyzed = 0
-    errors = 0
-    total_episodes = 0
+    if not claim_ingest_lock_with_wait(
+        store,
+        on_wait=lambda: console.print(
+            "[yellow]Waiting for a running Longhand ingest to finish...[/yellow]"
+        ),
+    ):
+        console.print("[red]✗[/red] Another Longhand ingest is still running — try again shortly.")
+        raise typer.Exit(1)
 
-    fallback_used = 0
-    for sess_row in sessions:
-        try:
-            transcript_path = sess_row["transcript_path"]
-            if transcript_path and Path(transcript_path).exists():
-                # Re-parse the transcript file for full event objects
-                parser = JSONLParser(transcript_path)
-                events = list(parser.parse_events())
-                if not events:
-                    continue
-                session_obj = parser.build_session(events)
-            else:
-                # Transcript rotated off disk — rebuild from the events table
-                # (the same source reattribute uses), so old sessions still
-                # get re-analyzed with current extractors.
-                loaded = store.load_session_from_db(sess_row)
-                if loaded is None:
-                    errors += 1
-                    continue
-                session_obj, events = loaded
-                fallback_used += 1
-            result = store.analyze_session(session_obj, events)
-            total_episodes += result.get("episodes", 0)
-            analyzed += 1
-            if analyzed % 20 == 0:
-                console.print(f"  [dim]{analyzed}/{len(sessions)}...[/dim]")
-        except Exception as e:
-            errors += 1
-            console.print(f"  [red]✗[/red] {sess_row['session_id'][:8]}: {e}")
+    try:
+        console.print(f"[cyan]Analyzing {len(sessions)} session(s)...[/cyan]")
+        analyzed = 0
+        errors = 0
+        total_episodes = 0
 
-    console.print()
-    console.print(
-        f"[bold]Analyzed {analyzed}[/bold] sessions, "
-        f"[bold]{total_episodes}[/bold] episodes "
-        f"([dim]{errors} errors; {fallback_used} rebuilt from the events table[/dim])"
-    )
+        fallback_used = 0
+        for sess_row in sessions:
+            try:
+                transcript_path = sess_row["transcript_path"]
+                if transcript_path and Path(transcript_path).exists():
+                    # Re-parse the transcript file for full event objects
+                    parser = JSONLParser(transcript_path)
+                    events = list(parser.parse_events())
+                    if not events:
+                        continue
+                    session_obj = parser.build_session(events)
+                else:
+                    # Transcript rotated off disk — rebuild from the events table
+                    # (the same source reattribute uses), so old sessions still
+                    # get re-analyzed with current extractors.
+                    loaded = store.load_session_from_db(sess_row)
+                    if loaded is None:
+                        errors += 1
+                        continue
+                    session_obj, events = loaded
+                    fallback_used += 1
+                result = store.analyze_session(session_obj, events)
+                total_episodes += result.get("episodes", 0)
+                analyzed += 1
+                if analyzed % 20 == 0:
+                    console.print(f"  [dim]{analyzed}/{len(sessions)}...[/dim]")
+            except Exception as e:
+                errors += 1
+                console.print(f"  [red]✗[/red] {sess_row['session_id'][:8]}: {e}")
 
-    # A full re-analysis can shift episode boundaries, leaving stale
-    # embeddings under old episode_ids. Clear and rebuild the collection
-    # from the now-current SQLite rows (formerly `reanalyze`'s job).
-    if all_sessions:
-        console.print("\n[cyan]Rebuilding episode embeddings...[/cyan]")
-        try:
-            store.vectors.client.delete_collection(name="episodes")
-            store.vectors.episodes_collection = store.vectors.client.get_or_create_collection(
-                name="episodes"
-            )
-        except Exception:
-            pass
+        console.print()
+        console.print(
+            f"[bold]Analyzed {analyzed}[/bold] sessions, "
+            f"[bold]{total_episodes}[/bold] episodes "
+            f"([dim]{errors} errors; {fallback_used} rebuilt from the events table[/dim])"
+        )
 
-        def _progress(done: int, total: int) -> None:
-            console.print(f"   {done}/{total}...", end="\r")
+        # A full re-analysis can shift episode boundaries, leaving stale
+        # embeddings under old episode_ids. Clear and rebuild the collection
+        # from the now-current SQLite rows (formerly `reanalyze`'s job).
+        if all_sessions:
+            console.print("\n[cyan]Rebuilding episode embeddings...[/cyan]")
+            try:
+                store.vectors.client.delete_collection(name="episodes")
+                store.vectors.episodes_collection = store.vectors.client.get_or_create_collection(
+                    name="episodes"
+                )
+            except Exception:
+                pass
 
-        embedded = store.backfill_episode_embeddings(progress=_progress)
-        console.print(f"[green]✓[/green] Embedded {embedded} episode(s).")
+            def _progress(done: int, total: int) -> None:
+                console.print(f"   {done}/{total}...", end="\r")
+
+            embedded = store.backfill_episode_embeddings(progress=_progress)
+            console.print(f"[green]✓[/green] Embedded {embedded} episode(s).")
+    finally:
+        release_ingest_lock(store)
 
 
 @app.command(rich_help_panel="Data")
@@ -1065,37 +1087,57 @@ def reattribute(
     case-duplicate paths, and junk projects minted from temp dirs. Idempotent.
 
     DRY-RUN BY DEFAULT: prints the moves grouped by destination and touches
-    nothing. Review, then re-run with --fix to apply.
+    nothing. Review, then re-run with --fix to apply. --fix holds the ingest
+    lock while it rewrites; the dry-run stays lock-free.
     """
-    store = _get_store(data_dir)
-    mode = "Re-attributing" if fix else "Dry-run: re-deriving"
-    console.print(f"[cyan]{mode} sessions from the events table...[/cyan]")
-    result = store.reattribute_sessions(apply=fix)
-    console.print(
-        f"[bold]Scanned {result['scanned']}[/bold] sessions, "
-        f"[bold]{result['reattributed']}[/bold] "
-        f"{'re-attributed' if fix else 'would move'} "
-        f"([dim]{result['skipped']} skipped — no events[/dim])"
+    from longhand.recall.project_fallback import (
+        claim_ingest_lock_with_wait,
+        release_ingest_lock,
     )
 
-    if result["changes"]:
-        by_move: dict[tuple[str | None, str], int] = {}
-        names: dict[str, str] = {}
-        for c in result["changes"]:
-            key = (c["old_project_id"], c["new_project_id"])
-            by_move[key] = by_move.get(key, 0) + 1
-            names[c["new_project_id"]] = c["new_display_name"]
-        for (old_pid, new_pid), n in sorted(by_move.items(), key=lambda kv: -kv[1]):
-            old_proj = store.sqlite.get_project(old_pid) if old_pid else None
-            old_name = (old_proj or {}).get("display_name") or old_pid or "(none)"
-            console.print(f"  {n:>4} session(s): {old_name} → {names[new_pid]}")
+    store = _get_store(data_dir)
 
-    if result["pruned"]:
-        verb = "pruned" if fix else "would be pruned"
-        console.print(f"  [dim]{result['pruned']} emptied project row(s) {verb}[/dim]")
+    if fix and not claim_ingest_lock_with_wait(
+        store,
+        on_wait=lambda: console.print(
+            "[yellow]Waiting for a running Longhand ingest to finish...[/yellow]"
+        ),
+    ):
+        console.print("[red]✗[/red] Another Longhand ingest is still running — try again shortly.")
+        raise typer.Exit(1)
 
-    if not fix and result["changes"]:
-        console.print("\n[dim]Run with --fix to apply.[/dim]")
+    try:
+        mode = "Re-attributing" if fix else "Dry-run: re-deriving"
+        console.print(f"[cyan]{mode} sessions from the events table...[/cyan]")
+        result = store.reattribute_sessions(apply=fix)
+        console.print(
+            f"[bold]Scanned {result['scanned']}[/bold] sessions, "
+            f"[bold]{result['reattributed']}[/bold] "
+            f"{'re-attributed' if fix else 'would move'} "
+            f"([dim]{result['skipped']} skipped — no events[/dim])"
+        )
+
+        if result["changes"]:
+            by_move: dict[tuple[str | None, str], int] = {}
+            names: dict[str, str] = {}
+            for c in result["changes"]:
+                key = (c["old_project_id"], c["new_project_id"])
+                by_move[key] = by_move.get(key, 0) + 1
+                names[c["new_project_id"]] = c["new_display_name"]
+            for (old_pid, new_pid), n in sorted(by_move.items(), key=lambda kv: -kv[1]):
+                old_proj = store.sqlite.get_project(old_pid) if old_pid else None
+                old_name = (old_proj or {}).get("display_name") or old_pid or "(none)"
+                console.print(f"  {n:>4} session(s): {old_name} → {names[new_pid]}")
+
+        if result["pruned"]:
+            verb = "pruned" if fix else "would be pruned"
+            console.print(f"  [dim]{result['pruned']} emptied project row(s) {verb}[/dim]")
+
+        if not fix and result["changes"]:
+            console.print("\n[dim]Run with --fix to apply.[/dim]")
+    finally:
+        if fix:
+            release_ingest_lock(store)
 
 
 def _deprecated(old: str, new: str) -> None:
@@ -1476,6 +1518,10 @@ def redact(
     --apply, matches are masked in SQLite and changed vector documents are
     re-embedded.
     """
+    from longhand.recall.project_fallback import (
+        claim_ingest_lock_with_wait,
+        release_ingest_lock,
+    )
     from longhand.redaction import redact_text, scan_text
 
     store = _get_store(data_dir)
@@ -1488,67 +1534,90 @@ def redact(
             console.print("[yellow]Aborted — nothing changed.[/yellow]")
             return
 
-    pattern_counts: dict[str, int] = {}
-    rows_touched: dict[str, int] = {}
-
-    with store.sqlite.connect() as conn:
-        for table, (pk, columns) in _REDACT_TABLES.items():
-            try:
-                rows = conn.execute(f"SELECT {pk}, {', '.join(columns)} FROM {table}").fetchall()  # noqa: S608 — identifiers are from the hardcoded _REDACT_TABLES map
-            except Exception:
-                continue  # table may not exist on older schemas
-            touched = 0
-            for row in rows:
-                updates: dict[str, str] = {}
-                row_matched = False
-                for col in columns:
-                    val = row[col]
-                    if not val:
-                        continue
-                    found = scan_text(val)
-                    if not found:
-                        continue
-                    row_matched = True
-                    for name, n in found.items():
-                        pattern_counts[name] = pattern_counts.get(name, 0) + n
-                    if apply:
-                        new_val, _ = redact_text(val)
-                        updates[col] = new_val
-                if updates:
-                    set_clause = ", ".join(f"{c} = ?" for c in updates)
-                    conn.execute(
-                        f"UPDATE {table} SET {set_clause} WHERE {pk} = ?",  # noqa: S608
-                        (*updates.values(), row[pk]),
-                    )
-                if row_matched:
-                    touched += 1
-            if touched:
-                rows_touched[table] = touched
-
-    if not pattern_counts:
-        console.print("[green]No secret-shaped strings found. Store is clean.[/green]")
-        return
-
-    table_out = Table(
-        title="Secrets masked" if apply else "Secrets found (scan only — nothing changed)"
-    )
-    table_out.add_column("Pattern", style="cyan")
-    table_out.add_column("Matches", style="yellow", justify="right")
-    for name in sorted(pattern_counts):
-        table_out.add_row(name, str(pattern_counts[name]))
-    console.print(table_out)
-    for tbl, n in rows_touched.items():
-        console.print(f"[dim]{tbl}: {n} row(s) affected[/dim]")
-
+    # Claim only after the irreversibility confirm — nobody should hold the
+    # writers' lock while staring at a y/N prompt. Scan mode is read-only and
+    # stays lock-free.
+    locked = False
     if apply:
-        embedded = store.vectors.redact_documents(redact_text)
-        console.print(f"[green]Re-embedded {embedded} vector document(s).[/green]")
-        console.print("[green]Done. Matched values were masked in place.[/green]")
-    else:
-        console.print(
-            "\n[dim]Run `longhand redact --apply` to mask these, and "
-            "`longhand config --set redact.enabled=true` to mask future ingests.[/dim]"
+        if not claim_ingest_lock_with_wait(
+            store,
+            on_wait=lambda: console.print(
+                "[yellow]Waiting for a running Longhand ingest to finish...[/yellow]"
+            ),
+        ):
+            console.print(
+                "[red]✗[/red] Another Longhand ingest is still running — try again shortly."
+            )
+            raise typer.Exit(1)
+        locked = True
+
+    try:
+        pattern_counts: dict[str, int] = {}
+        rows_touched: dict[str, int] = {}
+
+        with store.sqlite.connect() as conn:
+            for table, (pk, columns) in _REDACT_TABLES.items():
+                try:
+                    rows = conn.execute(
+                        f"SELECT {pk}, {', '.join(columns)} FROM {table}"
+                    ).fetchall()  # noqa: S608 — identifiers are from the hardcoded _REDACT_TABLES map
+                except Exception:
+                    continue  # table may not exist on older schemas
+                touched = 0
+                for row in rows:
+                    updates: dict[str, str] = {}
+                    row_matched = False
+                    for col in columns:
+                        val = row[col]
+                        if not val:
+                            continue
+                        found = scan_text(val)
+                        if not found:
+                            continue
+                        row_matched = True
+                        for name, n in found.items():
+                            pattern_counts[name] = pattern_counts.get(name, 0) + n
+                        if apply:
+                            new_val, _ = redact_text(val)
+                            updates[col] = new_val
+                    if updates:
+                        set_clause = ", ".join(f"{c} = ?" for c in updates)
+                        conn.execute(
+                            f"UPDATE {table} SET {set_clause} WHERE {pk} = ?",  # noqa: S608
+                            (*updates.values(), row[pk]),
+                        )
+                    if row_matched:
+                        touched += 1
+                if touched:
+                    rows_touched[table] = touched
+
+        if not pattern_counts:
+            console.print("[green]No secret-shaped strings found. Store is clean.[/green]")
+            return
+
+        table_out = Table(
+            title="Secrets masked" if apply else "Secrets found (scan only — nothing changed)"
         )
+        table_out.add_column("Pattern", style="cyan")
+        table_out.add_column("Matches", style="yellow", justify="right")
+        for name in sorted(pattern_counts):
+            table_out.add_row(name, str(pattern_counts[name]))
+        console.print(table_out)
+        for tbl, n in rows_touched.items():
+            console.print(f"[dim]{tbl}: {n} row(s) affected[/dim]")
+
+        if apply:
+            embedded = store.vectors.redact_documents(redact_text)
+            console.print(f"[green]Re-embedded {embedded} vector document(s).[/green]")
+            console.print("[green]Done. Matched values were masked in place.[/green]")
+        else:
+            console.print(
+                "\n[dim]Run `longhand redact --apply` to mask these, and "
+                "`longhand config --set redact.enabled=true` to mask future ingests.[/dim]"
+            )
+    finally:
+        if locked:
+            release_ingest_lock(store)
 
 
 # -----------------------------------------------------------------------------

--- a/longhand/recall/project_fallback.py
+++ b/longhand/recall/project_fallback.py
@@ -20,6 +20,8 @@ from __future__ import annotations
 import os
 import subprocess
 import sys
+import time
+from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -101,6 +103,15 @@ def infer_missing_projects(store: LonghandStore) -> list[dict[str, Any]]:
 
     Returns the list of project fingerprints that were upserted.
     """
+    # This runs inside the UserPromptSubmit hook: never claim, never wait.
+    # When a live ingest holds the lock, the projects it is building will be
+    # visible on the next query anyway — defer rather than stack writers.
+    lock = _lock_path(store)
+    if lock.exists():
+        holder = _read_lock_pid(lock)
+        if holder and holder != os.getpid() and _lock_holder_alive(holder):
+            return []
+
     files = discover_sessions()
     if not files:
         return []
@@ -201,6 +212,38 @@ def trigger_background_episode_backfill(store: LonghandStore) -> bool:
     happens in a detached process that claims the ingest lock.
     """
     return spawn_background(store, ["backfill-episodes"], "background-backfill")
+
+
+def claim_ingest_lock_with_wait(
+    store: LonghandStore,
+    timeout_s: float = 15.0,
+    interval_s: float = 0.5,
+    on_wait: Callable[[], None] | None = None,
+) -> bool:
+    """Claim the ingest lock, waiting up to `timeout_s` for a live holder.
+
+    CLI commands use this where hooks use the non-blocking claim_ingest_lock:
+    a human running `analyze` wants the command to run when the current
+    ingest finishes, not to be told "try again later". `on_wait` fires once,
+    the first time waiting actually begins, so callers can print a note.
+
+    Returns True when the lock is ours; False when the timeout expired.
+    Same-PID claims are idempotent (inherited from claim_ingest_lock), so
+    nested wait-claims by one process return immediately instead of
+    deadlocking against themselves.
+    """
+    deadline = time.monotonic() + timeout_s
+    waited = False
+    while True:
+        if claim_ingest_lock(store):
+            return True
+        if not waited:
+            waited = True
+            if on_wait is not None:
+                on_wait()
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(interval_s)
 
 
 def claim_ingest_lock(store: LonghandStore) -> bool:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -248,6 +248,159 @@ def test_cli_reconcile_detects_null_project_rows(
     assert "1 ingested but project_id IS NULL" in result.stdout
 
 
+# ─── ingest-lock coverage for the heavy writers ──────────────────────────────
+#
+# analyze / reattribute --fix / redact --apply write into the same SQLite +
+# Chroma stores the ingest lock serializes. They wait-claim the lock (humans
+# want "run when the ingest finishes", not "try again later"), abort with
+# exit 1 on timeout, and never touch the lock in their read-only modes.
+
+
+def test_analyze_aborts_when_ingest_lock_stays_busy(
+    runner: CliRunner, sample_session_file: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    from longhand.recall import project_fallback
+    from longhand.setup_commands import ingest_single_session
+    from longhand.storage.store import LonghandStore
+
+    data_dir = tmp_path / "lh"
+    ingest_single_session(str(sample_session_file), data_dir=str(data_dir), run_analysis=False)
+
+    # A busy holder that never lets go — don't actually poll for 15s in a test.
+    monkeypatch.setattr(project_fallback, "claim_ingest_lock_with_wait", lambda store, **kw: False)
+    analyzed: list[int] = []
+    monkeypatch.setattr(
+        LonghandStore, "analyze_session", lambda self, *a, **k: analyzed.append(1) or {}
+    )
+
+    result = runner.invoke(app, ["analyze", "--all", "--data-dir", str(data_dir)])
+
+    assert result.exit_code == 1
+    assert "ingest" in result.output.lower()
+    assert analyzed == []  # aborted before touching the store
+
+
+def test_analyze_claims_and_releases_the_lock(
+    runner: CliRunner, sample_session_file: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    from longhand.recall import project_fallback
+    from longhand.setup_commands import ingest_single_session
+    from longhand.storage.store import LonghandStore
+
+    data_dir = tmp_path / "lh"
+    ingest_single_session(str(sample_session_file), data_dir=str(data_dir), run_analysis=False)
+    store = LonghandStore(data_dir=data_dir)
+    with store.sqlite.connect() as conn:
+        sid = conn.execute("SELECT session_id FROM sessions").fetchone()[0]
+
+    calls: list[str] = []
+    monkeypatch.setattr(
+        project_fallback,
+        "claim_ingest_lock_with_wait",
+        lambda store, **kw: calls.append("claim") or True,
+    )
+    monkeypatch.setattr(
+        project_fallback, "release_ingest_lock", lambda store: calls.append("release")
+    )
+    monkeypatch.setattr(LonghandStore, "analyze_session", lambda self, *a, **k: {"episodes": 0})
+
+    result = runner.invoke(app, ["analyze", "--session", sid[:8], "--data-dir", str(data_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert calls == ["claim", "release"]
+
+
+def test_reattribute_fix_aborts_when_ingest_lock_stays_busy(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    from longhand.recall import project_fallback
+    from longhand.storage.store import LonghandStore
+
+    monkeypatch.setattr(project_fallback, "claim_ingest_lock_with_wait", lambda store, **kw: False)
+    moved: list[int] = []
+    monkeypatch.setattr(
+        LonghandStore,
+        "reattribute_sessions",
+        lambda self, apply=False: moved.append(1) or {},
+    )
+
+    result = runner.invoke(app, ["reattribute", "--fix", "--data-dir", str(tmp_path / "lh")])
+
+    assert result.exit_code == 1
+    assert moved == []
+
+
+def test_reattribute_dry_run_never_touches_the_lock(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    from longhand.recall import project_fallback
+
+    claims: list[int] = []
+    monkeypatch.setattr(
+        project_fallback,
+        "claim_ingest_lock_with_wait",
+        lambda store, **kw: claims.append(1) or True,
+    )
+
+    result = runner.invoke(app, ["reattribute", "--data-dir", str(tmp_path / "lh")])
+
+    assert result.exit_code == 0, result.output
+    assert claims == []
+
+
+def test_redact_apply_aborts_when_ingest_lock_stays_busy(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    from longhand.recall import project_fallback
+
+    monkeypatch.setattr(project_fallback, "claim_ingest_lock_with_wait", lambda store, **kw: False)
+
+    result = runner.invoke(app, ["redact", "--apply", "--yes", "--data-dir", str(tmp_path / "lh")])
+
+    assert result.exit_code == 1
+
+
+def test_redact_scan_never_touches_the_lock(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    from longhand.recall import project_fallback
+
+    claims: list[int] = []
+    monkeypatch.setattr(
+        project_fallback,
+        "claim_ingest_lock_with_wait",
+        lambda store, **kw: claims.append(1) or True,
+    )
+
+    result = runner.invoke(app, ["redact", "--data-dir", str(tmp_path / "lh")])
+
+    assert result.exit_code == 0, result.output
+    assert claims == []
+
+
+def test_redact_apply_claims_lock_only_after_confirmation(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Declining the irreversibility prompt must abort before any lock work —
+    users shouldn't hold the writers' lock while staring at a y/N prompt."""
+    from longhand.recall import project_fallback
+
+    claims: list[int] = []
+    monkeypatch.setattr(
+        project_fallback,
+        "claim_ingest_lock_with_wait",
+        lambda store, **kw: claims.append(1) or True,
+    )
+
+    result = runner.invoke(
+        app, ["redact", "--apply", "--data-dir", str(tmp_path / "lh")], input="n\n"
+    )
+
+    assert result.exit_code == 0
+    assert "Aborted" in result.output
+    assert claims == []
+
+
 # ─── doctor hook-error visibility ───────────────────────────────────────────
 
 

--- a/tests/test_project_fallback.py
+++ b/tests/test_project_fallback.py
@@ -6,6 +6,8 @@ import importlib.util
 import os
 import subprocess
 import sys
+import threading
+import time
 import types
 from pathlib import Path
 from unittest.mock import patch
@@ -370,6 +372,102 @@ def test_recall_does_not_spawn_when_vectors_populated(temp_store, monkeypatch):
     recall_pipeline.recall(temp_store, "background backfill problem")
 
     assert spawned == []
+
+
+# ─── wait-claim + prompt-path lock discipline ────────────────────────────────
+
+
+def test_wait_claim_immediate_when_free(temp_store):
+    temp_store.data_dir.mkdir(parents=True, exist_ok=True)
+    waited: list[int] = []
+
+    ok = project_fallback.claim_ingest_lock_with_wait(
+        temp_store, timeout_s=1, interval_s=0.05, on_wait=lambda: waited.append(1)
+    )
+
+    assert ok is True
+    assert waited == []  # never had to wait
+    lock = temp_store.data_dir / ".ingest.lock"
+    assert lock.read_text().strip() == str(os.getpid())
+    project_fallback.release_ingest_lock(temp_store)
+
+
+def test_wait_claim_times_out_against_live_holder(temp_store):
+    temp_store.data_dir.mkdir(parents=True, exist_ok=True)
+    lock = temp_store.data_dir / ".ingest.lock"
+    lock.write_text(str(os.getppid()))  # an alive PID that isn't ours
+    waited: list[int] = []
+
+    start = time.monotonic()
+    ok = project_fallback.claim_ingest_lock_with_wait(
+        temp_store, timeout_s=0.3, interval_s=0.05, on_wait=lambda: waited.append(1)
+    )
+
+    assert ok is False
+    assert time.monotonic() - start >= 0.3
+    assert waited == [1]  # fired once when waiting began, not once per poll
+    assert lock.read_text().strip() == str(os.getppid())  # holder untouched
+    lock.unlink()
+
+
+def test_wait_claim_acquires_after_holder_releases(temp_store):
+    temp_store.data_dir.mkdir(parents=True, exist_ok=True)
+    lock = temp_store.data_dir / ".ingest.lock"
+    lock.write_text(str(os.getppid()))
+
+    releaser = threading.Timer(0.15, lock.unlink)
+    releaser.start()
+    try:
+        ok = project_fallback.claim_ingest_lock_with_wait(temp_store, timeout_s=5, interval_s=0.05)
+    finally:
+        releaser.cancel()
+
+    assert ok is True
+    assert lock.read_text().strip() == str(os.getpid())
+    project_fallback.release_ingest_lock(temp_store)
+
+
+def test_wait_claim_idempotent_for_own_pid(temp_store):
+    temp_store.data_dir.mkdir(parents=True, exist_ok=True)
+    assert project_fallback.claim_ingest_lock(temp_store) is True
+    waited: list[int] = []
+
+    ok = project_fallback.claim_ingest_lock_with_wait(
+        temp_store, timeout_s=1, interval_s=0.05, on_wait=lambda: waited.append(1)
+    )
+
+    assert ok is True
+    assert waited == []
+    project_fallback.release_ingest_lock(temp_store)
+
+
+def test_infer_missing_projects_defers_to_live_ingest(temp_store, monkeypatch):
+    """infer_missing_projects runs inside the UserPromptSubmit hook: when a
+    live ingest holds the lock it must return [] before doing ANY work —
+    never claim, never wait, never stack writers."""
+    temp_store.data_dir.mkdir(parents=True, exist_ok=True)
+    lock = temp_store.data_dir / ".ingest.lock"
+    lock.write_text(str(os.getppid()))
+
+    discovered: list[int] = []
+    monkeypatch.setattr(project_fallback, "discover_sessions", lambda: discovered.append(1) or [])
+
+    assert project_fallback.infer_missing_projects(temp_store) == []
+    assert discovered == [], "deferral must precede any discovery work"
+    lock.unlink()
+
+
+def test_infer_missing_projects_ignores_stale_lock(temp_store, sample_session_file, monkeypatch):
+    """A dead holder must not block the cheap project pass."""
+    temp_store.data_dir.mkdir(parents=True, exist_ok=True)
+    lock = temp_store.data_dir / ".ingest.lock"
+    lock.write_text("0")  # PID 0 — dead/invalid
+
+    monkeypatch.setattr(project_fallback, "discover_sessions", lambda: [Path(sample_session_file)])
+
+    inferred = project_fallback.infer_missing_projects(temp_store)
+    assert len(inferred) == 1
+    lock.unlink()
 
 
 # ─── lock-holder liveness ─────────────────────────────────────────────────────


### PR DESCRIPTION
v0.13.0 train, PR 4 of 10.

## What
- New \`claim_ingest_lock_with_wait(store, timeout_s=15, interval_s=0.5, on_wait)\` in project_fallback — humans get "run when the ingest finishes", hooks keep the non-blocking claim. \`on_wait\` fires once (prints a waiting note); same-PID claims remain idempotent, so nested wait-claims cannot self-deadlock.
- **analyze** wait-claims for its whole run (heaviest Chroma writer — episode/segment rewrites + the \`--all\` embedding rebuild are inside the lock; hooks defer meanwhile and reconcile heals). Timeout → exit 1.
- **reattribute --fix** wait-claims; the dry-run never touches the lock.
- **redact --apply** claims **after** the irreversibility confirm — declining aborts without ever contending; scan mode never touches the lock. Timeout → exit 1.
- **infer_missing_projects** (runs inside the UserPromptSubmit hook) now defers immediately — read-only holder check, \`[]\` before any discovery work when a live ingest holds the lock; stale holders ignored as before.

Deadlock audit from the design doc holds: no nested claims across these paths, and the same-PID idempotence covers re-entry.

## Tests (TDD, red first)
Primitive: immediate claim (no wait), timeout against a live holder (on_wait fired once, holder untouched), acquire-after-release (timer thread), same-PID idempotence. Prompt path: deferral precedes any discovery work; stale locks don't block. Commands: blocked → exit 1 without touching the store, claim/release pairing on success, dry-run/scan never touch the lock, decline-confirm aborts before any lock work.

Gate: ruff + format + mypy + version-sync + full pytest (472 passed, 77.4% cov) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)