### PR TITLE
Datetime normalization: tz-aware UTC writes, user-local recall windows

### DIFF
--- a/longhand/recall/recall_pipeline.py
+++ b/longhand/recall/recall_pipeline.py
@@ -166,7 +166,10 @@ def recall(
     6. Build narrative
     """
     if now is None:
-        now = datetime.now(timezone.utc)
+        # The user's wall clock, tz-aware: time phrases like "today" anchor
+        # to the local calendar day (see time_parser); recency arithmetic is
+        # offset-aware either way.
+        now = datetime.now().astimezone()
 
     # 0. First-run backfill — after an upgrade the episodes vector collection
     # can be empty while SQLite is populated. Embedding the whole corpus
@@ -705,7 +708,7 @@ def _detect_project_drift(
 
     last_transcript_mtime_iso: str | None = None
     if max_mtime > 0.0:
-        last_transcript_mtime_iso = _dt.fromtimestamp(max_mtime).isoformat()
+        last_transcript_mtime_iso = _dt.fromtimestamp(max_mtime, tz=timezone.utc).isoformat()
 
     stale = len(truly_missing) > 0
     stale_reason: str | None = None

--- a/longhand/recall/time_parser.py
+++ b/longhand/recall/time_parser.py
@@ -13,7 +13,7 @@ No dateparser dependency. ~100 lines of rules.
 from __future__ import annotations
 
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, tzinfo
 
 
 def _utc(dt: datetime) -> datetime:
@@ -61,17 +61,28 @@ _UNIT_TO_DAYS = {
 def parse_time_phrase(
     query: str,
     now: datetime | None = None,
+    *,
+    tz: tzinfo | None = None,
 ) -> tuple[datetime | None, datetime | None, str]:
     """Parse time phrases out of a query.
 
     Returns (since, until, cleaned_query) where:
     - since/until are tz-aware UTC datetimes (or None if no phrase matched)
     - cleaned_query has the matched time phrase removed
+
+    Day boundaries anchor to the wall clock of `now`'s timezone — the
+    system-local zone by default. A UTC-7 evening is already "tomorrow" in
+    UTC, so anchoring at UTC midnight made "today" exclude the user's whole
+    day. Pass an aware `now` to anchor in its zone, or `tz` to place a
+    naive/omitted `now`; naive `now` without `tz` keeps the old UTC anchor.
     """
     if now is None:
-        now = datetime.now(timezone.utc)
-    else:
-        now = _utc(now)
+        # The user's wall clock, tz-aware: "today" means their calendar day.
+        now = datetime.now(tz) if tz is not None else datetime.now().astimezone()
+    elif now.tzinfo is None:
+        now = now.replace(tzinfo=tz if tz is not None else timezone.utc)
+    elif tz is not None:
+        now = now.astimezone(tz)
 
     # Numeric phrase first (more specific)
     match = _NUMERIC_PHRASE.search(query)
@@ -85,7 +96,7 @@ def parse_time_phrase(
         since = _day_start(target - timedelta(days=window))
         until = target + timedelta(days=window)
         cleaned = query[: match.start()] + query[match.end() :]
-        return since, until, cleaned.strip()
+        return _utc(since), _utc(until), cleaned.strip()
 
     # Fixed phrases
     for pattern, (days_start, days_end) in _FIXED_PHRASES:
@@ -94,6 +105,6 @@ def parse_time_phrase(
             since = _day_start(now - timedelta(days=days_start))
             until = now - timedelta(days=days_end) if days_end > 0 else now
             cleaned = query[: match.start()] + query[match.end() :]
-            return since, until, cleaned.strip()
+            return _utc(since), _utc(until), cleaned.strip()
 
     return None, None, query

--- a/longhand/setup_commands.py
+++ b/longhand/setup_commands.py
@@ -21,6 +21,7 @@ from rich.table import Table
 
 from longhand.parser import JSONLParser, discover_sessions
 from longhand.storage import LonghandStore
+from longhand.timeutil import utcnow
 
 console = Console()
 
@@ -752,8 +753,6 @@ def ingest_live_tail(
     Returns a small dict with counts. Never raises — designed to be called
     from a hook chain that must not crash Claude Code.
     """
-    from datetime import datetime as _dt
-
     from longhand.recall.project_fallback import (
         claim_ingest_lock,
         release_ingest_lock,
@@ -897,9 +896,9 @@ def ingest_live_tail(
             ).fetchone()
 
         started_at = (agg["started_at"] if agg and agg["started_at"] else None) or (
-            existing_session["started_at"] if existing_session else _dt.now().isoformat()
+            existing_session["started_at"] if existing_session else utcnow().isoformat()
         )
-        ended_at = agg["ended_at"] if agg and agg["ended_at"] else _dt.now().isoformat()
+        ended_at = agg["ended_at"] if agg and agg["ended_at"] else utcnow().isoformat()
 
         # Derive cwd the same way build_session does (mode of project-resolving
         # cwds), not MAX(cwd). None → the UPSERT's COALESCE preserves the existing
@@ -941,7 +940,7 @@ def ingest_live_tail(
                     agg["git_branch"] if agg else None,
                     best_cwd,
                     agg["model"] if agg else None,
-                    _dt.now().isoformat(),
+                    utcnow().isoformat(),
                 ),
             )
 

--- a/longhand/storage/migrations.py
+++ b/longhand/storage/migrations.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 import sqlite3
 import time
-from datetime import datetime
+
+from longhand.timeutil import utcnow
 
 MIGRATIONS: dict[int, str] = {
     1: """
@@ -310,7 +311,7 @@ def apply_migrations(conn: sqlite3.Connection) -> list[int]:
             _apply_alters(conn, version)
             conn.execute(
                 "INSERT INTO schema_version (version, applied_at) VALUES (?, ?)",
-                (version, datetime.now().isoformat()),
+                (version, utcnow().isoformat()),
             )
         except (sqlite3.IntegrityError, sqlite3.OperationalError):
             # Two processes can race the same migration right after an

--- a/longhand/storage/sqlite_store.py
+++ b/longhand/storage/sqlite_store.py
@@ -12,11 +12,12 @@ import sqlite3
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from longhand.storage.migrations import apply_migrations
+from longhand.timeutil import utcnow
 from longhand.types import Event, EventType, Session
 
 SCHEMA = """
@@ -82,6 +83,10 @@ CREATE TABLE IF NOT EXISTS ingestion_log (
 
 
 def _iso(dt: datetime) -> str:
+    """ISO-8601 with an explicit offset — naive input is stamped as UTC so
+    no writer can regress to ambiguous local-clock strings."""
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
     return dt.isoformat()
 
 
@@ -186,7 +191,7 @@ class SQLiteStore:
                     session.git_branch,
                     session.cwd,
                     session.model,
-                    _iso(datetime.now()),
+                    _iso(utcnow()),
                 ),
             )
 
@@ -286,7 +291,7 @@ class SQLiteStore:
                     session_id = excluded.session_id,
                     analysis_stage = 'pending'
                 """,
-                (transcript_path, session_id, _iso(datetime.now())),
+                (transcript_path, session_id, _iso(utcnow())),
             )
 
     def log_ingestion(
@@ -316,7 +321,7 @@ class SQLiteStore:
                 (
                     transcript_path,
                     session_id,
-                    _iso(datetime.now()),
+                    _iso(utcnow()),
                     file_size,
                     event_count,
                     file_size,
@@ -393,7 +398,7 @@ class SQLiteStore:
                 (
                     transcript_path,
                     session_id,
-                    _iso(datetime.now()),
+                    _iso(utcnow()),
                     event_count,
                     last_offset,
                 ),
@@ -848,7 +853,7 @@ class SQLiteStore:
                     outcome.get("resolution_event_id"),
                     outcome.get("summary", ""),
                     json.dumps(outcome.get("topics", [])),
-                    datetime.now().isoformat(),
+                    utcnow().isoformat(),
                 ),
             )
 

--- a/longhand/timeutil.py
+++ b/longhand/timeutil.py
@@ -1,0 +1,15 @@
+"""Shared timezone-aware clock helpers.
+
+Storage timestamps are UTC ISO-8601 with an explicit offset (+00:00).
+Rows written before v0.13 are naive local-clock strings; readers interpret
+naive values as UTC — metadata-grade tolerance, no backfill migration.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def utcnow() -> datetime:
+    """The current moment as a tz-aware UTC datetime."""
+    return datetime.now(timezone.utc)

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -494,6 +494,20 @@ def test_store_construction_refuses_too_new_db(tmp_path: Path):
         SQLiteStore(db)
 
 
+def test_migration_stamps_are_utc_aware(tmp_path: Path):
+    """schema_version.applied_at carries a UTC offset (v0.13 normalization);
+    legacy naive stamps are read as UTC — metadata-grade, no backfill."""
+    from datetime import datetime
+
+    store = SQLiteStore(tmp_path / "aware.db")
+    with store.connect() as conn:
+        stamps = [r[0] for r in conn.execute("SELECT applied_at FROM schema_version")]
+
+    assert stamps
+    for stamp in stamps:
+        assert datetime.fromisoformat(stamp).tzinfo is not None, stamp
+
+
 def test_equal_version_db_reopens_fine(tmp_path: Path):
     """A DB at exactly the newest known version opens without complaint."""
     db = tmp_path / "current.db"

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -2,7 +2,40 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from longhand.parser import JSONLParser
+
+
+def test_iso_attaches_utc_to_naive_input():
+    """_iso hardens naive datetimes to UTC so no writer can regress to
+    local-clock stamps (v0.13 datetime normalization)."""
+    from longhand.storage.sqlite_store import _iso
+
+    assert _iso(datetime(2026, 7, 11, 12, 0)) == "2026-07-11T12:00:00+00:00"
+    aware = datetime(2026, 7, 11, 12, 0, tzinfo=timezone.utc)
+    assert _iso(aware) == "2026-07-11T12:00:00+00:00"
+
+
+def test_ingest_timestamps_are_utc_aware(sample_session_file, temp_store):
+    """sessions.ingested_at and ingestion_log.ingested_at carry a UTC offset.
+
+    Legacy naive rows (pre-v0.13 local-clock stamps) stay readable — readers
+    interpret naive values as UTC; no backfill migration.
+    """
+    parser = JSONLParser(sample_session_file)
+    events = list(parser.parse_events())
+    session = parser.build_session(events)
+    temp_store.ingest_session(session, events, run_analysis=False)
+
+    with temp_store.sqlite.connect() as conn:
+        session_stamp = conn.execute("SELECT ingested_at FROM sessions").fetchone()[0]
+        log_stamp = conn.execute("SELECT ingested_at FROM ingestion_log").fetchone()[0]
+
+    for stamp in (session_stamp, log_stamp):
+        parsed = datetime.fromisoformat(stamp)
+        assert parsed.tzinfo is not None, f"naive timestamp written: {stamp}"
+        assert parsed.utcoffset() == timezone.utc.utcoffset(None)
 
 
 def test_ingest_and_query_roundtrip(sample_session_file, temp_store):

--- a/tests/test_time_parser.py
+++ b/tests/test_time_parser.py
@@ -7,7 +7,7 @@ incidentally (the no-match return); these tests pin the actual phrase semantics.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -119,3 +119,61 @@ def test_default_now_uses_current_time():
     assert since is not None and until is not None
     assert since <= until
     assert "yesterday" not in cleaned
+
+
+# ─── user-local day anchoring (v0.13) ─────────────────────────────────────────
+#
+# "today" means the user's calendar day. Anchoring day boundaries at UTC
+# midnight cut local evenings off: at 5:30pm in UTC-7 the UTC date has already
+# flipped, so a "today" query excluded everything the user did that day.
+
+MST = timezone(timedelta(hours=-7))  # fixed offset, no DST — deterministic
+
+
+def test_today_anchors_to_local_midnight_not_utc():
+    # 2026-07-11 17:30 in UTC-7 == 2026-07-12 00:30 UTC: the UTC date flipped.
+    local_evening = datetime(2026, 7, 11, 17, 30, tzinfo=MST)
+
+    since, until, _ = parse_time_phrase("what did I do today", now=local_evening)
+
+    # "today" = (1, 0): window starts at the LOCAL day-start of (now - 1d),
+    # i.e. Jul 10 00:00-07:00 = Jul 10 07:00 UTC. The old UTC anchor placed
+    # it at Jul 11 00:00 UTC — 5pm local the previous day — silently cutting
+    # local mornings out of every "today" query for UTC-minus users.
+    assert since == datetime(2026, 7, 10, 7, 0, tzinfo=timezone.utc)
+    assert until == local_evening  # same instant
+    assert since.utcoffset() == timedelta(0)  # edges are UTC-normalized
+    assert until.utcoffset() == timedelta(0)
+
+
+def test_yesterday_covers_the_local_calendar_day():
+    local_evening = datetime(2026, 7, 11, 17, 30, tzinfo=MST)
+
+    since, until, _ = parse_time_phrase("yesterday", now=local_evening)
+
+    # (days_ago_start, days_ago_end) = (2, 1) anchored on the LOCAL day.
+    assert since == datetime(2026, 7, 9, 7, 0, tzinfo=timezone.utc)
+    assert until == datetime(2026, 7, 10, 17, 30, tzinfo=MST)
+
+
+def test_tz_kwarg_anchors_a_naive_now():
+    naive = datetime(2026, 7, 11, 17, 30)  # frozen wall clock, zone via tz=
+    since, _, _ = parse_time_phrase("today", now=naive, tz=MST)
+    assert since == datetime(2026, 7, 10, 7, 0, tzinfo=timezone.utc)
+
+
+def test_default_anchor_is_local_and_aware():
+    since, _, _ = parse_time_phrase("today")
+    assert since is not None and since.tzinfo is not None
+    # "today" = (1, 0): local day-start of (now - 1d), in the system zone.
+    expected = (datetime.now().astimezone() - timedelta(days=1)).replace(
+        hour=0, minute=0, second=0, microsecond=0
+    )
+    assert since == expected  # aware comparison — instant equality
+
+
+def test_explicit_utc_now_keeps_utc_anchoring():
+    """Regression: aware-UTC `now` (every existing caller) anchors in UTC."""
+    since, until, _ = parse_time_phrase("yesterday", now=NOW)
+    assert since == _dt(2026, 5, 26)
+    assert until == _dt(2026, 5, 27, 12, 0)


### PR DESCRIPTION
v0.13.0 train, PR 5 of 10.

## Writes — one clock
- New \`longhand/timeutil.py\` with \`utcnow()\`; all ten naive \`datetime.now()\` write sites replaced (sqlite_store ×5, migrations \`applied_at\`, \`ingest_live_tail\` ×3, drift-cache mtime→UTC iso).
- \`_iso()\` hardened: naive input is stamped UTC, so no future writer can regress to ambiguous local-clock strings.
- **Read tolerance**: legacy naive rows are interpreted as UTC (metadata-grade; \`_recency_boost\` already did exactly this). No backfill migration.

## Recall windows — the user's calendar day
- \`parse_time_phrase(query, now=None, *, tz=None)\`: day boundaries anchor to the wall clock of \`now\`'s timezone, system-local by default. At 5:30pm in UTC-7 the UTC date has flipped, so the old UTC-midnight anchor silently cut local mornings out of "today"/"yesterday" queries.
- Backward-compatible: aware \`now\` keeps its zone (every existing caller passes aware-UTC — behavior identical), naive \`now\` still anchors UTC, and returned edges are **UTC-normalized** so \`isoformat()\` comparisons against stored \`+00:00\` stamps stay lexicographically safe. \`recall()\`'s default clock is now local-aware to match.
- \`_day_start\` and the window arithmetic: zero changes.

## Tests (TDD, red first)
Frozen UTC-7 "today" boundary (local midnight, not UTC midnight of the next date), local-calendar "yesterday", \`tz=\` placing a frozen naive clock, default-anchor aware + instant-correct, explicit-UTC-now regression pin, \`_iso\` naive→UTC unit, ingest + migration stamps parse tz-aware.

**Dogfood note:** recall_diff windows shift once for non-UTC users — expected; re-baseline at the 0.13.0 dogfood pass.

Gate: ruff + format + mypy + version-sync + full pytest (480 passed, 77.4% cov) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)