### PR TITLE
Honest error detection: command-context suppressions, false-positive canary, AUTO_SCOPE_MIN_SCORE

### DIFF
--- a/.fieldnotes/notes/0002-project-inference-cwd-mode.md
+++ b/.fieldnotes/notes/0002-project-inference-cwd-mode.md
@@ -5,8 +5,8 @@ references:
 - advisory: false
   lines: null
   path: longhand/parser.py
-  pinned_at: '2026-07-10T20:55:48.344557Z'
-  sha: 611a1710fa576229caba133d4e7563eb63d14027ab5917eaf6c6f4a205f3b7c7
+  pinned_at: '2026-07-11T19:15:34.126886Z'
+  sha: 611c83dca0c9894243068be02cc1955e13a3f72de9c7f075e63aa732c301d5e4
   symbol: null
 session_id: null
 superseded_by: '0006'

--- a/longhand/extractors/errors.py
+++ b/longhand/extractors/errors.py
@@ -15,6 +15,7 @@ Returns None if no error is detected. An ErrorSignal otherwise.
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
 
@@ -132,10 +133,134 @@ def _is_benign_line(line: str) -> bool:
     return any(p.search(line) for p in _BENIGN_LINE_PATTERNS)
 
 
-def detect_error(content: str | None) -> ErrorSignal | None:
+# ─── command-context suppressions ────────────────────────────────────────────
+#
+# The paired Bash command tells us whether error-shaped output is noise.
+# Suppression is per-pattern: a matched rule silences only the listed
+# pattern names, everything else keeps scanning, so a real error later in
+# the same output still registers (canary_error_false_positives pins this).
+
+_ERRNO_PATTERNS = frozenset({"bash_common", "bash_errno"})
+
+# Pattern classes routinely quoted verbatim in search hits, git history,
+# and file contents. Everything except python_traceback — the multi-frame
+# traceback header stays live everywhere as the one high-signal structural
+# marker.
+_ERROR_WORD_PATTERNS = _ERRNO_PATTERNS | frozenset(
+    {
+        "bash_error",
+        "bash_error_lowercase",
+        "panic_fatal",
+        "python_exception",
+        "node_error",
+        "node_module_missing",
+        "node_unhandled_promise",
+        "assertion_error",
+        "expected_got",
+        "test_fail",
+        "test_summary_fail",
+        "pytest_failed",
+        "mocha_failing",
+        "ts_compile_error",
+        "ts_type_error",
+        "go_compile_error",
+        "rust_compile_error",
+        "rust_abort",
+        "curl_error",
+        "http_error_status",
+    }
+)
+
+_PROBE_COMMANDS = frozenset({"test", "[", "ls", "stat", "which", "command", "type"})
+_READ_PROBE_COMMANDS = frozenset({"cat", "head", "tail"})
+_SEARCH_COMMANDS = frozenset({"grep", "egrep", "fgrep", "rg", "ag"})
+_GIT_READ_SUBCOMMANDS = frozenset(
+    {
+        "log",
+        "show",
+        "diff",
+        "status",
+        "blame",
+        "grep",
+        "branch",
+        "remote",
+        "describe",
+        "rev-parse",
+        "ls-files",
+        "shortlog",
+        "reflog",
+    }
+)
+
+
+def _first_word(command: str) -> str:
+    parts = command.strip().split()
+    if not parts:
+        return ""
+    return parts[0].rsplit("/", 1)[-1]  # /opt/homebrew/bin/rg → rg
+
+
+def _is_search(command: str) -> bool:
+    return _first_word(command) in _SEARCH_COMMANDS
+
+
+def _is_git_read(command: str) -> bool:
+    parts = command.strip().split()
+    return (
+        len(parts) >= 2
+        and parts[0].rsplit("/", 1)[-1] == "git"
+        and parts[1] in _GIT_READ_SUBCOMMANDS
+    )
+
+
+def _is_probe(command: str) -> bool:
+    # An explicit 2>/dev/null anywhere is the caller saying "failure is fine".
+    return _first_word(command) in _PROBE_COMMANDS or "2>/dev/null" in command
+
+
+def _is_read_probe(command: str) -> bool:
+    return _first_word(command) in _READ_PROBE_COMMANDS
+
+
+# Ordered — the first matching rule decides which pattern names stay silent
+# for this command's output.
+_COMMAND_CONTEXT_SUPPRESSIONS: list[tuple[Callable[[str], bool], frozenset[str]]] = [
+    # Search output quotes matched lines verbatim — the single highest-volume
+    # false-positive source on the live corpus (2026-07-09 audit).
+    (_is_search, _ERROR_WORD_PATTERNS),
+    # Git history legitimately mentions failures; a live `fatal:` from git
+    # itself must still register.
+    (_is_git_read, _ERROR_WORD_PATTERNS - {"panic_fatal"}),
+    # Existence probes: ENOENT/EACCES *is* the answer, not a failure.
+    (_is_probe, _ERRNO_PATTERNS),
+    (_is_read_probe, _ERRNO_PATTERNS),
+]
+
+
+def _suppressed_patterns(command: str | None) -> frozenset[str]:
+    if not command:
+        return frozenset()
+    for applies, suppressed in _COMMAND_CONTEXT_SUPPRESSIONS:
+        if applies(command):
+            return suppressed
+    return frozenset()
+
+
+def detect_error(
+    content: str | None,
+    *,
+    tool_name: str | None = None,
+    command: str | None = None,
+) -> ErrorSignal | None:
     """Detect if a tool_result content string indicates an error.
 
     Returns the first matching ErrorSignal, or None if the content looks clean.
+
+    `command` — the paired Bash command, when the caller knows it — drives
+    per-pattern suppression via _COMMAND_CONTEXT_SUPPRESSIONS. `tool_name`
+    is accepted for callers that have it; no current rule keys on it (the
+    parser already gates detection to command-executing tools). Both are
+    optional: bare detect_error(content) behaves exactly as before.
     """
     if not content:
         return None
@@ -144,8 +269,12 @@ def detect_error(content: str | None) -> ErrorSignal | None:
     if not text.strip():
         return None
 
+    suppressed = _suppressed_patterns(command)
+
     # Scan against patterns in priority order
     for pattern, severity, category, name in _PATTERNS:
+        if name in suppressed:
+            continue
         for match in pattern.finditer(text):
             # Extract the line containing the match
             start = text.rfind("\n", 0, match.start()) + 1

--- a/longhand/mcp_server.py
+++ b/longhand/mcp_server.py
@@ -79,6 +79,15 @@ _HINT_PROJECTS = "Use a smaller `limit`, a `keyword`, or a `category` filter."
 
 
 MAX_LIMIT = 1000
+
+# Fuzzy-match score at or above which a tool trusts match_projects enough to
+# act on the top hit without an explicit project filter (search auto-scoping,
+# list_sessions staleness banners). Trade-off: higher and literal project
+# names get buried under cross-project noise; lower and vague queries get
+# wrongly pinned to one project. 0.8 = a strong name/alias/keyword hit,
+# below exact-path certainty. Every auto-scope decision is surfaced via
+# `auto_scoped_to` in the payload — the evidence channel for tuning this.
+AUTO_SCOPE_MIN_SCORE = 0.8
 MAX_OUTPUT_CHARS = 200000
 MAX_QUERY_CHARS = 2000
 
@@ -1102,7 +1111,7 @@ async def _tool_search(store: LonghandStore, arguments: dict[str, Any]) -> list[
     if not project_id and not project_name:
         try:
             matches = match_projects(store, query, top_k=1)
-            if matches and matches[0].score >= 0.8:
+            if matches and matches[0].score >= AUTO_SCOPE_MIN_SCORE:
                 project_name = matches[0].display_name
                 auto_scoped_to = matches[0].display_name
         except Exception:
@@ -1307,7 +1316,7 @@ async def _tool_list_sessions(store: LonghandStore, arguments: dict[str, Any]) -
     if project_filter:
         try:
             matches = match_projects(store, project_filter, top_k=1)
-            if matches and matches[0].score >= 0.8:
+            if matches and matches[0].score >= AUTO_SCOPE_MIN_SCORE:
                 proj = store.sqlite.get_project(matches[0].project_id)
                 if proj:
                     banner = staleness_banner(

--- a/longhand/parser.py
+++ b/longhand/parser.py
@@ -424,9 +424,15 @@ class JSONLParser:
                 error_signal = None
                 git_signal = None
                 if paired_tool in COMMAND_EXECUTING_TOOLS:
-                    error_signal = detect_error(result_content)
-                    # Extract structured git data from Bash git commands
                     paired_input = self._tool_input_by_id.get(tool_use_id or "", {})
+                    # Thread the command so probe/search/git-read noise is
+                    # suppressed at the source (honest error counts).
+                    error_signal = detect_error(
+                        result_content,
+                        tool_name=paired_tool,
+                        command=paired_input.get("command", ""),
+                    )
+                    # Extract structured git data from Bash git commands
                     git_signal = extract_git_signal(
                         command=paired_input.get("command", ""),
                         output=result_content,

--- a/tests/fixtures/corpus/canary_error_false_positives.py
+++ b/tests/fixtures/corpus/canary_error_false_positives.py
@@ -1,0 +1,131 @@
+"""Canary: probe/search noise must not inflate a session's error count.
+
+Bug class: detect_error runs on raw tool_result text with no idea what
+command produced it. A session that probes missing paths (`ls`, `stat` —
+ENOENT is the *answer*, not a failure), greps for the literal word
+"Error:", and then hits one real pytest failure used to book four errors
+instead of one. Session outcomes then skew toward "struggled" and recall
+narratives lead with noise.
+
+Audit anchor (2026-07-09): search-command output quoting error words was
+the single highest-volume false-positive source on the live corpus.
+"""
+
+from __future__ import annotations
+
+from tests.canary_harness import OutputAssertion
+
+DESCRIPTION = (
+    "Probe ENOENTs and rg 'Error:' hits are noise; the pytest failure is "
+    "the session's only real error — error_detected count must be exactly 1."
+)
+
+SESSION_ID = "canary-error-noise-session"
+CWD = "/tmp/canary-error-noise"
+
+
+def _ts(minute: int) -> str:
+    return f"2026-07-09T10:{minute:02d}:00.000Z"
+
+
+def _bash_pair(idx: int, minute: int, command: str, output: str) -> list[dict]:
+    """An assistant tool_use (Bash) and its paired user tool_result."""
+    return [
+        {
+            "type": "assistant",
+            "uuid": f"a-{idx}",
+            "parentUuid": f"u-{idx - 1}" if idx else "u-0",
+            "sessionId": SESSION_ID,
+            "timestamp": _ts(minute),
+            "cwd": CWD,
+            "isSidechain": False,
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": f"toolu_canary_{idx}",
+                        "name": "Bash",
+                        "input": {"command": command},
+                    }
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "uuid": f"r-{idx}",
+            "parentUuid": f"a-{idx}",
+            "sessionId": SESSION_ID,
+            "timestamp": _ts(minute + 1),
+            "cwd": CWD,
+            "isSidechain": False,
+            "message": {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": f"toolu_canary_{idx}",
+                        "content": output,
+                    }
+                ],
+            },
+        },
+    ]
+
+
+_EVENTS: list[dict] = [
+    {
+        "type": "user",
+        "uuid": "u-0",
+        "parentUuid": None,
+        "sessionId": SESSION_ID,
+        "timestamp": _ts(0),
+        "cwd": CWD,
+        "isSidechain": False,
+        "message": {"role": "user", "content": "check the config then run the tests"},
+    },
+    # Probe a maybe-missing path — ENOENT is the answer, not a failure.
+    *_bash_pair(
+        1, 1, "ls /tmp/definitely-missing", "ls: /tmp/definitely-missing: No such file or directory"
+    ),
+    # Read-probe an optional config file.
+    *_bash_pair(
+        2,
+        3,
+        "cat /etc/canary-missing.conf",
+        "cat: /etc/canary-missing.conf: No such file or directory",
+    ),
+    # Grep for error handling — hits quote error-shaped text verbatim.
+    *_bash_pair(
+        3,
+        5,
+        'rg "Error" src/',
+        "src/retry.py:7:# retries on AssertionError from the flaky mock\n"
+        'src/probe.py:12:msg = "No such file or directory"',
+    ),
+    # The one real failure in the session.
+    *_bash_pair(
+        4,
+        7,
+        "pytest tests/ -q",
+        "FAILED tests/test_config.py::test_load - AssertionError: boom\n1 failed, 3 passed in 0.42s",
+    ),
+]
+
+SESSIONS: list[tuple[str, list[dict]]] = [(f"{SESSION_ID}.jsonl", _EVENTS)]
+
+
+def _exactly_one_real_error(store) -> tuple[bool, str]:
+    with store.sqlite.connect() as conn:
+        rows = conn.execute("SELECT error_snippet FROM events WHERE error_detected = 1").fetchall()
+    snippets = [r["error_snippet"] for r in rows]
+    ok = len(rows) == 1 and "FAILED" in (snippets[0] or "")
+    return ok, f"error_detected rows: {len(rows)} — snippets: {snippets}"
+
+
+ASSERTIONS = [
+    OutputAssertion(
+        description="only the pytest failure counts as an error",
+        predicate=_exactly_one_real_error,
+    )
+]

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -6,6 +6,84 @@ from longhand.extractors.errors import detect_error
 from longhand.extractors.file_refs import extract_file_references
 from longhand.extractors.topics import extract_extensions, extract_keywords
 
+# ─── Error detection: command-context suppressions (v0.13) ──────────────────
+#
+# The paired Bash command tells us whether error-shaped output is noise:
+# probing a maybe-missing path, grepping for the word "Error:", or reading
+# git history that mentions failures. Suppression is per-pattern — every
+# other pattern keeps scanning, so a real error later still registers.
+
+PROBE_ENOENT = "ls: /tmp/definitely-missing: No such file or directory"
+TRACEBACK = (
+    'Traceback (most recent call last):\n  File "/tmp/app.py", line 42, in main\nValueError: boom'
+)
+
+
+def test_probe_command_suppresses_errno_noise():
+    assert (
+        detect_error(PROBE_ENOENT, tool_name="Bash", command="ls /tmp/definitely-missing") is None
+    )
+
+
+def test_no_context_backward_compatible():
+    # The same content with no command context keeps the old behavior.
+    sig = detect_error(PROBE_ENOENT)
+    assert sig is not None and sig.pattern == "bash_common"
+
+
+def test_dev_null_redirect_marks_probe_intent():
+    out = "stat: cannot stat '/x': No such file or directory"
+    assert detect_error(out, command="stat /x 2>/dev/null || echo absent") is None
+
+
+def test_read_probe_suppresses_errno():
+    out = "cat: /etc/missing.conf: No such file or directory"
+    assert detect_error(out, command="cat /etc/missing.conf") is None
+
+
+def test_search_command_suppresses_error_words():
+    # grep-style file:line: prefixes defeat the ^-anchored patterns already;
+    # the unanchored ones (AssertionError, ENOENT text) are what false-fire.
+    out = (
+        "src/retry.py:7:# retries on AssertionError from the flaky mock\n"
+        'src/probe.py:12:msg = "No such file or directory"'
+    )
+    assert detect_error(out, command="rg 'Error' src/") is None
+    assert detect_error(out) is not None  # no context → detected, as before
+
+
+def test_git_read_suppresses_error_words_but_keeps_fatal():
+    log_out = (
+        "commit abc1234\n"
+        "    fix the flaky test\n"
+        "\n"
+        "    AssertionError: boom was showing up in CI logs\n"
+        "    ValueError: now handled gracefully"
+    )
+    assert detect_error(log_out) is not None  # content alone looks like an error
+    assert detect_error(log_out, command="git log") is None
+
+    fatal_out = "fatal: not a git repository (or any of the parent directories): .git"
+    sig = detect_error(fatal_out, command="git log")
+    assert sig is not None and sig.pattern == "panic_fatal"
+
+
+def test_real_error_after_suppressed_noise_still_detected():
+    out = PROBE_ENOENT + "\n" + TRACEBACK
+    sig = detect_error(out, command="ls /tmp/definitely-missing")
+    assert sig is not None and sig.pattern == "python_traceback"
+
+
+def test_non_probe_command_keeps_errno_detection():
+    sig = detect_error(PROBE_ENOENT, command="python3 build.py")
+    assert sig is not None and sig.pattern == "bash_common"
+
+
+def test_path_prefixed_search_binary_is_recognized():
+    out = "src/retry.py:7:# retries on AssertionError from the flaky mock"
+    assert detect_error(out, command="/opt/homebrew/bin/rg 'Error' src/") is None
+
+
 # ─── Error detection ───────────────────────────────────────────────────────
 
 

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -40,6 +40,45 @@ def _payload(result):
         return text
 
 
+# ─── auto-scope threshold + observability ────────────────────────────────────
+
+
+def test_search_auto_scope_is_observable_in_payload(temp_store, sample_session_file, monkeypatch):
+    """When search silently narrows to a matched project, the payload must say
+    so (auto_scoped_to) — the cheap evidence channel for tuning the threshold."""
+    from types import SimpleNamespace
+
+    _ingest(sample_session_file, temp_store)
+    fake = SimpleNamespace(
+        score=mcp_server.AUTO_SCOPE_MIN_SCORE,
+        display_name="test-project",
+        project_id="p_canary",
+    )
+    monkeypatch.setattr(mcp_server, "match_projects", lambda *a, **k: [fake])
+
+    payload = _payload(_call(mcp_server._tool_search, temp_store, {"query": "test-project auth"}))
+
+    assert isinstance(payload, dict)
+    assert payload.get("auto_scoped_to") == "test-project"
+
+
+def test_auto_scope_below_threshold_does_not_scope(temp_store, sample_session_file, monkeypatch):
+    from types import SimpleNamespace
+
+    _ingest(sample_session_file, temp_store)
+    fake = SimpleNamespace(
+        score=mcp_server.AUTO_SCOPE_MIN_SCORE - 0.01,
+        display_name="test-project",
+        project_id="p_canary",
+    )
+    monkeypatch.setattr(mcp_server, "match_projects", lambda *a, **k: [fake])
+
+    payload = _payload(_call(mcp_server._tool_search, temp_store, {"query": "test-project auth"}))
+
+    if isinstance(payload, dict):
+        assert "auto_scoped_to" not in payload
+
+
 # ─── Helpers / dispatch wiring ──────────────────────────────────────────────
 
 


### PR DESCRIPTION
v0.13.0 train, PR 6 of 10 (Promise 5 groundwork — honest metrics).

## detect_error learns what command produced the output
- \`detect_error(content, *, tool_name=None, command=None)\` — kwargs optional, bare calls unchanged. The parser threads both from the paired tool_use.
- \`_COMMAND_CONTEXT_SUPPRESSIONS\` (first-match-wins, **per-pattern** — unsuppressed patterns keep scanning so a real error later in the same output still registers):
  - **search** (\`grep\`/\`rg\`/\`ag\`, path-invoked too) → error-word classes silent (highest-volume false-positive source on the live corpus, 2026-07-09 audit)
  - **git reads** (\`log/show/diff/status/blame/…\`) → error words silent, **\`fatal:\` stays live**
  - **probes** (\`test/[/ls/stat/which/type\`, or any \`2>/dev/null\`) and **read-probes** (\`cat/head/tail\`) → errno noise silent (ENOENT is the answer)
  - \`python_traceback\` stays live everywhere — the one structural, high-signal marker.

## Canary
\`canary_error_false_positives\`: probe ENOENTs + rg output quoting AssertionError/ENOENT text + one real pytest failure → \`error_detected == 1\`, and the one error is the pytest failure.

## MCP auto-scope
\`AUTO_SCOPE_MIN_SCORE = 0.8\` module constant replaces both magic literals (mcp_server search auto-scope + list_sessions staleness resolution) with the trade-off documented; tests pin that \`auto_scoped_to\` is observable in the payload at the threshold and absent below it.

## Tests (TDD, red first)
Per-rule suppression cases (incl. path-prefixed binaries and \`2>/dev/null\` intent), real-error-after-noise, no-context backward compat, non-probe commands keep errno detection, git \`fatal:\` liveness — plus the canary and the two auto-scope payload pins. Note: grep-style \`file:line:\` prefixes already defeat \`^\`-anchored patterns, so the tests use genuinely unanchored matches to stay non-vacuous.

Fieldnote 0002 re-pinned after verifying its cwd-mode attribution rule is untouched.

Gate: ruff + format + mypy + version-sync + full pytest (492 passed, 77.5% cov) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)