### PR TITLE
Upstream-drift canary: doctor 'Transcript format' row + transcript-shapes fixture gate

### DIFF
--- a/.fieldnotes/notes/0002-project-inference-cwd-mode.md
+++ b/.fieldnotes/notes/0002-project-inference-cwd-mode.md
@@ -5,8 +5,8 @@ references:
 - advisory: false
   lines: null
   path: longhand/parser.py
-  pinned_at: '2026-07-11T19:15:34.126886Z'
-  sha: 611c83dca0c9894243068be02cc1955e13a3f72de9c7f075e63aa732c301d5e4
+  pinned_at: '2026-07-11T19:29:10.325279Z'
+  sha: c4e50bbda7b0b0a3c6ed239ba30888a54235aaf5102389c4b15d52d6422574f5
   symbol: null
 session_id: null
 superseded_by: '0006'

--- a/longhand/parser.py
+++ b/longhand/parser.py
@@ -25,6 +25,38 @@ from longhand.types import Event, EventType, FileOperation, Session
 MAX_FILE_SIZE_BYTES = 500 * 1024 * 1024  # 500MB per session file
 MAX_LINE_LENGTH = 50 * 1024 * 1024  # 50MB per JSONL line
 
+# Internal orchestration and auxiliary UI entry types — deliberately not
+# ingested. Each would otherwise be stored as an "unknown" event carrying its
+# full raw_json (12,238 rows — the 3rd-largest event type on a real corpus)
+# while containing nothing recallable. Every member must have a fixture line
+# in tests/fixtures/transcript_shapes/entries.jsonl; real-but-not-ingested
+# types are triaged there instead (TRIAGED_UNKNOWN).
+KNOWN_SKIP_ENTRY_TYPES = frozenset(
+    {
+        "queue-operation",
+        "progress",
+        "last-prompt",
+        "mode",
+        "permission-mode",
+        "attachment",
+        "ai-title",
+        "agent-name",
+    }
+)
+
+# Real upstream entry types we deliberately do NOT parse yet, but preserve as
+# unknown events (raw intact) instead of skipping — visible to doctor, cheap
+# to promote later. Every member needs a fixture line and a reason:
+# - summary: UI-side conversation summary ({"summary": ..., "leafUuid": ...});
+#   duplicative of transcript content, no timeline position. Triaged 2026-07-11.
+# - pr-link: PR created during the session ({"prNumber", "prUrl", ...}).
+#   Genuinely recallable — a promotion candidate for a future git-ops tie-in —
+#   preserved until then. Triaged 2026-07-11 (found by the doctor drift row
+#   on the live corpus the day the row shipped).
+# - worktree-state: worktree orchestration snapshot; cwd/branch data already
+#   lives on events. Triaged 2026-07-11 (same harvest as pr-link).
+TRIAGED_UNKNOWN_ENTRY_TYPES = frozenset({"summary", "pr-link", "worktree-state"})
+
 
 _MAX_UNIQUE_CWDS_SCANNED = 20
 
@@ -353,20 +385,9 @@ class JSONLParser:
         if entry_type == "file-history-snapshot":
             return [self._file_snapshot_event(entry, base_sequence)]
 
-        # Internal orchestration and auxiliary UI state — skip. Each of these
-        # would otherwise be stored as an "unknown" event carrying its full
-        # raw_json (12,238 rows — the 3rd-largest event type on a real
-        # corpus) while containing nothing recallable.
-        if entry_type in {
-            "queue-operation",
-            "progress",
-            "last-prompt",
-            "mode",
-            "permission-mode",
-            "attachment",
-            "ai-title",
-            "agent-name",
-        }:
+        # Internal orchestration and auxiliary UI state — skip (see the
+        # constant's docs and the transcript_shapes fixture corpus).
+        if entry_type in KNOWN_SKIP_ENTRY_TYPES:
             return []
 
         # User messages

--- a/longhand/setup_commands.py
+++ b/longhand/setup_commands.py
@@ -1023,6 +1023,58 @@ def _freshness_status(store: LonghandStore) -> str | None:
     )
 
 
+def _transcript_format_status(store: LonghandStore, days: int = 30) -> str:
+    """Rich-formatted upstream-drift check: unknown transcript entry types.
+
+    Claude Code adds entry types without notice; the parser preserves them as
+    event_type='unknown' rows with raw_json intact. A pile of one NEW type
+    means the transcript format drifted — a newer longhand probably reads it.
+    Types already dispositioned (KNOWN_SKIP_ENTRY_TYPES members stored before
+    the skip existed, or deliberately-preserved TRIAGED_UNKNOWN_ENTRY_TYPES)
+    are excluded — alarming on understood types forever would train users to
+    ignore the row. The fixture corpus in tests/fixtures/transcript_shapes/
+    regression-gates every known type; this row is how new drift surfaces on
+    a live store.
+    """
+    from collections import Counter
+
+    from longhand.parser import KNOWN_SKIP_ENTRY_TYPES, TRIAGED_UNKNOWN_ENTRY_TYPES
+
+    cutoff = (utcnow() - timedelta(days=days)).isoformat()
+    try:
+        with store.sqlite.connect() as conn:
+            rows = conn.execute(
+                "SELECT raw_json FROM events "
+                "WHERE event_type = 'unknown' AND timestamp >= ? LIMIT 500",
+                (cutoff,),
+            ).fetchall()
+    except Exception:
+        return "[dim]—[/dim] could not inspect events"
+
+    # Counter over the raw type in Python — JSON1 availability varies across
+    # bundled SQLites, so no json_extract in the query.
+    dispositioned = KNOWN_SKIP_ENTRY_TYPES | TRIAGED_UNKNOWN_ENTRY_TYPES
+    counter: Counter[str] = Counter()
+    for row in rows:
+        try:
+            entry_type = str(json.loads(row["raw_json"]).get("type", "?"))
+        except Exception:
+            entry_type = "?"
+        if entry_type not in dispositioned:
+            counter[entry_type] += 1
+
+    if not counter:
+        return f"[green]✓[/green] no undispositioned entry types in the last {days} days"
+
+    top = ", ".join(f"{name} ×{n}" for name, n in counter.most_common(3))
+    capped = "+" if len(rows) == 500 else ""
+    return (
+        f"[yellow]⚠[/yellow] {sum(counter.values())}{capped} unrecognized entries in the "
+        f"last {days} days ({top}) — the transcript format may have drifted; "
+        "try [bold]pip install -U longhand[/bold]"
+    )
+
+
 def _hook_errors_status(store: LonghandStore, days: int = 7) -> str:
     """Rich-formatted count of hook-error breadcrumbs in the last `days` days.
 
@@ -1205,6 +1257,11 @@ def doctor() -> None:
     # 5b. Hook failures breadcrumbed by ingest-session's hook mode — freshness
     # says "something is missing"; this row says why.
     table.add_row("Hook errors (7d)", _hook_errors_status(store))
+
+    # 5c. Upstream-drift canary: unknown transcript entry types accumulating
+    # means Claude Code's format moved and this longhand can't read the new
+    # entries yet.
+    table.add_row("Transcript format", _transcript_format_status(store))
 
     # 6. Stats
     stats = store.stats()

--- a/scripts/harvest_entry_shapes.py
+++ b/scripts/harvest_entry_shapes.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Harvest one example line per transcript entry type from local sessions.
+
+Dev tool for the transcript_shapes fixture corpus. Run it when doctor's
+"Transcript format" row goes yellow: it scans ~/.claude/projects for entry
+types, prints one sanitized example line per type NOT already covered by
+tests/fixtures/transcript_shapes/entries.jsonl, and you review + append the
+new lines with a disposition (parse it, add to parser.KNOWN_SKIP_ENTRY_TYPES,
+or triage in test_transcript_shapes.TRIAGED_UNKNOWN with a reason).
+
+Sanitization is aggressive — every string is truncated and content bodies
+are replaced — because fixture lines get committed. Review before pasting.
+
+Usage: python3 scripts/harvest_entry_shapes.py [--all]
+    --all    print an example for every type, not just uncovered ones
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+FIXTURE = (
+    Path(__file__).parent.parent / "tests" / "fixtures" / "transcript_shapes" / "entries.jsonl"
+)
+_MAX_STR = 60
+
+
+def _sanitize(value: object, depth: int = 0) -> object:
+    if depth > 6:
+        return "…"
+    if isinstance(value, str):
+        return value if len(value) <= _MAX_STR else value[:_MAX_STR] + "…"
+    if isinstance(value, dict):
+        return {k: _sanitize(v, depth + 1) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_sanitize(v, depth + 1) for v in value[:3]]
+    return value
+
+
+def main() -> int:
+    show_all = "--all" in sys.argv
+
+    covered: set[str] = set()
+    if FIXTURE.exists() and not show_all:
+        for line in FIXTURE.read_text().splitlines():
+            if line.strip():
+                covered.add(str(json.loads(line).get("type")))
+
+    examples: dict[str, dict] = {}
+    projects_dir = Path.home() / ".claude" / "projects"
+    for jsonl in sorted(projects_dir.glob("*/*.jsonl")):
+        try:
+            with jsonl.open() as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    entry_type = str(entry.get("type", "?"))
+                    if entry_type in covered or entry_type in examples:
+                        continue
+                    examples[entry_type] = _sanitize(entry)  # type: ignore[assignment]
+        except OSError:
+            continue
+
+    if not examples:
+        print("# every observed entry type is already covered by the fixture", file=sys.stderr)
+        return 0
+
+    for entry_type in sorted(examples):
+        print(json.dumps(examples[entry_type], ensure_ascii=False))
+    print(
+        f"# {len(examples)} uncovered type(s): {', '.join(sorted(examples))} — "
+        "sanitize further if needed, then append to the fixture with a disposition",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/fixtures/transcript_shapes/entries.jsonl
+++ b/tests/fixtures/transcript_shapes/entries.jsonl
@@ -1,0 +1,16 @@
+{"type":"user","uuid":"shape-user-1","parentUuid":null,"sessionId":"s-shapes","timestamp":"2026-07-01T10:00:00.000Z","cwd":"/tmp/shapes-project","isSidechain":false,"version":"1.0.44","message":{"role":"user","content":"run the tests and fix whatever breaks"}}
+{"type":"assistant","uuid":"shape-asst-1","parentUuid":"shape-user-1","sessionId":"s-shapes","timestamp":"2026-07-01T10:00:05.000Z","cwd":"/tmp/shapes-project","isSidechain":false,"message":{"role":"assistant","model":"claude-sonnet-5","content":[{"type":"text","text":"Running the suite."},{"type":"thinking","thinking":"Start with the failing module."},{"type":"tool_use","id":"toolu_shape_01","name":"Bash","input":{"command":"pytest -q"}}]}}
+{"type":"user","uuid":"shape-toolres-1","parentUuid":"shape-asst-1","sessionId":"s-shapes","timestamp":"2026-07-01T10:00:09.000Z","cwd":"/tmp/shapes-project","isSidechain":false,"message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_shape_01","content":"4 passed in 0.21s"}]}}
+{"type":"system","uuid":"shape-system-1","parentUuid":null,"sessionId":"s-shapes","timestamp":"2026-07-01T10:00:10.000Z","cwd":"/tmp/shapes-project","isSidechain":false,"content":"Compacted conversation history.","level":"info"}
+{"type":"file-history-snapshot","messageId":"shape-fhs-1","sessionId":"s-shapes","timestamp":"2026-07-01T10:00:11.000Z","snapshot":{"trackedFileBackups":{}},"isSnapshotUpdate":false}
+{"type":"queue-operation","uuid":"shape-queue-1","sessionId":"s-shapes","timestamp":"2026-07-01T10:00:12.000Z","operation":"enqueue","prompt":"next task"}
+{"type":"progress","uuid":"shape-progress-1","sessionId":"s-shapes","timestamp":"2026-07-01T10:00:13.000Z","data":{"type":"agent_progress","message":"working"}}
+{"type":"last-prompt","uuid":"shape-lastprompt-1","sessionId":"s-shapes","timestamp":"2026-07-01T10:00:14.000Z","prompt":"run the tests"}
+{"type":"mode","uuid":"shape-mode-1","sessionId":"s-shapes","timestamp":"2026-07-01T10:00:15.000Z","mode":"default"}
+{"type":"permission-mode","uuid":"shape-permmode-1","sessionId":"s-shapes","timestamp":"2026-07-01T10:00:16.000Z","permissionMode":"acceptEdits"}
+{"type":"attachment","uuid":"shape-attach-1","sessionId":"s-shapes","timestamp":"2026-07-01T10:00:17.000Z","attachment":{"type":"queued_command","prompt":"and lint"}}
+{"type":"ai-title","uuid":"shape-aititle-1","sessionId":"s-shapes","timestamp":"2026-07-01T10:00:18.000Z","title":"Fix failing tests"}
+{"type":"agent-name","uuid":"shape-agentname-1","sessionId":"s-shapes","timestamp":"2026-07-01T10:00:19.000Z","name":"tester"}
+{"type":"summary","summary":"Fixed the auth token refresh by adding a mutex around the cache","leafUuid":"shape-asst-1"}
+{"type":"pr-link","sessionId":"s-shapes","prNumber":42,"prUrl":"https://github.com/example/repo/pull/42","prRepository":"example/repo","timestamp":"2026-07-01T10:00:20.000Z"}
+{"type":"worktree-state","sessionId":"s-shapes","worktreeSession":{"originalCwd":"/tmp/shapes-project","worktreePath":"/tmp/shapes-project/.claude/worktrees/wt-1","worktreeName":"wt-1","worktreeBranch":"worktree-wt-1","originalBranch":"main","originalHeadCommit":"0000000000000000000000000000000000000000","sessionId":"s-shapes"}}

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -440,6 +440,71 @@ def test_hook_errors_status_counts_recent_and_ignores_old(tmp_path: Path):
     assert "hook-errors-*.log" in status
 
 
+# ─── doctor transcript-format drift ──────────────────────────────────────────
+
+
+def test_transcript_format_status_green_when_no_unknowns(tmp_path: Path):
+    from longhand.setup_commands import _transcript_format_status
+    from longhand.storage import LonghandStore
+
+    store = LonghandStore(data_dir=tmp_path / "longhand")
+    status = _transcript_format_status(store)
+    assert "green" in status
+
+
+def test_transcript_format_status_yellow_names_the_drifting_type(tmp_path: Path):
+    from longhand.setup_commands import _transcript_format_status
+    from longhand.storage import LonghandStore
+    from longhand.timeutil import utcnow
+
+    store = LonghandStore(data_dir=tmp_path / "longhand")
+    recent = utcnow().isoformat()
+    with store.sqlite.connect() as conn:
+        for i in range(3):
+            conn.execute(
+                "INSERT INTO events (event_id, session_id, event_type, sequence,"
+                " timestamp, content, raw_json) VALUES (?, 's-drift', 'unknown', ?, ?, '', ?)",
+                (f"unk-{i}", i, recent, json.dumps({"type": "flux-capacitor"})),
+            )
+        # An old unknown outside the 30-day window must not count.
+        conn.execute(
+            "INSERT INTO events (event_id, session_id, event_type, sequence,"
+            " timestamp, content, raw_json) VALUES ('unk-old', 's-drift', 'unknown',"
+            " 99, '2020-01-01T00:00:00+00:00', '', ?)",
+            (json.dumps({"type": "ancient"}),),
+        )
+        conn.commit()
+
+    status = _transcript_format_status(store)
+    assert "yellow" in status
+    assert "flux-capacitor" in status
+    assert "ancient" not in status
+    assert "pip install -U longhand" in status
+
+
+def test_transcript_format_status_ignores_dispositioned_types(tmp_path: Path):
+    """Skip-set rows stored before the skip existed, and deliberately-preserved
+    triaged types, are understood — alarming on them forever would train users
+    to ignore the drift row."""
+    from longhand.setup_commands import _transcript_format_status
+    from longhand.storage import LonghandStore
+    from longhand.timeutil import utcnow
+
+    store = LonghandStore(data_dir=tmp_path / "longhand")
+    recent = utcnow().isoformat()
+    with store.sqlite.connect() as conn:
+        for i, entry_type in enumerate(["attachment", "summary", "pr-link"]):
+            conn.execute(
+                "INSERT INTO events (event_id, session_id, event_type, sequence,"
+                " timestamp, content, raw_json) VALUES (?, 's-known', 'unknown', ?, ?, '', ?)",
+                (f"known-{i}", i, recent, json.dumps({"type": entry_type})),
+            )
+        conn.commit()
+
+    status = _transcript_format_status(store)
+    assert "green" in status
+
+
 # ─── doctor freshness ──────────────────────────────────────────────────────
 
 

--- a/tests/test_transcript_shapes.py
+++ b/tests/test_transcript_shapes.py
@@ -1,0 +1,90 @@
+"""Upstream-drift regression gate: the transcript-shapes fixture corpus.
+
+Claude Code adds transcript entry types without notice. Every type we know
+about must be explicitly dispositioned — parsed into events, skipped by
+`parser.KNOWN_SKIP_ENTRY_TYPES`, or triaged in `TRIAGED_UNKNOWN` with a
+written reason — and this suite fails the moment a fixture line isn't.
+
+The loop closes with doctor: unknown-event buildup turns the "Transcript
+format" row yellow, `scripts/harvest_entry_shapes.py` harvests the new
+shape, the line lands here, and the disposition becomes a reviewed diff
+instead of silent unknown-event bloat.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from longhand import parser as parser_mod
+from longhand.parser import JSONLParser
+from longhand.types import EventType
+
+FIXTURE = Path(__file__).parent / "fixtures" / "transcript_shapes" / "entries.jsonl"
+
+# Entry types the parser turns into Events.
+KNOWN_HANDLED = {"user", "assistant", "system", "file-history-snapshot"}
+
+# The triage registry lives in the parser (single source of truth — doctor's
+# drift row excludes dispositioned types too). Adding a member there is a
+# decision, not a dodge: every entry needs a fixture line and a written reason.
+TRIAGED_UNKNOWN = parser_mod.TRIAGED_UNKNOWN_ENTRY_TYPES
+
+
+def _fixture_entries() -> list[dict]:
+    return [json.loads(line) for line in FIXTURE.read_text().splitlines() if line.strip()]
+
+
+def test_every_fixture_type_is_dispositioned():
+    known = KNOWN_HANDLED | parser_mod.KNOWN_SKIP_ENTRY_TYPES | TRIAGED_UNKNOWN
+    for entry in _fixture_entries():
+        entry_type = entry.get("type")
+        assert entry_type in known, (
+            f"fixture entry type {entry_type!r} has no disposition — parse it, add it "
+            "to parser.KNOWN_SKIP_ENTRY_TYPES, or triage it in TRIAGED_UNKNOWN with a reason"
+        )
+
+
+def test_fixture_covers_every_skip_set_member():
+    fixture_types = {e.get("type") for e in _fixture_entries()}
+    missing = parser_mod.KNOWN_SKIP_ENTRY_TYPES - fixture_types
+    assert not missing, f"skip-set members without a fixture line: {sorted(missing)}"
+
+
+def test_fixture_covers_every_handled_type():
+    fixture_types = {e.get("type") for e in _fixture_entries()}
+    missing = KNOWN_HANDLED - fixture_types
+    assert not missing, f"handled types without a fixture line: {sorted(missing)}"
+
+
+def test_fixture_covers_every_triaged_type():
+    fixture_types = {e.get("type") for e in _fixture_entries()}
+    missing = TRIAGED_UNKNOWN - fixture_types
+    assert not missing, f"triaged types without a fixture line: {sorted(missing)}"
+
+
+def test_skip_and_triage_sets_are_disjoint():
+    overlap = parser_mod.KNOWN_SKIP_ENTRY_TYPES & TRIAGED_UNKNOWN
+    assert not overlap, f"a type cannot be both skipped and preserved: {sorted(overlap)}"
+
+
+def test_fixture_parses_with_expected_dispositions(tmp_path: Path):
+    """End-to-end: handled types produce events, skipped types produce none,
+    triaged types land as preserved unknown events."""
+    target = tmp_path / "shapes.jsonl"
+    target.write_text(FIXTURE.read_text())
+
+    events = list(JSONLParser(target).parse_events())
+
+    produced = {e.event_type for e in events}
+    assert EventType.USER_MESSAGE in produced
+    assert EventType.ASSISTANT_TEXT in produced
+    assert EventType.TOOL_CALL in produced
+    assert EventType.TOOL_RESULT in produced
+    assert EventType.SYSTEM in produced
+    assert EventType.FILE_SNAPSHOT in produced
+
+    # Triaged types are preserved as unknown events — raw intact, visible to
+    # doctor — and nothing else leaks into the unknown bucket.
+    unknown_types = {e.raw.get("type") for e in events if e.event_type == EventType.UNKNOWN}
+    assert unknown_types == set(TRIAGED_UNKNOWN)


### PR DESCRIPTION
v0.13.0 train, PR 7 of 10 — Promise 4's named artifacts (upstream drift is never silent).

## What
- **parser**: \`KNOWN_SKIP_ENTRY_TYPES\` exported (hoisted from the inline dispatch set) + new \`TRIAGED_UNKNOWN_ENTRY_TYPES\` registry — real upstream types deliberately preserved as unknown events (raw intact, promotable) rather than skipped, each with a written reason.
- **doctor "Transcript format" row**: counts recent (30d) \`event_type='unknown'\` rows by raw type (SQL LIMIT 500 on \`idx_events_type\`, Counter in Python — no \`json_extract\`, JSON1 availability varies). Dispositioned types are excluded so the row alarms **only on new drift** — otherwise legacy skip-set rows would keep it yellow forever and train users to ignore it.
- **Fixture gate** \`tests/fixtures/transcript_shapes/entries.jsonl\` + \`tests/test_transcript_shapes.py\`: every fixture type must be parsed / skipped / triaged; the fixture must cover every set member; the sets must be disjoint; end-to-end parse pins each disposition's behavior.
- **\`scripts/harvest_entry_shapes.py\`**: when the row goes yellow, harvests one sanitized example line per uncovered type.

## The mechanism worked on day one
The plan predicted first-run triage of \`summary\`. Running the new row against the live corpus **also caught \`pr-link\` (×19) and \`worktree-state\` — two real upstream types nobody knew about** — which were harvested and triaged in this same PR (\`pr-link\` is flagged as a promotion candidate; PR URLs are genuinely recallable). Live doctor now reads green: every unknown on the corpus is understood.

## Tests (TDD, red first)
Disposition/coverage/disjointness gates, end-to-end fixture parse (handled → events, skipped → nothing, triaged → preserved unknowns), doctor row green/yellow/window/dispositioned-types cases.

Gate: ruff + format + mypy + version-sync + full pytest (501 passed, 77.5% cov) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)