### PR TITLE
CLI surface consolidation: status absorbs recap/continue, LONGHAND_DATA_DIR, --json

### DIFF
--- a/longhand/cli/_commands.py
+++ b/longhand/cli/_commands.py
@@ -78,10 +78,13 @@ _UPDATE_CHECK_EXCLUDED = {
     "__prompt-hook-run",
     "backfill-episodes",
     "context",
+    "continue",
     "ingest-live",
     "ingest-session",
     "mcp-server",
+    "patterns",
     "reanalyze",
+    "recap",
 }
 
 
@@ -448,7 +451,12 @@ def ingest(
 # -----------------------------------------------------------------------------
 
 
-@app.command(rich_help_panel="Data")
+@app.command(
+    rich_help_panel="Data",
+    epilog="See also: longhand reattribute — re-derives project ownership for "
+    "sessions already in the database; reconcile re-ingests transcripts that "
+    "never made it in.",
+)
 def reconcile(
     data_dir: str | None = typer.Option(None, "--data-dir", help="Longhand data directory"),
     fix: bool = typer.Option(
@@ -1070,7 +1078,12 @@ def analyze(
         release_ingest_lock(store)
 
 
-@app.command(rich_help_panel="Data")
+@app.command(
+    rich_help_panel="Data",
+    epilog="See also: longhand reconcile — re-ingests transcripts missing from "
+    "the database; reattribute re-derives project ownership for sessions "
+    "already in it.",
+)
 def reattribute(
     fix: bool = typer.Option(
         False,
@@ -2031,16 +2044,17 @@ def _session_to_markdown(store, session_id: str) -> str:
 # -----------------------------------------------------------------------------
 
 
-@app.command(rich_help_panel="Browse & insights")
+@app.command(hidden=True, rich_help_panel="Browse & insights")
 def patterns(
     limit: int = typer.Option(10, "--limit", "-n", help="Top N pattern groups to show"),
     min_count: int = typer.Option(2, "--min", help="Minimum episode count per pattern"),
     data_dir: str | None = typer.Option(None, "--data-dir"),
 ):
-    """Show recurring fix patterns across all episodes — bugs you keep fixing.
+    """Deprecated — use `longhand recall "<topic>"`. Removed in v1.0.
 
     Groups episodes by error category and shared keywords from problem descriptions.
     """
+    _deprecated("patterns", 'recall "<topic>"')
     import json as _json
     import re as _re
     from collections import defaultdict
@@ -2159,19 +2173,17 @@ def patterns(
 # -----------------------------------------------------------------------------
 
 
-@app.command(rich_help_panel="Recall")
-def recap(
-    days: int = typer.Option(7, "--days", "-d", help="How far back to look"),
-    limit: int = typer.Option(10, "--limit", "-n"),
-    project: str | None = typer.Option(
-        None, "--project", "-p", help="Filter by project id or name"
-    ),
-    data_dir: str | None = typer.Option(None, "--data-dir"),
-):
-    """Show what you've been working on recently — sessions + outcomes + latest context."""
+def _recap_digest(
+    store,
+    days: int,
+    limit: int,
+    project: str | None,
+    json_out: bool = False,
+) -> None:
+    """Recent-work digest — the body behind bare `status` (and the deprecated
+    `recap` alias until it is removed at 1.0)."""
+    import json as _json
     from datetime import timedelta, timezone
-
-    store = _get_store(data_dir)
 
     since = (datetime.now(timezone.utc) - timedelta(days=days)).isoformat()
 
@@ -2192,6 +2204,9 @@ def recap(
     )
 
     if not sessions:
+        if json_out:
+            print(_json.dumps({"mode": "digest", "days": days, "sessions": []}))
+            return
         console.print(
             f"[yellow]No sessions in the last {days} days"
             + (f" for project '{project}'" if project else "")
@@ -2201,23 +2216,10 @@ def recap(
 
     sessions = sessions[:limit]
 
-    header_title = f"Recap — last {days} days"
-    if project:
-        header_title += f" · {project}"
-    console.print(Panel.fit(f"[bold]{header_title}[/bold]", border_style="cyan"))
-    console.print()
-
+    entries: list[dict] = []
     for s in sessions:
         sid = s["session_id"]
         outcome = store.sqlite.get_outcome(sid)
-        outcome_str = outcome["outcome"] if outcome else "—"
-        outcome_color = {
-            "shipped": "green",
-            "fixed": "green",
-            "stuck": "red",
-            "abandoned": "dim",
-            "exploratory": "blue",
-        }.get(outcome_str, "white")
 
         # Get project info if available
         project_name = "—"
@@ -2237,32 +2239,80 @@ def recap(
 
         # Episode count for this session
         eps = store.sqlite.query_episodes(session_id=sid, limit=100)
-        resolved = sum(1 for e in eps if e.get("status") == "resolved")
 
-        # Header line
-        header = Text()
-        header.append(f"{_format_timestamp(s['started_at'])}  ", style="dim")
-        header.append(f"{sid[:8]}  ", style="cyan")
-        header.append(f"[{outcome_str}]", style=outcome_color)
-        header.append(f"  {project_name}", style="magenta")
-        if eps:
-            header.append(f"  {resolved}/{len(eps)} episodes", style="yellow")
-        console.print(header)
-
-        if first_user_msg:
-            console.print(f"  [dim]>[/dim] {first_user_msg}")
-
+        topics: list[str] = []
         if outcome and outcome.get("topics_json"):
-            import json as _json
-
             try:
                 topics = _json.loads(outcome["topics_json"])[:5]
-                if topics:
-                    console.print(f"  [dim]topics:[/dim] {', '.join(topics)}")
             except Exception:
                 pass
 
+        entries.append(
+            {
+                "session_id": sid,
+                "started_at": s["started_at"],
+                "outcome": outcome["outcome"] if outcome else None,
+                "project": project_name,
+                "episodes_total": len(eps),
+                "episodes_resolved": sum(1 for e in eps if e.get("status") == "resolved"),
+                "first_user_message": first_user_msg,
+                "topics": topics,
+            }
+        )
+
+    if json_out:
+        print(_json.dumps({"mode": "digest", "days": days, "sessions": entries}, indent=2))
+        return
+
+    header_title = f"Status — last {days} days"
+    if project:
+        header_title += f" · {project}"
+    console.print(Panel.fit(f"[bold]{header_title}[/bold]", border_style="cyan"))
+    console.print()
+
+    for entry in entries:
+        outcome_str = entry["outcome"] or "—"
+        outcome_color = {
+            "shipped": "green",
+            "fixed": "green",
+            "stuck": "red",
+            "abandoned": "dim",
+            "exploratory": "blue",
+        }.get(outcome_str, "white")
+
+        header = Text()
+        header.append(f"{_format_timestamp(entry['started_at'])}  ", style="dim")
+        header.append(f"{entry['session_id'][:8]}  ", style="cyan")
+        header.append(f"[{outcome_str}]", style=outcome_color)
+        header.append(f"  {entry['project']}", style="magenta")
+        if entry["episodes_total"]:
+            header.append(
+                f"  {entry['episodes_resolved']}/{entry['episodes_total']} episodes",
+                style="yellow",
+            )
+        console.print(header)
+
+        if entry["first_user_message"]:
+            console.print(f"  [dim]>[/dim] {entry['first_user_message']}")
+
+        if entry["topics"]:
+            console.print(f"  [dim]topics:[/dim] {', '.join(entry['topics'])}")
+
         console.print()
+
+
+@app.command(hidden=True, rich_help_panel="Recall")
+def recap(
+    days: int = typer.Option(7, "--days", "-d", help="How far back to look"),
+    limit: int = typer.Option(10, "--limit", "-n"),
+    project: str | None = typer.Option(
+        None, "--project", "-p", help="Filter by project id or name"
+    ),
+    data_dir: str | None = typer.Option(None, "--data-dir"),
+):
+    """Deprecated alias for `longhand status`. Removed in v1.0."""
+    _deprecated("recap", "status --days N")
+    _recap_digest(_get_store(data_dir), days, limit, project)
 
 
 # -----------------------------------------------------------------------------
@@ -2272,26 +2322,67 @@ def recap(
 
 @app.command("status", rich_help_panel="Recall")
 def status_cmd(
-    project: str = typer.Argument(..., help="Project name (fuzzy match)"),
-    commits: int = typer.Option(10, "--commits", "-c", help="Max recent commits to show"),
-    episodes: int = typer.Option(5, "--episodes", "-e", help="Max recent episodes"),
+    project: str | None = typer.Argument(
+        None, help="Project name (fuzzy match) — where that project left off"
+    ),
+    session: str | None = typer.Option(
+        None, "--session", "-s", help="Session ID prefix — resume one session"
+    ),
+    days: int = typer.Option(7, "--days", "-d", help="Digest window for bare `status`"),
+    limit: int = typer.Option(10, "--limit", "-n", help="Digest session cap for bare `status`"),
+    digest_project: str | None = typer.Option(
+        None, "--project", "-p", help="Filter the bare-status digest by project"
+    ),
+    events: int = typer.Option(10, "--events", help="Events to show with --session"),
+    commits: int = typer.Option(10, "--commits", "-c", help="Max recent commits (project mode)"),
+    episodes: int = typer.Option(5, "--episodes", "-e", help="Max recent episodes (project mode)"),
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output"),
     data_dir: str | None = typer.Option(None, "--data-dir"),
 ):
-    """Show where a project left off — recent commits, issues, and context."""
-    from longhand.recall.recall_pipeline import recall_project_status
+    """Where things stand — the single resume command (git-status shape).
+
+    Bare `status`: recent-work digest. `status <project>`: where that project
+    left off (commits, issues, context). `status --session <prefix>`: the tail
+    of one session so you can pick up where you left off.
+    """
+    import json as _json
+
+    if project and session:
+        console.print("[red]Pass a project OR --session, not both.[/red]")
+        raise typer.Exit(2)
 
     store = _get_store(data_dir)
-    result = recall_project_status(
-        store,
-        project,
-        max_commits=commits,
-        max_episodes=episodes,
-    )
-    if not result:
-        console.print(f"[red]No project matching: {project}[/red]")
-        raise typer.Exit(1)
 
-    console.print(Markdown(result.narrative))
+    if session:
+        _session_tail(store, session, events, json_out=json_out)
+        return
+
+    if project:
+        from longhand.recall.recall_pipeline import recall_project_status
+
+        result = recall_project_status(
+            store,
+            project,
+            max_commits=commits,
+            max_episodes=episodes,
+        )
+        if not result:
+            console.print(f"[red]No project matching: {project}[/red]")
+            raise typer.Exit(1)
+
+        if json_out:
+            import dataclasses
+
+            try:
+                payload: dict = dataclasses.asdict(result)
+            except TypeError:
+                payload = {"narrative": result.narrative}
+            print(_json.dumps({"mode": "project", **payload}, indent=2, default=str))
+            return
+        console.print(Markdown(result.narrative))
+        return
+
+    _recap_digest(store, days, limit, digest_project, json_out=json_out)
 
 
 # -----------------------------------------------------------------------------
@@ -2299,14 +2390,9 @@ def status_cmd(
 # -----------------------------------------------------------------------------
 
 
-@app.command("continue", rich_help_panel="Recall")
-def continue_cmd(
-    session_id: str = typer.Argument(..., help="Session ID prefix"),
-    n: int = typer.Option(10, "--events", "-n", help="How many recent events to show"),
-    data_dir: str | None = typer.Option(None, "--data-dir"),
-):
-    """Show the last N events of a session so you can pick up where you left off."""
-    store = _get_store(data_dir)
+def _session_tail(store, session_id: str, n: int, json_out: bool = False) -> None:
+    """Tail one session — the body behind `status --session` (and the
+    deprecated `continue` alias until it is removed at 1.0)."""
 
     sessions_rows = store.sqlite.list_sessions(limit=1000)
     full_id = None
@@ -2330,6 +2416,33 @@ def continue_cmd(
 
     outcome = store.sqlite.get_outcome(full_id)
 
+    # Grab all events then take the last n (excluding thinking for readability)
+    all_events = store.sqlite.get_events(session_id=full_id, limit=10000)
+    visible_events = [
+        e
+        for e in all_events
+        if e["event_type"] not in ("assistant_thinking", "file_snapshot", "system")
+    ]
+    recent = visible_events[-n:]
+
+    if json_out:
+        import json as _json
+
+        print(
+            _json.dumps(
+                {
+                    "mode": "session",
+                    "session": dict(session_row),
+                    "project": project_name,
+                    "outcome": dict(outcome) if outcome else None,
+                    "events": [dict(e) for e in recent],
+                },
+                indent=2,
+                default=str,
+            )
+        )
+        return
+
     header_lines = [
         f"[bold]{full_id}[/bold]",
         f"[dim]Project:[/dim] {project_name}",
@@ -2341,15 +2454,6 @@ def continue_cmd(
         header_lines.append(f"[dim]Outcome:[/dim] {outcome['outcome']}")
     console.print(Panel.fit("\n".join(header_lines), title="Session", border_style="cyan"))
     console.print()
-
-    # Grab all events then take the last n (excluding thinking for readability)
-    all_events = store.sqlite.get_events(session_id=full_id, limit=10000)
-    visible_events = [
-        e
-        for e in all_events
-        if e["event_type"] not in ("assistant_thinking", "file_snapshot", "system")
-    ]
-    recent = visible_events[-n:]
 
     if not recent:
         console.print("[yellow]No visible events in session.[/yellow]")
@@ -2400,6 +2504,17 @@ def continue_cmd(
                 border_style="yellow",
             )
         )
+
+
+@app.command("continue", hidden=True, rich_help_panel="Recall")
+def continue_cmd(
+    session_id: str = typer.Argument(..., help="Session ID prefix"),
+    n: int = typer.Option(10, "--events", "-n", help="How many recent events to show"),
+    data_dir: str | None = typer.Option(None, "--data-dir"),
+):
+    """Deprecated alias for `longhand status --session`. Removed in v1.0."""
+    _deprecated("continue", "status --session <prefix>")
+    _session_tail(_get_store(data_dir), session_id, n)
 
 
 # -----------------------------------------------------------------------------
@@ -2574,25 +2689,25 @@ def mcp_uninstall_cmd():
     _mcp_uninstall()
 
 
-@mcp_app.command("serve")
-def mcp_serve_cmd():
-    """Run the MCP server (stdio). Used by Claude Desktop."""
+def _run_mcp_server() -> None:
     import asyncio
 
     from longhand.mcp_server import main as mcp_main
 
     asyncio.run(mcp_main())
+
+
+@mcp_app.command("serve")
+def mcp_serve_cmd():
+    """Run the MCP server (stdio). Used by Claude Desktop."""
+    _run_mcp_server()
 
 
 # Short alias so `longhand mcp-server` also works (matches install command)
 @app.command("mcp-server", hidden=True)
 def mcp_server_cmd():
     """Run the MCP server (stdio). Used by Claude Desktop."""
-    import asyncio
-
-    from longhand.mcp_server import main as mcp_main
-
-    asyncio.run(mcp_main())
+    _run_mcp_server()
 
 
 @app.command("ingest-session", hidden=True)
@@ -2672,9 +2787,11 @@ def ingest_live_cmd(
 
 
 @app.command(rich_help_panel="Setup & health")
-def doctor():
+def doctor(
+    json_out: bool = typer.Option(False, "--json", help="Machine-readable output"),
+):
     """Diagnose Longhand installation and data."""
-    _doctor()
+    _doctor(json_out=json_out)
 
 
 @app.command("reanalyze", hidden=True)

--- a/longhand/demo/runner.py
+++ b/longhand/demo/runner.py
@@ -77,7 +77,7 @@ def run_demo(*, keep: bool = False) -> Path | None:
 
     Args:
         keep: if True, leave the temp dir in place (printed to stdout) so the
-            user can explore further with `LONGHAND_DIR=<path> longhand ...`.
+            user can explore further with `LONGHAND_DATA_DIR=<path> longhand ...`.
             If False (default), clean up at the end.
 
     Returns:
@@ -172,7 +172,9 @@ def run_demo(*, keep: bool = False) -> Path | None:
     # 6. Cleanup
     if keep:
         console.print(f"[yellow]--keep[/yellow]: corpus preserved at [cyan]{demo_root}[/cyan]")
-        console.print(f"  Explore with: [bold]LONGHAND_DIR={store_dir} longhand sessions[/bold]")
+        console.print(
+            f"  Explore with: [bold]LONGHAND_DATA_DIR={store_dir} longhand sessions[/bold]"
+        )
         return demo_root
     else:
         shutil.rmtree(demo_root, ignore_errors=True)

--- a/longhand/redaction.py
+++ b/longhand/redaction.py
@@ -184,9 +184,10 @@ def redact_event(event: Event) -> int:
 
 def redaction_enabled() -> bool:
     """Read redact.enabled from ~/.longhand/config.json. Default: off."""
-    from pathlib import Path
 
-    config_path = Path.home() / ".longhand" / "config.json"
+    from longhand.storage.store import resolve_data_dir
+
+    config_path = resolve_data_dir() / "config.json"
     try:
         if config_path.exists():
             user = json.loads(config_path.read_text())

--- a/longhand/setup_commands.py
+++ b/longhand/setup_commands.py
@@ -264,7 +264,9 @@ def _load_hook_config() -> dict:
     """Load hook configuration from ~/.longhand/config.json, falling back to defaults."""
     import json as _json
 
-    config_path = Path.home() / ".longhand" / "config.json"
+    from longhand.storage.store import resolve_data_dir
+
+    config_path = resolve_data_dir() / "config.json"
     config = dict(_DEFAULT_HOOK_CONFIG)
     try:
         if config_path.exists():
@@ -410,6 +412,11 @@ RECONCILER_INTERVAL_SECONDS = 30 * 60  # 30 minutes
 
 
 def _reconciler_plist_xml(longhand_bin: str, log_path: Path) -> str:
+    # launchd does not inherit shell env: bake the resolved data dir in, or a
+    # LONGHAND_DATA_DIR-relocated store would be invisible to the reconciler.
+    from longhand.storage.store import resolve_data_dir
+
+    data_dir = resolve_data_dir()
     return f"""<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -432,6 +439,11 @@ def _reconciler_plist_xml(longhand_bin: str, log_path: Path) -> str:
     <string>{log_path}</string>
     <key>ProcessType</key>
     <string>Background</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>LONGHAND_DATA_DIR</key>
+        <string>{data_dir}</string>
+    </dict>
 </dict>
 </plist>
 """
@@ -462,7 +474,9 @@ def schedule_install_reconciler() -> None:
         )
         raise typer.Exit(1)
 
-    logs_dir = Path.home() / ".longhand" / "logs"
+    from longhand.storage.store import resolve_data_dir as _resolve
+
+    logs_dir = _resolve() / "logs"
     logs_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
     log_path = logs_dir / "reconcile.log"
 
@@ -580,11 +594,11 @@ def mcp_uninstall() -> None:
 
 
 def _hook_data_dir(data_dir: str | None) -> Path:
-    """Mirror LonghandStore's data-dir choice without constructing a store —
+    """LonghandStore's data-dir choice without constructing a store —
     store-open failures still need somewhere to leave a breadcrumb."""
-    from longhand.storage.store import DEFAULT_DATA_DIR
+    from longhand.storage.store import resolve_data_dir
 
-    return Path(data_dir) if data_dir else DEFAULT_DATA_DIR
+    return resolve_data_dir(data_dir)
 
 
 def _log_hook_error(data_dir: Path, message: str) -> None:
@@ -1115,18 +1129,19 @@ def _human_size(n: int) -> str:
     return f"{size:.1f} TB"
 
 
-def doctor() -> None:
+def doctor(json_out: bool = False) -> None:
     """Diagnose Longhand installation and data."""
-    table = Table(title="Longhand Doctor", show_header=False, border_style="cyan")
-    table.add_column("Check", style="bold")
-    table.add_column("Status")
+    rows: list[tuple[str, str]] = []
+
+    def _row(label: str, value: str) -> None:
+        rows.append((label, value))
 
     # 1. longhand on PATH?
     longhand_bin = shutil.which("longhand")
     if longhand_bin:
-        table.add_row("longhand CLI", f"[green]✓[/green] {longhand_bin}")
+        _row("longhand CLI", f"[green]✓[/green] {longhand_bin}")
     else:
-        table.add_row(
+        _row(
             "longhand CLI",
             "[yellow]⚠[/yellow] not on PATH (run [bold]pip install longhand[/bold])",
         )
@@ -1135,7 +1150,7 @@ def doctor() -> None:
     # HTTPS GET to pypi.org; opt-out via LONGHAND_NO_UPDATE_CHECK=1).
     from longhand import update_check
 
-    table.add_row("Version", update_check.doctor_status())
+    _row("Version", update_check.doctor_status())
 
     # 2. SessionEnd + Stop + UserPromptSubmit hooks installed?
     hook_installed = False
@@ -1160,32 +1175,32 @@ def doctor() -> None:
                 break
 
     if hook_stale:
-        table.add_row(
+        _row(
             "SessionEnd hook",
             "[red]✗[/red] stale — uses pre-0.5.2 $CLAUDE_TRANSCRIPT_PATH "
             "(silently failing). Run [bold]longhand hook install[/bold] to upgrade.",
         )
     elif hook_installed:
-        table.add_row("SessionEnd hook", "[green]✓[/green] installed (final/full ingest)")
+        _row("SessionEnd hook", "[green]✓[/green] installed (final/full ingest)")
     else:
-        table.add_row(
+        _row(
             "SessionEnd hook",
             "[yellow]⚠[/yellow] not installed (run [bold]longhand hook install[/bold])",
         )
 
     if stop_hook_installed:
-        table.add_row("Stop hook", "[green]✓[/green] installed (live tail per turn)")
+        _row("Stop hook", "[green]✓[/green] installed (live tail per turn)")
     else:
-        table.add_row(
+        _row(
             "Stop hook",
             "[yellow]⚠[/yellow] not installed — in-progress sessions invisible. "
             "Run [bold]longhand hook install[/bold].",
         )
 
     if prompt_hook_installed:
-        table.add_row("UserPromptSubmit hook", "[green]✓[/green] installed (auto-context)")
+        _row("UserPromptSubmit hook", "[green]✓[/green] installed (auto-context)")
     else:
-        table.add_row(
+        _row(
             "UserPromptSubmit hook",
             "[yellow]⚠[/yellow] not installed (run [bold]longhand prompt-hook install[/bold])",
         )
@@ -1193,12 +1208,12 @@ def doctor() -> None:
     # 2b. Reconciler launchd job (macOS only)
     if sys.platform == "darwin":
         if RECONCILER_PLIST_PATH.exists():
-            table.add_row(
+            _row(
                 "Reconciler job",
                 "[green]✓[/green] installed (launchd, every 30 min)",
             )
         else:
-            table.add_row(
+            _row(
                 "Reconciler job",
                 "[dim]—[/dim] not installed "
                 "(run [bold]longhand schedule install-reconciler[/bold])",
@@ -1212,9 +1227,9 @@ def doctor() -> None:
             mcp_installed = True
 
     if mcp_installed:
-        table.add_row("Claude Desktop MCP", "[green]✓[/green] installed")
+        _row("Claude Desktop MCP", "[green]✓[/green] installed")
     else:
-        table.add_row(
+        _row(
             "Claude Desktop MCP",
             "[dim]—[/dim] not installed (run [bold]longhand mcp install[/bold])",
         )
@@ -1232,9 +1247,9 @@ def doctor() -> None:
             pass
 
     if cc_mcp_installed:
-        table.add_row("Claude Code MCP", "[green]✓[/green] installed")
+        _row("Claude Code MCP", "[green]✓[/green] installed")
     else:
-        table.add_row(
+        _row(
             "Claude Code MCP",
             "[dim]—[/dim] not installed (run [bold]claude mcp add longhand -s user -- longhand mcp-server[/bold])",
         )
@@ -1242,9 +1257,12 @@ def doctor() -> None:
     # 4. Data directory
     store = LonghandStore()
     data_ok = store.data_dir.exists() and store.data_dir.is_dir()
-    table.add_row(
+    from longhand.storage.store import data_dir_source
+
+    _row(
         "Data directory",
-        f"[green]✓[/green] {store.data_dir}" if data_ok else f"[red]✗[/red] {store.data_dir}",
+        (f"[green]✓[/green] {store.data_dir}" if data_ok else f"[red]✗[/red] {store.data_dir}")
+        + f" [dim](source: {data_dir_source()})[/dim]",
     )
 
     # 5. Recent ingest freshness — detects silently broken hooks. If Claude
@@ -1252,27 +1270,27 @@ def doctor() -> None:
     # the hook is either misconfigured or failing quietly.
     freshness_row = _freshness_status(store)
     if freshness_row:
-        table.add_row("Recent ingest (7d)", freshness_row)
+        _row("Recent ingest (7d)", freshness_row)
 
     # 5b. Hook failures breadcrumbed by ingest-session's hook mode — freshness
     # says "something is missing"; this row says why.
-    table.add_row("Hook errors (7d)", _hook_errors_status(store))
+    _row("Hook errors (7d)", _hook_errors_status(store))
 
     # 5c. Upstream-drift canary: unknown transcript entry types accumulating
     # means Claude Code's format moved and this longhand can't read the new
     # entries yet.
-    table.add_row("Transcript format", _transcript_format_status(store))
+    _row("Transcript format", _transcript_format_status(store))
 
     # 6. Stats
     stats = store.stats()
-    table.add_row("Sessions ingested", f"{stats.get('sessions', 0):,}")
-    table.add_row("Events stored", f"{stats.get('events', 0):,}")
-    table.add_row("Projects inferred", f"{stats.get('projects', 0):,}")
-    table.add_row("Episodes extracted", f"{stats.get('episodes', 0):,}")
+    _row("Sessions ingested", f"{stats.get('sessions', 0):,}")
+    _row("Events stored", f"{stats.get('events', 0):,}")
+    _row("Projects inferred", f"{stats.get('projects', 0):,}")
+    _row("Episodes extracted", f"{stats.get('episodes', 0):,}")
 
     sessions_needing_analysis = max(0, stats.get("sessions", 0) - stats.get("outcomes", 0))
     if sessions_needing_analysis > 0:
-        table.add_row(
+        _row(
             "Sessions needing analysis",
             f"[yellow]{sessions_needing_analysis}[/yellow] (run [bold]longhand analyze --all[/bold])",
         )
@@ -1287,17 +1305,30 @@ def doctor() -> None:
         if chroma_dir.exists()
         else 0
     )
-    table.add_row("Storage", f"SQLite {_human_size(db_size)} · vectors {_human_size(chroma_size)}")
+    _row("Storage", f"SQLite {_human_size(db_size)} · vectors {_human_size(chroma_size)}")
 
     with store.sqlite.connect() as conn:
         aux_events = conn.execute(
             "SELECT COUNT(*) FROM events WHERE event_type = 'unknown'"
         ).fetchone()[0]
     if aux_events > 0:
-        table.add_row(
+        _row(
             "Aux/unknown events",
             f"[yellow]{aux_events:,}[/yellow] stored orchestration noise "
             "(reclaim: [bold]longhand db vacuum --prune-aux[/bold])",
         )
 
+    if json_out:
+        from rich.text import Text as _Text
+
+        print(
+            json.dumps({label: _Text.from_markup(value).plain for label, value in rows}, indent=2)
+        )
+        return
+
+    table = Table(title="Longhand Doctor", show_header=False, border_style="cyan")
+    table.add_column("Check", style="bold")
+    table.add_column("Status")
+    for label, value in rows:
+        table.add_row(label, value)
     console.print(table)

--- a/longhand/storage/store.py
+++ b/longhand/storage/store.py
@@ -7,6 +7,7 @@ SQLite is the source of truth. ChromaDB is the search index.
 from __future__ import annotations
 
 import hashlib
+import os
 from collections.abc import Callable
 from pathlib import Path
 
@@ -24,6 +25,31 @@ from longhand.storage.vector_store import CHROMA_BATCH_SIZE, VectorStore
 from longhand.types import Event, Session
 
 DEFAULT_DATA_DIR = Path.home() / ".longhand"
+
+
+def resolve_data_dir(flag_value: str | Path | None = None) -> Path:
+    """Longhand's data directory — the single resolution rule.
+
+    Precedence: explicit flag/argument > LONGHAND_DATA_DIR env var >
+    ~/.longhand. The env var is what carries a relocated store into hooks,
+    spawned workers, and the MCP server: child processes inherit it, so
+    nothing else needs a flag.
+    """
+    if flag_value:
+        return Path(flag_value)
+    env = os.environ.get("LONGHAND_DATA_DIR", "").strip()
+    if env:
+        return Path(env)
+    return DEFAULT_DATA_DIR
+
+
+def data_dir_source(flag_value: str | Path | None = None) -> str:
+    """Which precedence level won — doctor prints this next to the path."""
+    if flag_value:
+        return "--data-dir flag"
+    if os.environ.get("LONGHAND_DATA_DIR", "").strip():
+        return "LONGHAND_DATA_DIR"
+    return "default"
 
 
 def _build_episode_text(episode: dict) -> str:
@@ -50,7 +76,7 @@ class LonghandStore:
     """Combined storage for Longhand: SQLite (truth) + ChromaDB (search)."""
 
     def __init__(self, data_dir: str | Path | None = None):
-        self.data_dir = Path(data_dir) if data_dir else DEFAULT_DATA_DIR
+        self.data_dir = resolve_data_dir(data_dir)
         self.data_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
 
         self.sqlite = SQLiteStore(self.data_dir / "longhand.db")

--- a/longhand/update_check.py
+++ b/longhand/update_check.py
@@ -43,9 +43,9 @@ def is_disabled() -> bool:
 def cache_path(data_dir: str | Path | None = None) -> Path:
     # Imported lazily: store pulls in chromadb-adjacent modules that this
     # module must not load on the fast --version path.
-    from longhand.storage.store import DEFAULT_DATA_DIR
+    from longhand.storage.store import resolve_data_dir
 
-    base = Path(data_dir) if data_dir else DEFAULT_DATA_DIR
+    base = resolve_data_dir(data_dir)
     return base / "update-check.json"
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,9 @@ def _no_update_check(monkeypatch):
     otherwise refresh the PyPI update cache after every CliRunner invocation.
     Tests that exercise the update check delete this env var explicitly."""
     monkeypatch.setenv("LONGHAND_NO_UPDATE_CHECK", "1")
+    # A developer's real LONGHAND_DATA_DIR must never leak into tests;
+    # tests that exercise the env var set it explicitly.
+    monkeypatch.delenv("LONGHAND_DATA_DIR", raising=False)
 
 
 def _line(entry: dict[str, Any]) -> str:

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -248,6 +248,159 @@ def test_cli_reconcile_detects_null_project_rows(
     assert "1 ingested but project_id IS NULL" in result.stdout
 
 
+# ─── status consolidation + deprecation aliases (v0.13) ─────────────────────
+#
+# `status` is the single resume command, git-status shaped: bare = recent
+# digest, positional = project deep status, --session = one session's tail.
+# recap/continue/patterns become hidden delegating aliases through 0.13 and
+# are deleted at 1.0.
+
+
+def _seed_session(sample_session_file: Path, data_dir: Path) -> str:
+    """Ingest the sample session; return its session_id."""
+    from longhand.setup_commands import ingest_single_session
+    from longhand.storage import LonghandStore
+
+    ingest_single_session(str(sample_session_file), data_dir=str(data_dir), run_analysis=False)
+    store = LonghandStore(data_dir=data_dir)
+    with store.sqlite.connect() as conn:
+        return conn.execute("SELECT session_id FROM sessions").fetchone()[0]
+
+
+def test_status_bare_shows_recent_digest(
+    runner: CliRunner, sample_session_file: Path, tmp_path: Path
+):
+    data_dir = tmp_path / "lh"
+    sid = _seed_session(sample_session_file, data_dir)
+
+    result = runner.invoke(app, ["status", "--days", "3650", "--data-dir", str(data_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert sid[:8] in result.stdout
+
+
+def test_status_unknown_project_still_exits_one(runner: CliRunner, tmp_path: Path):
+    result = runner.invoke(
+        app, ["status", "definitely-no-such-project", "--data-dir", str(tmp_path / "lh")]
+    )
+    assert result.exit_code == 1
+    assert "No project matching" in result.stdout
+
+
+def test_status_session_mode_tails_events(
+    runner: CliRunner, sample_session_file: Path, tmp_path: Path
+):
+    data_dir = tmp_path / "lh"
+    sid = _seed_session(sample_session_file, data_dir)
+
+    result = runner.invoke(app, ["status", "--session", sid[:8], "--data-dir", str(data_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert sid in result.stdout  # full id in the session header
+    assert "Last" in result.stdout  # the event tail rendered
+
+
+def test_status_rejects_project_and_session_together(runner: CliRunner, tmp_path: Path):
+    result = runner.invoke(
+        app,
+        ["status", "someproj", "--session", "abc", "--data-dir", str(tmp_path / "lh")],
+    )
+    assert result.exit_code == 2
+
+
+def test_status_json_digest(runner: CliRunner, sample_session_file: Path, tmp_path: Path):
+    data_dir = tmp_path / "lh"
+    sid = _seed_session(sample_session_file, data_dir)
+
+    result = runner.invoke(app, ["status", "--days", "3650", "--json", "--data-dir", str(data_dir)])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert payload["mode"] == "digest"
+    assert any(s["session_id"] == sid for s in payload["sessions"])
+
+
+def test_recap_alias_delegates_with_deprecation_notice(
+    runner: CliRunner, sample_session_file: Path, tmp_path: Path
+):
+    data_dir = tmp_path / "lh"
+    sid = _seed_session(sample_session_file, data_dir)
+
+    result = runner.invoke(app, ["recap", "--days", "3650", "--data-dir", str(data_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert "deprecated" in result.stdout.lower()
+    assert sid[:8] in result.stdout  # the digest still renders
+
+
+def test_continue_alias_delegates_with_deprecation_notice(
+    runner: CliRunner, sample_session_file: Path, tmp_path: Path
+):
+    data_dir = tmp_path / "lh"
+    sid = _seed_session(sample_session_file, data_dir)
+
+    result = runner.invoke(app, ["continue", sid[:8], "--data-dir", str(data_dir)])
+
+    assert result.exit_code == 0, result.output
+    assert "deprecated" in result.stdout.lower()
+    assert "Last" in result.stdout  # the tail still renders
+
+
+def test_patterns_warns_deprecated_but_still_runs(runner: CliRunner, tmp_path: Path):
+    result = runner.invoke(app, ["patterns", "--data-dir", str(tmp_path / "lh")])
+
+    assert result.exit_code == 0, result.output
+    assert "deprecated" in result.stdout.lower()
+    assert "No episodes" in result.stdout  # the body still ran (deleted at 1.0)
+
+
+def test_deprecated_resume_commands_are_hidden():
+    hidden = {
+        (info.name or info.callback.__name__.replace("_", "-"))
+        for info in app.registered_commands
+        if info.hidden
+    }
+    assert {"recap", "continue", "patterns"} <= hidden
+
+
+def test_hook_config_honors_data_dir_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from longhand.setup_commands import _load_hook_config
+
+    cfg_dir = tmp_path / "env"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.json").write_text(json.dumps({"hook": {"max_episodes": 7}}))
+    monkeypatch.setenv("LONGHAND_DATA_DIR", str(cfg_dir))
+    monkeypatch.setenv("HOME", str(tmp_path))  # the real ~/.longhand must not leak in
+
+    assert _load_hook_config()["max_episodes"] == 7
+
+
+def test_doctor_json_reports_data_dir_and_source(
+    runner: CliRunner, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setenv("LONGHAND_DATA_DIR", str(tmp_path / "lh"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    result = runner.invoke(app, ["doctor", "--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.stdout)
+    assert str(tmp_path / "lh") in payload["Data directory"]
+    assert "LONGHAND_DATA_DIR" in payload["Data directory"]
+
+
+def test_reconciler_plist_bakes_data_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """launchd jobs do not inherit shell env — the plist must carry the
+    resolved data dir explicitly or a relocated store gets missed."""
+    from longhand.setup_commands import _reconciler_plist_xml
+
+    monkeypatch.setenv("LONGHAND_DATA_DIR", str(tmp_path / "relocated"))
+    xml = _reconciler_plist_xml("/usr/local/bin/longhand", tmp_path / "reconcile.log")
+
+    assert "LONGHAND_DATA_DIR" in xml
+    assert str(tmp_path / "relocated") in xml
+
+
 # ─── ingest-lock coverage for the heavy writers ──────────────────────────────
 #
 # analyze / reattribute --fix / redact --apply write into the same SQLite +

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -155,6 +155,9 @@ def test_redaction_disabled_by_default(tmp_path: Path, monkeypatch: pytest.Monke
 
 def test_parser_redacts_when_enabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("HOME", str(tmp_path))
+    # config.json now resolves through resolve_data_dir (env > frozen default),
+    # so relocation in tests goes through the env var.
+    monkeypatch.setenv("LONGHAND_DATA_DIR", str(tmp_path / ".longhand"))
     _enable_redaction(tmp_path)
     assert redaction_enabled() is True
 
@@ -171,6 +174,7 @@ def test_parser_redacts_when_enabled(tmp_path: Path, monkeypatch: pytest.MonkeyP
 
 def test_tail_parse_redacts_when_enabled(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("LONGHAND_DATA_DIR", str(tmp_path / ".longhand"))
     _enable_redaction(tmp_path)
 
     transcript = tmp_path / "session.jsonl"

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -38,6 +38,30 @@ def test_ingest_timestamps_are_utc_aware(sample_session_file, temp_store):
         assert parsed.utcoffset() == timezone.utc.utcoffset(None)
 
 
+def test_resolve_data_dir_precedence(tmp_path, monkeypatch):
+    """flag > LONGHAND_DATA_DIR env > ~/.longhand — the single resolution rule."""
+    from longhand.storage.store import DEFAULT_DATA_DIR, resolve_data_dir
+
+    monkeypatch.delenv("LONGHAND_DATA_DIR", raising=False)
+    assert resolve_data_dir() == DEFAULT_DATA_DIR
+    assert resolve_data_dir(tmp_path / "flag") == tmp_path / "flag"
+
+    monkeypatch.setenv("LONGHAND_DATA_DIR", str(tmp_path / "env"))
+    assert resolve_data_dir() == tmp_path / "env"
+    assert resolve_data_dir(tmp_path / "flag") == tmp_path / "flag"  # flag still wins
+
+
+def test_longhand_store_honors_data_dir_env(tmp_path, monkeypatch):
+    """Env inheritance is what carries a relocated store into hooks, spawned
+    workers, and the MCP server without any of them taking a flag."""
+    from longhand.storage import LonghandStore
+
+    monkeypatch.setenv("LONGHAND_DATA_DIR", str(tmp_path / "env-store"))
+    store = LonghandStore()
+    assert store.data_dir == tmp_path / "env-store"
+    assert (tmp_path / "env-store" / "longhand.db").exists()
+
+
 def test_ingest_and_query_roundtrip(sample_session_file, temp_store):
     parser = JSONLParser(sample_session_file)
     events = list(parser.parse_events())

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -175,6 +175,11 @@ def test_after_command_never_raises(enabled, monkeypatch):
     update_check.after_command()  # must swallow, not raise
 
 
+def test_cache_path_honors_data_dir_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("LONGHAND_DATA_DIR", str(tmp_path / "env"))
+    assert update_check.cache_path() == tmp_path / "env" / "update-check.json"
+
+
 # ─── structural exclusion: hooks and MCP never run the check ─────────────────
 
 


### PR DESCRIPTION
v0.13.0 train, PR 8 of 10 — the deprecation window opens (Promise 1 groundwork).

## status — the single resume command (git-status shape)
- bare \`status\` → recent-work digest (\`--days/-p/--limit\`; formerly \`recap\`)
- \`status <project>\` → unchanged deep project status
- \`status --session <prefix>\` → one session's tail (formerly \`continue\`; \`--events\`)
- positional + \`--session\` together → exit 2 · \`--json\` on all three modes
- \`recap\` / \`continue\` / \`patterns\` → **hidden delegating aliases** that print a deprecation notice and still run through 0.13 (deleted at 1.0); all three in \`_UPDATE_CHECK_EXCLUDED\` (the hidden⊆excluded structural test enforces membership)

## LONGHAND_DATA_DIR
- \`store.resolve_data_dir()\`: **flag > env > ~/.longhand** + \`data_dir_source()\`; consumers: \`LonghandStore\`, update-check cache, hook-config + redaction \`config.json\` readers (lazy imports — the parser hot path must not pull chroma), hook breadcrumbs
- env inheritance carries a relocated store into hooks, spawned workers, and the MCP server — no flags needed
- **reconciler plist bakes the resolved dir** (launchd doesn't inherit shell env — a relocated store was invisible to the reconcile job)
- doctor's Data-directory row names the winning source; the demo's \`LONGHAND_DIR\` suggestion (which never worked) becomes the real variable
- conftest neutralizes a developer's real env var for suite determinism

## Also
\`doctor --json\` (rows refactor, markup stripped) · \`mcp serve\`/\`mcp-server\` share one body · \`reconcile\`/\`reattribute\` cross-reference each other in \`--help\` epilogs.

## Tests (TDD, red first — 13 red)
status three modes + mutual exclusion + \`--json\`, alias delegation + deprecation notices + hidden-flag pin, resolve precedence, store/cache/hook-config env honoring, plist bakes the dir, doctor \`--json\` + source. Two redaction tests moved from HOME-based config injection to the env var (config path no longer re-reads \`Path.home()\` at call time).

Gate: ruff + format + mypy + version-sync + full pytest (516 passed, 79.3% cov) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)