### PR TITLE
MCP surface 19→13: absorptions, deprecation preambles, reconcile warning, docs rewrite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,38 +4,39 @@
 
 When a user asks about past work:
 
-1. **"Do you remember when..."** → Use `recall` FIRST. It handles fuzzy time, project matching, and episode retrieval in one call.
+1. **"Do you remember when..."** → Use `recall` FIRST. It handles fuzzy time, project matching, and retrieval in one call, returning a narrative built from conversation segments and session timelines — plus high-precision problem→fix episodes when the work left clean evidence.
 
-2. **"Find X in session Y"** → Use `search_in_context` with the session_id + natural language query. Returns matches WITH surrounding conversation. Do NOT paginate `get_session_timeline` manually.
+2. **"Find X in session Y"** → Use `search` with `session_id` + `context_events` + a natural-language query. Returns matches WITH surrounding conversation. Do NOT paginate `get_session_timeline` manually.
 
-3. **"What happened in session X?"** → Use `get_session_timeline` with `summary_only: true` first to scan, then `search_in_context` to drill into specifics.
+3. **"What happened in session X?"** → Use `get_session_timeline` with `summary_only: true` first to scan, then `search` (with `session_id` + `context_events`) to drill into specifics. Use `tail: N` for how the session ended or the latest events.
 
 4. **"What file did we edit?"** → Use `get_file_history` or `replay_file`.
 
-5. **"What did we commit?"** → Use `find_commits` (cross-session) or `get_session_commits` (single session).
+5. **"What did we commit?"** → Use `find_commits` — pass a `query` for cross-session search, or a `session_id` with no query for one session's chronological git story.
 
 6. **"Where did we leave off on X?"** → Use `recall_project_status` with the project name. Returns recent commits, unresolved issues, last session outcome, and conversation context in one call. Git-aware when git data exists, degrades gracefully without it.
 
 ## Anti-Patterns (AVOID)
 
-- **Never paginate `get_session_timeline` in a loop** looking for something. Use `search_in_context` or `search` with `session_id` filter instead.
+- **Never paginate `get_session_timeline` in a loop** looking for something. Use `search` with `session_id` + `context_events` instead.
 - **Never use `search` without `session_id`** when you know which session to look in. Unscoped search returns noise from all sessions.
 - **Never skip `recall`** for "do you remember" questions. It was built for exactly this use case.
+- **Don't call the deprecated names** — `search_in_context`, `get_latest_events`, `get_project_timeline`, `get_session_commits`, `get_episode`, `match_project` still answer (with a migration preamble), but the surviving tools take the same parameters directly.
 
 ## Tool Pairing Patterns
 
 ### Pattern A: Find a discussion in a known session (2-3 calls max)
 1. `list_sessions` → identify the session
-2. `search_in_context(session_id, query)` → find the discussion with surrounding context
-3. (Optional) `get_session_timeline` at specific offset if you need more surrounding context
+2. `search(session_id, query, context_events)` → find the discussion with surrounding context
+3. (Optional) `get_session_timeline` at a specific offset if you need even more surrounding context
 
 ### Pattern B: Recall past work across sessions (1-2 calls)
-1. `recall(query)` → get projects, episodes, narrative
-2. (Optional) `search_in_context` to read the raw conversation around an episode
+1. `recall(query)` → get projects, narrative, and any high-precision episodes
+2. (Optional) `search(session_id, context_events)` to read the raw conversation around a result
 
 ### Pattern C: Pick up a project where you left off (1 call)
-1. `recall_project_status(project)` → get recent commits, unresolved issues, last outcome, conversation context
-2. (Optional) `search_in_context` to drill into a specific session from the results
+1. `recall_project_status(project)` → recent commits, unresolved issues, last outcome, conversation context
+2. (Optional) `search(session_id, ...)` to drill into a specific session from the results
 
 ### Pattern D: Investigate a file's history (2 calls)
 1. `get_file_history(file_path)` → see all edits chronologically
@@ -43,10 +44,11 @@ When a user asks about past work:
 
 ## Key Filters
 
-- `search` and `search_in_context` accept: `session_id`, `event_type`, `tool_name`, `file_path_contains`, `project_name`
+- `search` accepts: `session_id`, `event_type`, `tool_name`, `file_path_contains`, `project_id`, `project_name` — plus `context_events` (with `session_id`) to wrap each match in its surrounding conversation
+- `list_sessions` accepts: `project` (path substring) or `project_id` (+ `since`/`until`) for an outcome-enriched project timeline
 - Always use the most specific filter available to reduce noise
 - `session_id` supports prefix matching (first 8 chars is usually enough)
 
 ## Deeper Tools (less common starting points)
 
-Beyond the decision tree above: `get_latest_events` (last N events, reverse-chron), `find_episodes`/`get_episode` (structured episode queries when you already know project/time bounds), `get_session_commits` (commits within one session), `match_project` (fuzzy project-name confirmation with reasons), `list_projects`/`list_plans` (browse), `get_stats` (store health), `reconcile` (re-ingest drift, `fix=true`). Valid tools — just rarely the right first call.
+Beyond the decision tree above: `get_session_timeline` with `tail` (the last N events, replaces get_latest_events), `find_episodes` with `episode_id` (full detail: referenced events, diff, post-fix file state), `list_projects` with `match` (fuzzy candidates with scored reasons — "which project did you mean?"), `list_plans` (browse plan-file writes), `get_stats` (store health), and `reconcile` (re-ingest drift) — **pass `fix` explicitly**: `fix=true` heals now; the implicit default flips to dry-run at v1.0.

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Longhand reads those files. Then it gives you:
 - **Conversation segments** — topic-level clustering (stories, design discussions, debugging, planning) so recall finds the *why*, not just the *what*
 - **Git-aware project recall** — ask "where did we leave off on X" and get recent commits, unresolved issues, last session outcome in one call
 - **Git commit extraction** — structured extraction of every git commit, push, merge, checkout from sessions, linked to episodes
-- **MCP server** — 19 tools that let Claude query Longhand directly during live conversations
+- **MCP server** — 13 tools that let Claude query Longhand directly during live conversations
 - **Auto-ingest hook** — drops into Claude Code's `SessionEnd` hook so new sessions are indexed automatically
 - **Live ingestion** — optional `Stop` hook tails the active transcript between turns so in-flight sessions show up in `recall` immediately
 - **Plan history** — every Write/Edit to `~/.claude/plans/*.md` is captured as a first-class entity, queryable via `longhand plans list` and the `list_plans` MCP tool
@@ -337,34 +337,30 @@ That's one local command. No API call. The fix came from a session file Claude C
 
 ## MCP Integration (Claude Desktop)
 
-Run `longhand mcp install` to wire Longhand into Claude Desktop's config. After you restart Claude Desktop, it has nineteen tools:
+Run `longhand mcp install` to wire Longhand into Claude Desktop's config. After you restart Claude Desktop, it has thirteen tools:
 
 **Core (searchable archive):**
-- `search` — semantic search with session, project, tool, file, and event_type filters (all combinable)
-- `list_sessions` — recent sessions with project/time filters
-- `get_session_timeline` — chronological view with offset/tail pagination and summary-only scan mode
-- `get_latest_events` — most recent events across all sessions, project- and tool-filterable
+- `search` — semantic search with session, project, tool, file, and event_type filters (all combinable); pass `context_events` with a `session_id` to get each match wrapped in its surrounding conversation
+- `list_sessions` — recent sessions with project/time filters; pass `project_id` (plus optional `since`/`until`) for a project's outcome-enriched session timeline
+- `get_session_timeline` — chronological view with offset/tail pagination and summary-only scan mode (`tail: N` covers "the latest events / how did it end")
 - `replay_file` — reconstruct file state at a point in time
 - `get_file_history` — every edit to a file across all sessions
 - `get_stats` — storage statistics
 
 **Proactive memory:**
-- `recall` — fuzzy natural-language recall (use this first)
+- `recall` — fuzzy natural-language recall (use this first): a narrative built from conversation segments and session timelines, with high-precision problem→fix episodes when the work left clean evidence
 - `recall_project_status` — "where did we leave off on X?" — git-aware project summary with commits, issues, last outcome
-- `search_in_context` — find something in a session and get the surrounding conversation
-- `match_project` — find projects by partial name / category / description
-- `find_episodes` — structured search for problem→fix pairs
-- `get_episode` — full detail for one episode including diff + file state
-- `list_projects` — browse inferred projects (compact by default, verbose optional)
-- `get_project_timeline` — session-level timeline for one project
+- `find_episodes` — structured search for problem→fix pairs; pass `episode_id` for full detail on one episode (referenced events, diff, post-fix file state)
+- `list_projects` — browse inferred projects; pass `match` for fuzzy candidates with scored reasons
 - `list_plans` — every Write/Edit to `~/.claude/plans/*.md` across your entire history
 
 **Git history:**
-- `get_session_commits` — all git operations in a session (commits, pushes, checkouts, merges)
-- `find_commits` — search across all sessions by commit message, hash prefix, or branch name
+- `find_commits` — search across all sessions by commit message, hash prefix, or branch name; or pass a `session_id` without a query for one session's chronological git story
 
 **Self-healing:**
-- `reconcile` — wraps `longhand reconcile --fix` so Claude can re-attribute and re-ingest from inside a session after a staleness banner
+- `reconcile` — wraps `longhand reconcile` so Claude can re-attribute and re-ingest from inside a session after a staleness banner; pass `fix` explicitly (the implicit default flips to dry-run at v1.0)
+
+**Deprecated (still answer through 0.x, with a migration preamble; leave the listing at v1.0):** `search_in_context` → `search(context_events)` · `get_latest_events` → `get_session_timeline(tail)` · `get_project_timeline` → `list_sessions(project_id)` · `get_session_commits` → `find_commits(session_id)` · `get_episode` → `find_episodes(episode_id)` · `match_project` → `list_projects(match)`
 
 All tools support `max_chars` output capping with pagination hints. No more 96k dumps crashing your context.
 
@@ -416,7 +412,7 @@ longhand/
 ├── analysis/              — per-session (project, outcomes, episodes, embeddings)
 ├── recall/                — per-query (time parsing, project match, narrative)
 ├── cli.py                 — Typer CLI with Rich output
-├── mcp_server.py          — Model Context Protocol server (19 tools)
+├── mcp_server.py          — Model Context Protocol server (13 tools)
 └── setup_commands.py      — hook install, mcp install, config, doctor
 ```
 
@@ -477,8 +473,8 @@ The single most common question: *does Longhand consume a lot of tokens when Cla
 | Tool | Default output cap | Rough token equivalent |
 |---|---:|---:|
 | `search` | 12,000 chars | ~3,000 tokens |
-| `recall`, `get_session_timeline`, `get_latest_events`, `get_session_commits`, `find_commits` | 12,000–16,000 chars | ~3,000–4,000 tokens |
-| `search_in_context` | 20,000 chars | ~5,000 tokens |
+| `recall`, `get_session_timeline`, `find_commits` | 12,000–16,000 chars | ~3,000–4,000 tokens |
+| `search` in context mode (`context_events`) | 20,000 chars | ~5,000 tokens |
 | Absolute ceiling (`MAX_OUTPUT_CHARS`) | 200,000 chars | ~50,000 tokens |
 
 **Why this matters — the comparison:**

--- a/longhand/mcp_server.py
+++ b/longhand/mcp_server.py
@@ -238,8 +238,9 @@ async def list_tools() -> list[Tool]:
                 "Returns events matching a natural language query, with optional "
                 "filters by event type, session, project, tool, or file path. "
                 "IMPORTANT: Always pass session_id when you know which session to search — "
-                "unscoped search returns noisy results. For finding a discussion WITH "
-                "surrounding conversation context, use search_in_context instead."
+                "unscoped search returns noisy results. To read matches WITH their "
+                "surrounding conversation, pass context_events (requires session_id): "
+                "each match comes back with N events before and after it."
             ),
             inputSchema={
                 "type": "object",
@@ -253,6 +254,10 @@ async def list_tools() -> list[Tool]:
                     "session_id": {
                         "type": "string",
                         "description": "Scope search to a single session (prefix match — first 8 chars usually enough)",
+                    },
+                    "context_events": {
+                        "type": "integer",
+                        "description": "With session_id: return each match wrapped in N surrounding events (the old search_in_context)",
                     },
                     "project_id": {
                         "type": "string",
@@ -293,6 +298,7 @@ async def list_tools() -> list[Tool]:
             name="search_in_context",
             title="Search a Session With Surrounding Context",
             description=(
+                "[DEPRECATED — use search with context_events] "
                 "Search within a specific session and return matches WITH surrounding "
                 "conversation context. This is the tool you want when you know WHICH "
                 "session to look in but need to FIND a specific discussion or event. "
@@ -358,7 +364,9 @@ async def list_tools() -> list[Tool]:
                 "'which sessions touched this project last week?' Filter by project "
                 "path substring to narrow results. NOT for searching content — use "
                 "`search` or `recall` for that. NOT for cross-session git history — "
-                "use `find_commits`. When a `project` filter matches a known project "
+                "use `find_commits`. Pass project_id (with optional since/until) for a "
+                "project's session timeline enriched with outcomes — the old "
+                "get_project_timeline. When a `project` filter matches a known project "
                 "and its on-disk transcripts exceed what's indexed, the response wraps "
                 "a `{stale, stale_reason, sessions}` envelope — call the `reconcile` "
                 "tool to catch up."
@@ -369,6 +377,18 @@ async def list_tools() -> list[Tool]:
                     "project": {
                         "type": "string",
                         "description": "Filter by project path substring (e.g. 'longhand', 'bsoi')",
+                    },
+                    "project_id": {
+                        "type": "string",
+                        "description": "Exact project_id — returns that project's session timeline enriched with outcomes",
+                    },
+                    "since": {
+                        "type": "string",
+                        "description": "ISO date — only sessions after this (with project_id)",
+                    },
+                    "until": {
+                        "type": "string",
+                        "description": "ISO date — only sessions before this (with project_id)",
                     },
                     "limit": {
                         "type": "integer",
@@ -402,8 +422,9 @@ async def list_tools() -> list[Tool]:
             title="Session Event Timeline",
             description=(
                 "Get a chronological timeline of events in a session. Supports session "
-                "id prefix match. Use 'tail' to get only the last N events (great for "
-                "checking how a session ended). Use 'offset' to paginate through long sessions. "
+                "id prefix match. Use 'tail' to get only the last N events — how a "
+                "session ended, the latest user message, the most recent tool call "
+                "(this replaces get_latest_events). Use 'offset' to paginate through long sessions. "
                 "NOT for searching — if you're looking for something specific in a session, "
                 "use search_in_context instead of paginating this tool in a loop."
             ),
@@ -460,6 +481,7 @@ async def list_tools() -> list[Tool]:
             name="get_latest_events",
             title="Latest Events in a Session",
             description=(
+                "[DEPRECATED — use get_session_timeline with tail] "
                 "Get the N most recent events in a session, in reverse chronological order "
                 "(sequence DESC). Use this when you need 'what was the latest X' — e.g., "
                 "the last user message, the last tool call, the last assistant response. "
@@ -619,9 +641,11 @@ async def list_tools() -> list[Tool]:
             description=(
                 "PROACTIVE MEMORY — START HERE for any 'do you remember...' question. "
                 "Handles fuzzy time references ('a couple months ago'), project matching "
-                "('that game project'), and episode retrieval in ONE call. Returns: matched "
-                "projects, relevant episodes (problem→fix pairs), diffs, verbatim thinking "
-                "blocks, reconstructed file states, and a prebuilt markdown narrative. "
+                "('that game project'), and retrieval in ONE call. Returns a prebuilt "
+                "markdown narrative from conversation segments and session timelines, "
+                "plus matched projects and — when the work left clean problem→fix "
+                "evidence — high-precision episodes with diffs, verbatim thinking "
+                "blocks, and reconstructed file states. "
                 "Do NOT manually search and paginate — use this tool first."
             ),
             inputSchema={
@@ -695,7 +719,8 @@ async def list_tools() -> list[Tool]:
                 "and errors. Idempotent — re-running with the same on-disk state is a "
                 "no-op. Acquires the ingest lock — serialized with concurrent ingestion. "
                 "May take 30s+ on cold state because it runs embeddings and episode "
-                "extraction during re-ingest. Pass `fix=false` for a dry-run summary."
+                "extraction during re-ingest. Pass `fix` EXPLICITLY: the implicit "
+                "default is true today but flips to false (dry-run) at v1.0."
             ),
             inputSchema={
                 "type": "object",
@@ -729,6 +754,7 @@ async def list_tools() -> list[Tool]:
             name="match_project",
             title="Fuzzy Project Match",
             description=(
+                "[DEPRECATED — use list_projects with match] "
                 "Fuzzy project matching. Given a partial project name, category, or "
                 "description, returns candidate projects with match reasons. Useful for "
                 "confirming 'which game did you mean?' before drilling into episodes."
@@ -767,14 +793,18 @@ async def list_tools() -> list[Tool]:
             title="Find Problem→Fix Episodes",
             description=(
                 "Structured search for problem→fix episodes. Filters: project_ids, time "
-                "range, keyword, has_fix. Returns raw episode rows. Use this when you "
-                "already know the project or want raw data instead of narrative. NOT "
-                "for narrative recall — use `recall` for that. NOT for full episode "
-                "detail — pass an episode_id to `get_episode` after this."
+                "range, keyword, has_fix. Returns raw episode rows. Pass episode_id "
+                "instead for FULL detail on one episode — referenced events, diff, and "
+                "post-fix file state (the old get_episode). NOT for narrative recall — "
+                "use `recall` for that."
             ),
             inputSchema={
                 "type": "object",
                 "properties": {
+                    "episode_id": {
+                        "type": "string",
+                        "description": "Detail mode: return full detail for exactly this episode (all other filters ignored)",
+                    },
                     "project_ids": {
                         "type": "array",
                         "items": {"type": "string"},
@@ -835,6 +865,7 @@ async def list_tools() -> list[Tool]:
             name="get_episode",
             title="Full Episode Detail (Problem → Fix → Verify)",
             description=(
+                "[DEPRECATED — use find_episodes with episode_id] "
                 "Full detail for one episode by episode_id. Includes all referenced events "
                 "(problem, diagnosis thinking block, fix edit, verification), the diff, "
                 "and the reconstructed file state after the fix. NOT for browsing — call "
@@ -869,6 +900,7 @@ async def list_tools() -> list[Tool]:
             name="get_session_commits",
             title="Get Git Operations from a Session",
             description=(
+                "[DEPRECATED — use find_commits with session_id and no query] "
                 "Returns every git operation (commit, push, pull, checkout, merge, etc.) "
                 "captured during a single Claude Code session, in chronological order. "
                 "Each row carries the timestamp, operation type, branch, hash, and "
@@ -914,17 +946,17 @@ async def list_tools() -> list[Tool]:
             name="find_commits",
             title="Find Commits Across Sessions",
             description=(
-                "Search across all sessions for git commits matching a query — by commit "
-                "message, hash prefix, or branch name. Great for 'find that commit where "
-                "we fixed the parser' queries. NOT for getting every operation in a known "
-                "session — use `get_session_commits` for that."
+                "Search git history captured from sessions. With a query: match commits "
+                "across all sessions by message, hash prefix, or branch name. Without a "
+                "query but with a session_id: every git operation in that session in "
+                "chronological order (the old get_session_commits)."
             ),
             inputSchema={
                 "type": "object",
                 "properties": {
                     "query": {
                         "type": "string",
-                        "description": "Commit message substring, hash prefix, or branch name",
+                        "description": "Optional: commit message substring, hash prefix, or branch name. Omit (with session_id) to list a session's git operations chronologically.",
                     },
                     "session_id": {
                         "type": "string",
@@ -945,7 +977,6 @@ async def list_tools() -> list[Tool]:
                         "description": "Max output characters",
                     },
                 },
-                "required": ["query"],
             },
             outputSchema={
                 "type": "array",
@@ -961,15 +992,19 @@ async def list_tools() -> list[Tool]:
                 "Browse all projects Longhand has inferred from your session history. "
                 "Returns project ID, display name, canonical path, category (cli tool / "
                 "web app / library / etc.), and session count. Filter by keyword (matches "
-                "name, path, aliases) or category. Use this to find a project_id before "
-                "calling get_project_timeline or recall_project_status. Set verbose=true "
-                "to include full metadata (aliases, languages, keywords arrays). NOT for "
-                "session-level activity — use `get_project_timeline` after you have a "
-                "project_id."
+                "name, path, aliases) or category. Pass match for fuzzy matching with "
+                "scored reasons — 'which project did you mean?' (the old match_project). "
+                "Use this to find a project_id before calling recall_project_status or "
+                "list_sessions(project_id=...). Set verbose=true for full metadata "
+                "(aliases, languages, keywords arrays)."
             ),
             inputSchema={
                 "type": "object",
                 "properties": {
+                    "match": {
+                        "type": "string",
+                        "description": "Fuzzy-match mode: partial name/category/description → scored candidates with reasons",
+                    },
                     "keyword": {
                         "type": "string",
                         "description": "Filter: matches project name, path, or aliases",
@@ -1012,6 +1047,7 @@ async def list_tools() -> list[Tool]:
             name="get_project_timeline",
             title="Project Session Timeline",
             description=(
+                "[DEPRECATED — use list_sessions with project_id] "
                 "Session-level timeline for a project — bird's-eye view of what's been "
                 "happening. Returns each session's start/end time, event count, outcome "
                 "(shipped / fixed / stuck / exploratory), and a summary line. Use this "
@@ -1089,6 +1125,10 @@ async def list_tools() -> list[Tool]:
 
 
 async def _tool_search(store: LonghandStore, arguments: dict[str, Any]) -> list[TextContent]:
+    # Context mode absorbs the old search_in_context: same params, 1:1.
+    if arguments.get("context_events") and arguments.get("session_id"):
+        return await _tool_search_in_context(store, arguments)
+
     limit = _limit(arguments.get("limit"), 10)
     max_chars = _max_chars(arguments.get("max_chars"), 12000)
     query = _query(arguments.get("query"))
@@ -1304,6 +1344,11 @@ async def _tool_search_in_context(
 
 
 async def _tool_list_sessions(store: LonghandStore, arguments: dict[str, Any]) -> list[TextContent]:
+    # project_id mode absorbs the old get_project_timeline: same params, 1:1,
+    # outcome enrichment included.
+    if arguments.get("project_id"):
+        return await _tool_get_project_timeline(store, arguments)
+
     project_filter = arguments.get("project")
     rows = store.sqlite.list_sessions(
         project_path=project_filter,
@@ -1627,6 +1672,10 @@ async def _tool_match_project(store: LonghandStore, arguments: dict[str, Any]) -
 
 
 async def _tool_find_episodes(store: LonghandStore, arguments: dict[str, Any]) -> list[TextContent]:
+    # episode_id detail mode absorbs the old get_episode.
+    if arguments.get("episode_id"):
+        return await _tool_get_episode(store, arguments)
+
     # has_fix=True (the default) filters in SQL; False means "no filter",
     # matching the old post-filter semantics (include fixless episodes too).
     # min_confidence defaults to 0.5 — the extractor's floor for episodes
@@ -1707,6 +1756,12 @@ async def _tool_get_session_commits(
 
 
 async def _tool_find_commits(store: LonghandStore, arguments: dict[str, Any]) -> list[TextContent]:
+    # No query + session_id absorbs the old get_session_commits (chronological).
+    if not (arguments.get("query") or "").strip():
+        if not arguments.get("session_id"):
+            return [TextContent(type="text", text="Pass a query, a session_id, or both.")]
+        return await _tool_get_session_commits(store, arguments)
+
     search_session_id = None
     if arguments.get("session_id"):
         search_session_id = _resolve_prefix(store, arguments["session_id"])
@@ -1722,6 +1777,12 @@ async def _tool_find_commits(store: LonghandStore, arguments: dict[str, Any]) ->
 
 
 async def _tool_list_projects(store: LonghandStore, arguments: dict[str, Any]) -> list[TextContent]:
+    # match mode absorbs the old match_project (fuzzy, with scored reasons).
+    if arguments.get("match"):
+        return await _tool_match_project(
+            store, {"query": arguments["match"], "top_k": arguments.get("limit", 5)}
+        )
+
     rows = store.sqlite.list_projects(
         keyword=arguments.get("keyword"),
         category=arguments.get("category"),
@@ -1767,7 +1828,15 @@ async def _tool_reconcile(store: LonghandStore, arguments: dict[str, Any]) -> li
     """
     fix = _bool(arguments.get("fix"), True)
     report = run_reconcile(store, fix=fix)
-    output = json.dumps(report.to_dict(), indent=2, default=str)
+    payload = report.to_dict()
+    if "fix" not in arguments:
+        # The implicit default flips to fix=false (dry-run) at v1.0 — nudge
+        # callers to say what they mean while both behaviors still work.
+        payload["deprecation_warning"] = (
+            "reconcile ran with the implicit default fix=true; at v1.0 the "
+            "default flips to fix=false (dry-run). Pass fix explicitly."
+        )
+    output = json.dumps(payload, indent=2, default=str)
     return [TextContent(type="text", text=output)]
 
 
@@ -1776,25 +1845,50 @@ async def _tool_list_plans(store: LonghandStore, arguments: dict[str, Any]) -> l
     return [TextContent(type="text", text=json.dumps(rows, indent=2, default=str))]
 
 
+# Retired tool → the surviving call shape that replaces it. Through 0.13 the
+# retired names stay in list_tools() with a [DEPRECATED] description prefix;
+# at 1.0 they leave the listing but KEEP answering here forever (with the
+# migration preamble) so stale user CLAUDE.md files never hard-fail.
+_RETIRED_TOOLS: dict[str, str] = {
+    "search_in_context": "search (pass context_events with session_id)",
+    "get_project_timeline": "list_sessions (pass project_id, optionally since/until)",
+    "get_latest_events": "get_session_timeline (pass tail)",
+    "get_session_commits": "find_commits (pass session_id, omit query)",
+    "get_episode": "find_episodes (pass episode_id)",
+    "match_project": "list_projects (pass match)",
+}
+
+
+def _deprecated_tool(name: str, handler: Any) -> Any:
+    """Wrap a retired tool: same behavior, plus a one-line migration preamble."""
+
+    async def _wrapped(store: LonghandStore, arguments: dict[str, Any]) -> list[TextContent]:
+        result = await handler(store, arguments)
+        preamble = f"[DEPRECATED] {name} is retired — use {_RETIRED_TOOLS[name]} instead.\n"
+        return [TextContent(type="text", text=preamble + tc.text) for tc in result]
+
+    return _wrapped
+
+
 _DISPATCH: dict[str, Any] = {
     "search": _tool_search,
-    "search_in_context": _tool_search_in_context,
+    "search_in_context": _deprecated_tool("search_in_context", _tool_search_in_context),
     "list_sessions": _tool_list_sessions,
     "get_session_timeline": _tool_get_session_timeline,
-    "get_latest_events": _tool_get_latest_events,
+    "get_latest_events": _deprecated_tool("get_latest_events", _tool_get_latest_events),
     "replay_file": _tool_replay_file,
     "get_file_history": _tool_get_file_history,
     "get_stats": _tool_get_stats,
     "recall": _tool_recall,
     "recall_project_status": _tool_recall_project_status,
     "reconcile": _tool_reconcile,
-    "match_project": _tool_match_project,
+    "match_project": _deprecated_tool("match_project", _tool_match_project),
     "find_episodes": _tool_find_episodes,
-    "get_episode": _tool_get_episode,
-    "get_session_commits": _tool_get_session_commits,
+    "get_episode": _deprecated_tool("get_episode", _tool_get_episode),
+    "get_session_commits": _deprecated_tool("get_session_commits", _tool_get_session_commits),
     "find_commits": _tool_find_commits,
     "list_projects": _tool_list_projects,
-    "get_project_timeline": _tool_get_project_timeline,
+    "get_project_timeline": _deprecated_tool("get_project_timeline", _tool_get_project_timeline),
     "list_plans": _tool_list_plans,
 }
 

--- a/longhand/setup_commands.py
+++ b/longhand/setup_commands.py
@@ -564,7 +564,7 @@ def mcp_install() -> None:
             f"[dim]Config:[/dim] {CLAUDE_DESKTOP_CONFIG_PATH}\n"
             f"[dim]Backup:[/dim] {backup or 'n/a'}\n\n"
             f"Restart Claude Desktop to activate. After restart, Claude will have "
-            f"access to [bold]recall[/bold], [bold]match_project[/bold], "
+            f"access to [bold]recall[/bold], [bold]recall_project_status[/bold], "
             f"[bold]find_episodes[/bold], and more.",
             title="MCP installed",
             border_style="green",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.Wynelson94/longhand",
   "title": "Longhand",
-  "description": "Local memory for Claude Code: 19 MCP tools for semantic recall, file replay, project timelines, and git history across your session JSONL \u2014 zero API calls, all local.",
+  "description": "Local memory for Claude Code: 13 MCP tools for semantic recall, file replay, project timelines, and git history across your session JSONL \u2014 zero API calls, all local.",
   "version": "0.12.0",
   "repository": {
     "url": "https://github.com/Wynelson94/longhand",

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -40,6 +40,148 @@ def _payload(result):
         return text
 
 
+# ─── MCP 19→13: absorptions + deprecation mechanics (v0.13) ──────────────────
+#
+# Six tools retire into six survivors via strict 1:1 parameter maps. Through
+# 0.13 the retired names stay listed with a [DEPRECATED — use …] description
+# prefix and every payload they return carries a one-line migration preamble.
+# At 1.0 they leave list_tools(); _DISPATCH keeps delegating aliases forever.
+
+RETIRED = {
+    "search_in_context": "search",
+    "get_project_timeline": "list_sessions",
+    "get_latest_events": "get_session_timeline",
+    "get_session_commits": "find_commits",
+    "get_episode": "find_episodes",
+    "match_project": "list_projects",
+}
+
+
+def _tools():
+    return {t.name: t for t in asyncio.run(mcp_server.list_tools())}
+
+
+def test_retired_tools_stay_listed_with_deprecated_prefix():
+    tools = _tools()
+    assert len(tools) == 19  # nothing leaves list_tools() until 1.0
+    for name, survivor in RETIRED.items():
+        assert tools[name].description.startswith("[DEPRECATED — use "), name
+        assert survivor in tools[name].description.splitlines()[0], name
+    for name in set(tools) - set(RETIRED):
+        assert not tools[name].description.startswith("[DEPRECATED"), name
+
+
+def test_retired_payloads_carry_migration_preamble(temp_store, sample_session_file):
+    _ingest(sample_session_file, temp_store)
+
+    result = _call(mcp_server._DISPATCH["match_project"], temp_store, {"query": "test-project"})
+
+    first_line = result[0].text.splitlines()[0]
+    assert first_line.startswith("[DEPRECATED]")
+    assert "list_projects" in first_line
+
+
+def test_search_absorbs_context_mode(temp_store, sample_session_file):
+    session = _ingest(sample_session_file, temp_store)
+
+    result = _call(
+        mcp_server._DISPATCH["search"],
+        temp_store,
+        {"query": "readme", "session_id": session.session_id, "context_events": 2},
+    )
+    payload = _payload(result)
+
+    assert isinstance(payload, dict)
+    assert "context_windows" in payload  # the search_in_context shape
+
+
+def test_list_sessions_absorbs_project_timeline(temp_store, sample_session_file):
+    _ingest(sample_session_file, temp_store)
+    with temp_store.sqlite.connect() as conn:
+        pid = conn.execute("SELECT project_id FROM sessions").fetchone()[0]
+    assert pid, "sample fixture should infer a project"
+
+    payload = _payload(
+        _call(mcp_server._DISPATCH["list_sessions"], temp_store, {"project_id": pid})
+    )
+
+    assert isinstance(payload, list) and payload
+    assert "outcome" in payload[0]  # timeline enrichment came along
+
+
+def test_find_commits_query_is_optional_and_absorbs_session_commits(
+    temp_store, sample_session_file
+):
+    session = _ingest(sample_session_file, temp_store)
+
+    assert _tools()["find_commits"].inputSchema.get("required", []) == []
+
+    payload = _payload(
+        _call(
+            mcp_server._DISPATCH["find_commits"],
+            temp_store,
+            {"session_id": session.session_id},
+        )
+    )
+    assert isinstance(payload, list)  # chronological ops for the session
+
+
+def test_find_episodes_absorbs_episode_detail(temp_store):
+    temp_store.sqlite.insert_episodes(
+        [
+            {
+                "episode_id": "ep-absorb",
+                "session_id": "s-absorb",
+                "project_id": "p-absorb",
+                "started_at": "2026-07-01T10:00:00Z",
+                "ended_at": "2026-07-01T10:30:00Z",
+                "problem_event_id": "pe",
+                "fix_event_id": "fe",
+                "problem_description": "the widget broke",
+                "fix_summary": "reattached the widget",
+                "touched_files": [],
+                "tags": [],
+                "status": "resolved",
+            }
+        ]
+    )
+
+    payload = _payload(
+        _call(mcp_server._DISPATCH["find_episodes"], temp_store, {"episode_id": "ep-absorb"})
+    )
+
+    assert isinstance(payload, dict)
+    assert payload["episode"]["episode_id"] == "ep-absorb"
+
+
+def test_list_projects_absorbs_match(temp_store, sample_session_file):
+    _ingest(sample_session_file, temp_store)
+
+    payload = _payload(
+        _call(mcp_server._DISPATCH["list_projects"], temp_store, {"match": "test-project"})
+    )
+
+    assert isinstance(payload, list) and payload
+    assert "reasons" in payload[0]  # the match_project shape
+
+
+def test_reconcile_implicit_fix_carries_deprecation_warning(temp_store, monkeypatch):
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        mcp_server,
+        "run_reconcile",
+        lambda store, fix: SimpleNamespace(to_dict=lambda: {"missing": 0, "ingested": 0}),
+    )
+
+    implicit = _payload(_call(mcp_server._DISPATCH["reconcile"], temp_store, {}))
+    assert "deprecation_warning" in implicit
+    assert "fix" in implicit["deprecation_warning"]
+
+    explicit = _payload(_call(mcp_server._DISPATCH["reconcile"], temp_store, {"fix": True}))
+    assert "deprecation_warning" not in explicit
+
+
 # ─── auto-scope threshold + observability ────────────────────────────────────
 
 


### PR DESCRIPTION
v0.13.0 train, PR 9 of 10 — the MCP half of the deprecation window (supersedes the June "complementary, not redundant" conclusion per the July design pass).

## Absorptions (strict 1:1 parameter maps, delegating handlers)
| retired | survivor |
|---|---|
| \`search_in_context\` | \`search\` + \`context_events\` (with \`session_id\`) |
| \`get_project_timeline\` | \`list_sessions\` + \`project_id\` (+\`since\`/\`until\`, outcome-enriched) |
| \`get_latest_events\` | \`get_session_timeline\` + \`tail\` |
| \`get_session_commits\` | \`find_commits\` + \`session_id\`, query now optional |
| \`get_episode\` | \`find_episodes\` + \`episode_id\` detail mode |
| \`match_project\` | \`list_projects\` + \`match\` |

## Deprecation mechanics (0.13)
All six stay in \`list_tools()\` with a \`[DEPRECATED — use …]\` description prefix; every payload they return is prepended with a one-line migration preamble (\`_deprecated_tool\` wrapper). At 1.0 they leave the listing but \`_DISPATCH\` keeps the aliases forever — stale user CLAUDE.mds never hard-fail.

## reconcile
Implicit \`fix\` now returns \`deprecation_warning\` in the report (default flips to dry-run at 1.0 — pass \`fix\` explicitly). The launchd reconciler already passes \`--fix\` explicitly and is unaffected.

## Docs (same PR)
Repo CLAUDE.md rewritten around the 13 survivors (decision tree items 2/3/5, anti-patterns incl. don't-call-deprecated-names, pairing patterns, key filters, deeper tools + the reconcile note). README MCP section: 13 active + 6 deprecated with migration arrows, **fixes the long-wrong \`get_latest_events\` description** (it was never cross-session), counts corrected (×3) and the pagination table updated. \`server.json\` description → 13. \`mcp_install\` panel names survivors. \`recall\`'s description now leads with the segments/timeline narrative; episodes are the high-precision signal when clean evidence exists (the honest reframe).

## Tests (TDD, red first — 8 red)
Retired-six listed with prefix + non-retired unprefixed + still 19 listed until 1.0; migration preamble on retired payloads; each absorption exercised end-to-end (context windows shape, outcome enrichment, chronological ops, episode detail, match reasons); \`find_commits\` schema has no required params; reconcile warning present implicitly / absent explicitly.

Gate: ruff + format + mypy + version-sync + full pytest (524 passed, 79.6% cov) green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)