### PR TITLE
docs: post-v0.13.0 refresh — README counts + status-led quick start, SECURITY.md accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/longhand?label=PyPI&color=blue)](https://pypi.org/project/longhand/)
 ![Python](https://img.shields.io/badge/python-3.10+-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
-![Tests](https://img.shields.io/badge/tests-316%20passing-brightgreen)
+![Tests](https://img.shields.io/badge/tests-524%20passing-brightgreen)
 ![Local](https://img.shields.io/badge/100%25-local-informational)
 [![SafeSkill 93/100](https://img.shields.io/badge/SafeSkill-93%2F100_Verified%20Safe-brightgreen)](https://safeskill.dev/scan/wynelson94-longhand)
 
@@ -30,6 +30,15 @@ longhand recall "that stripe webhook bug from last week"
 pip install longhand
 longhand demo         # sandboxed; cleans up afterwards (pass --keep to explore)
 ```
+
+**Upgrading to 0.13.0?** Nothing breaks — this release opens the v1.0 deprecation window, so every old name keeps working while pointing at its replacement:
+
+- `status` is now the single resume command: bare `status` = recent digest (was `recap`), `status <project>` unchanged, `status --session <prefix>` = session tail (was `continue`). The old commands still run and print a pointer; they're removed at v1.0.
+- Six MCP tools folded into six survivors with identical parameters (`search_in_context` → `search` + `context_events`, `get_episode` → `find_episodes` + `episode_id`, etc. — full table in the CHANGELOG). The retired names still answer, prefixed with a migration note.
+- Hooks can no longer exit nonzero — failures become breadcrumbs in `~/.longhand/logs/` and two new `doctor` rows (`Hook errors`, `Transcript format`) keep them visible.
+- "Today"/"yesterday" recall windows now follow your local calendar day instead of UTC's; rankings may shift once if you're not in UTC.
+- Windows users: this release fixes a serious bug where the ingest-lock liveness check could terminate other longhand processes.
+- New: `LONGHAND_DATA_DIR` relocates the store for the CLI, hooks, and MCP server in one move; `status --json` / `doctor --json` for scripting.
 
 **Upgrading to 0.9.0?** Live ingestion captures sessions in flight, plan history is preserved as first-class data, and an optional reconciler job keeps the index honest in the background:
 
@@ -67,7 +76,7 @@ longhand analyze --all           # fill in episodes + vectors whenever, safe to 
 
 Exact-text search, timelines, file history, and commit lookup all work after `--skip-analysis`. Semantic `recall` needs the `analyze --all` pass to complete. Typical throughput on an M-class Mac is ~1–2 sessions/sec for full analysis.
 
-> *Status: v0.13.0 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 281 real Claude Code sessions across 67 inferred projects. 323 unit tests passing.*
+> *Status: v0.13.0 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 339 real Claude Code sessions across 35 inferred projects. 524 unit tests passing.*
 
 **Full docs:** [Longhand Wiki](https://github.com/Wynelson94/longhand/wiki) — getting started, CLI reference, MCP tools reference, architecture, and troubleshooting.
 
@@ -247,13 +256,14 @@ longhand stats
 longhand sessions
 longhand projects
 
-# Daily-use commands
-longhand recap                              # what have I been up to
-longhand recap --days 30 --project bsoi     # filtered recap
-longhand continue <session-id>              # pick up where I left off (session-scoped)
+# Daily-use commands — status is the single resume command (git-status shape)
+longhand status                             # what have I been up to (recent digest)
+longhand status --days 30 -p bsoi           # filtered digest
 longhand status <project-name>              # where did we leave off on a project (git-aware)
-longhand patterns                           # what bugs do I keep fixing
+longhand status --session <session-id>      # pick up where a session left off
 longhand history src/app/route.ts           # every edit ever to a file
+# (recap / continue / patterns still work through 0.x — they print a pointer
+#  to their status/recall replacements and are removed at v1.0)
 
 # Semantic search
 longhand search "race condition"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,8 +4,8 @@ Longhand is a local-first tool that ingests Claude Code session transcripts into
 
 ## TL;DR
 
-- **Local-only.** No network calls. Nothing leaves your machine. The only network activity is the one-time ChromaDB embedding model download (~80MB) and any commands you explicitly invoke (e.g. `git push`).
-- **No shell, no `eval`/`exec`.** Longhand never uses a shell, `os.system`, `os.popen`, `eval`, or `exec`. It does spawn two fixed, list-form subprocesses — `launchctl` (to (un)load the optional reconciler) and `python -m longhand.cli ingest` (a detached background re-ingest) — neither of which interpolates user input or stored data, so the command-injection surface is zero.
+- **Local-only.** Nothing you stored ever leaves your machine. Network activity is limited to: the one-time ChromaDB embedding model download (~80MB), an optional once-daily version check against pypi.org (interactive CLI only — never from hooks or the MCP server, enforced by tests; disable with `LONGHAND_NO_UPDATE_CHECK=1`; the request carries no data beyond the HTTP request itself), and commands you explicitly invoke (e.g. `git push`).
+- **No shell, no `eval`/`exec`.** Longhand never uses a shell, `os.system`, `os.popen`, `eval`, or `exec`. It does spawn fixed, list-form subprocesses — `launchctl` (to (un)load the optional reconciler) and detached background workers (`python -m longhand ingest` / `python -m longhand backfill-episodes`) — none of which interpolates user input or stored data, so the command-injection surface is zero.
 - **Parameterized SQL everywhere.** Every user-supplied value is a bound parameter, never interpolated into SQL. LIKE clauses escape `%` and `_` wildcards. (The one f-string in SQL is `PRAGMA table_info({table})` with a hardcoded internal table name — no user input.)
 - **Bounded inputs.** Stdin readers, file sizes, line lengths, and filter strings are all capped to prevent DoS.
 - **Read-only on the source data.** Longhand never writes back to `~/.claude/projects/` — it only reads JSONL files.
@@ -41,7 +41,7 @@ Anything outside `~/.longhand/` and `~/.claude/projects/` is out of scope. Longh
 
 | Threat                                  | Defense |
 |-----------------------------------------|---------|
-| Command injection via tool output       | No shell, `eval`, or `exec`. The two `subprocess` spawns use fixed, list-form argv (`launchctl …`, `python -m longhand.cli ingest`) with no user- or tool-derived arguments. Tool output is never executed. |
+| Command injection via tool output       | No shell, `eval`, or `exec`. The two `subprocess` spawns use fixed, list-form argv (`launchctl …`, `python -m longhand ingest`) with no user- or tool-derived arguments. Tool output is never executed. |
 | SQL injection via search queries        | All SQL uses parameterized queries. LIKE wildcards escaped with `ESCAPE '\\'`. |
 | Path traversal via file_path filters    | File paths from queries are used only as LIKE substrings against the indexed `events` table. Longhand never opens files based on user input — it only opens JSONL files inside `~/.claude/projects/`. |
 | OOM via huge JSONL files                | Hard 500MB file size limit and 50MB per-line limit in `parser.py`. Lines exceeding the limit are skipped, not parsed. |
@@ -166,7 +166,7 @@ I'd rather hear about it.
 
 A few things that might look suspicious but aren't:
 
-- **`__prompt-hook-run`** is the internal hook handler. It's prefixed with `__` and marked `hidden=True` in Typer so it doesn't show in `--help`. It only reads bounded stdin and only invokes the local recall pipeline. That pipeline may spawn one detached, fixed-argv `python -m longhand.cli ingest` to refresh a stale index (see *Subprocess use — no shell, no injection* above); it never opens network sockets and never reads files outside what the recall pipeline already accesses.
+- **`__prompt-hook-run`** is the internal hook handler. It's prefixed with `__` and marked `hidden=True` in Typer so it doesn't show in `--help`. It only reads bounded stdin and only invokes the local recall pipeline. That pipeline may spawn one detached, fixed-argv `python -m longhand ingest` to refresh a stale index (see *Subprocess use — no shell, no injection* above); it never opens network sockets and never reads files outside what the recall pipeline already accesses.
 - **`__pycache__/` and `*.pyc`** are normal Python bytecode caches, not malicious files.
 - **The `chromadb` dependency pulls in `onnxruntime`** for the local embedding model. ONNX runs in a sandboxed inference graph — it doesn't execute Python. The model itself (`all-MiniLM-L6-v2`) is open and well-known.
 - **The `mcp` dependency is required** because the MCP server ships in the main package. It's a well-known Python client/server library published by Anthropic; see the [mcp package on PyPI](https://pypi.org/project/mcp/).


### PR DESCRIPTION
README: tests badge 316→524, status line 281/67/323→339/35/524 (the
project count SHRANK because the v0.12 attribution overhaul collapsed
junk projects — honest number), Quick Start leads with the status modes
(deprecated names noted), and an 'Upgrading to 0.13.0?' entry tops the
ladder.

SECURITY.md: the 'no network calls' TL;DR predated the v0.12 update
channel — now discloses the optional once-daily pypi.org version check
(CLI-only, never hooks/MCP, test-enforced, env opt-out). The documented
subprocess argv was stale twice over: the spawn target has been
'-m longhand' since v0.11.1 (the '-m longhand.cli' form documented here
dies instantly), and backfill-episodes is a second detached worker.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
