### PR TITLE
docs: correct stale counts — 524 tests, 13 MCP tools, re-measured corpus

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ longhand analyze --all           # fill in episodes + vectors whenever, safe to 
 
 Exact-text search, timelines, file history, and commit lookup all work after `--skip-analysis`. Semantic `recall` needs the `analyze --all` pass to complete. Typical throughput on an M-class Mac is ~1–2 sessions/sec for full analysis.
 
-> *Status: v0.13.0 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 339 real Claude Code sessions across 35 inferred projects. 524 unit tests passing.*
+> *Status: v0.13.0 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 387 real Claude Code sessions across 35 inferred projects. 524 unit tests passing.*
 
 **Full docs:** [Longhand Wiki](https://github.com/Wynelson94/longhand/wiki) — getting started, CLI reference, MCP tools reference, architecture, and troubleshooting.
 
@@ -106,7 +106,7 @@ The "memory crisis" in AI was an artificial constraint. Storage is solved. SQLit
 
 **Local. Complete. Yours.**
 
-> **Storage footprint:** ~2GB for a heavy power user (280+ sessions, 145k events, months of daily Opus usage across 14 repos). Typical users: 200–400MB. Once Claude Code rotates the source files off disk, Longhand isn't a duplicate — it's the only copy.
+> **Storage footprint:** ~4.5GB for a heavy power user (385+ sessions, 180k+ events, months of daily Opus usage across 35 inferred projects). Typical users: 200–400MB. Once Claude Code rotates the source files off disk, Longhand isn't a duplicate — it's the only copy.
 
 ---
 
@@ -456,21 +456,23 @@ Summary memory and Longhand solve different problems. Summary memory is good for
 
 ## Stats
 
-Tested end-to-end on a real Claude Code history:
-- 246 unique sessions
-- 125,745 events
-- 40,937 tool calls
-- 8,333 file edits
+Corpus measured 2026-07-24 against the author's live store on v0.13.0:
+- 387 unique sessions
+- 181,705 events
+- 58,338 tool calls
+- 13,743 file edits
 - 224 thinking blocks
-- 54 projects inferred automatically
-- 905 problem→fix episodes extracted (303 resolved)
-- 4,090 conversation segments (design, story, debugging, discussion, planning)
-- 1,561 git operations extracted (90 commits linked)
-- 77,711 vectors indexed
+- 35 projects inferred automatically
+- 1,033 problem→fix episodes extracted (385 resolved)
+- 3,789 conversation segments (design, story, debugging, discussion, planning)
+- 2,326 git operations extracted (106 commits linked)
+- 128,021 vectors indexed
+- Storage footprint: 4.5 GB total (3.5 GB SQLite + 970 MB ChromaDB) across 387 sessions — ~12 MB per session
+
+Latency, benchmarked on the earlier 246-session corpus (M-class Mac) and not re-measured since:
 - Vector search: ~56ms median (p90 ~62ms)
 - SQL queries (`get_events`): ~2ms median (p90 ~13ms)
 - Full recall pipeline: ~1.4s median, warm (~7 vector queries + artifact load + narrative)
-- Storage footprint: 2.0 GB total (1.4 GB SQLite + 618 MB ChromaDB) across 246 sessions — ~8 MB per session
 
 ---
 
@@ -499,7 +501,7 @@ Longhand is flat-cost: the cap is per-call, not per-corpus. Recalling across 10 
 
 ---
 
-316 unit tests passing. All 19 MCP tools stress-tested. Full security audit: zero critical findings, zero high findings. `~/.longhand/` created with 0700 permissions, all SQL parameterized, all inputs bounded. Dependencies: chromadb, typer, rich, pydantic, mcp.
+524 unit tests passing. All 13 MCP tools stress-tested. Full security audit: zero critical findings, zero high findings. `~/.longhand/` created with 0700 permissions, all SQL parameterized, all inputs bounded. Dependencies: chromadb, typer, rich, pydantic, mcp.
 
 ---
 

--- a/docs/distribution-submissions.md
+++ b/docs/distribution-submissions.md
@@ -89,7 +89,7 @@ https://github.com/hesreallyhim/awesome-claude-code/issues/new?template=recommen
 
 **Description (1-3 sentences, no emojis, descriptive not promotional):**
 
-> Longhand indexes Claude Code's session JSONL files into a local SQLite + ChromaDB database, giving you semantic search, deterministic file replay, and fuzzy recall across your entire history without any API calls. It installs a SessionEnd hook so new sessions auto-ingest, and exposes 17 MCP tools so Claude itself can query your past work during live sessions. Data never leaves the machine.
+> Longhand indexes Claude Code's session JSONL files into a local SQLite + ChromaDB database, giving you semantic search, deterministic file replay, and fuzzy recall across your entire history without any API calls. It installs a SessionEnd hook so new sessions auto-ingest, and exposes 13 MCP tools so Claude itself can query your past work during live sessions. Data never leaves the machine.
 
 **Recommendation checklist** — check all five required boxes:
 - [x] I have verified this resource is unique on the list


### PR DESCRIPTION
## Why

The v0.13.0 docs refresh (#69) fixed the Tests badge (316 → 524) but missed the closing line of the README, 15 lines from the bottom, which still read:

> `316 unit tests passing. All 19 MCP tools stress-tested.`

Both numbers were stale, and the README contradicted its own badge. Found during the post-0.13 bake review.

## What changed

| Claim | Was | Now |
|---|---|---|
| Closing line — tests | 316 | **524** |
| Closing line — MCP tools | 19 | **13** |
| Status line — sessions validated | 339 | **387** |
| Intro storage footprint | ~2GB / 280+ sessions / 145k events | **~4.5GB / 385+ sessions / 180k+ events** |
| Stats block | undated 246-session snapshot | **dated, re-measured 2026-07-24** |
| `distribution-submissions.md` D4 blurb | 17 MCP tools | **13** |

**On "13 MCP tools":** verified against `_DISPATCH` — 19 registrations = 13 survivors + 6 deprecated delegating aliases. 13 is the supported surface, consistent with README:202 and README:425.

**On the Stats block:** it was an undated measurement snapshot from a 246-session corpus, so it read as current. It now carries its measurement date and live `get_stats` figures. The three latency numbers were **not** re-measured, so they are explicitly attributed to the original 246-session benchmark rather than silently inheriting the new date.

**On `distribution-submissions.md`:** D4 (awesome-claude-code) is ready-to-paste copy for a submission that has **not** been made yet, so the wrong count would have gone out. `docs/devto-dogfood-post.md` keeps its "16 MCP tools" — that was accurate when published and is a sent artifact.

## Follow-up

Permanent enforcement is the surface-consistency check already scoped in the v1.0 plan (PR 13): README/CLAUDE.md counts asserted against actual registrations. This PR is the one-time correction; PR 13 is what keeps it correct.

## Verification

- `ruff check` / `ruff format --check` — clean
- `mypy longhand` — no issues, 43 source files
- `pytest -q` — **524 passed** (on Python 3.14.2 locally)
- `check_version_sync.py` — OK, `Status: vX.Y.Z` token untouched by the edit
- `fieldnotes verify` — all 6 notes verified
- Diff is 17/15 lines — proportional, no Markdown reflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)