### PR TITLE
ci: hard-gate Python 3.14 — the SIGILL blocker has cleared

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,22 +43,15 @@ jobs:
           pip install -e ".[dev]"
       - name: Run pytest (with coverage gate)
         id: pytest
-        # 3.14 runs but is non-blocking: onnxruntime's cp314 wheel (via chromadb)
-        # intermittently raises an illegal-instruction SIGILL on GitHub's
-        # heterogeneous runner CPUs. The CPython code is fine (3.14 passes locally
-        # and on most runners); only the native embedding lib is unstable. Keep
-        # 3.10–3.13 gated; surface 3.14 without letting a native crash block PRs.
-        # The Windows leg is likewise non-blocking while it gathers evidence.
-        continue-on-error: ${{ matrix.python-version == '3.14' || matrix.os == 'windows-latest' }}
+        # 3.14 became blocking on 2026-07-24 (issue #40). It was non-blocking
+        # because onnxruntime's cp314 wheel (via chromadb) raised an
+        # illegal-instruction SIGILL on GitHub's heterogeneous runner CPUs.
+        # onnxruntime 1.27.0 ships cp314 wheels including
+        # manylinux_2_28_x86_64 — the runner target — and the leg has been
+        # green on every run since v0.13.0. 3.10–3.14 are all gated now.
+        # The Windows leg stays non-blocking while it gathers evidence.
+        continue-on-error: ${{ matrix.os == 'windows-latest' }}
         run: pytest -q --cov=longhand --cov-report=term-missing --cov-fail-under=60
-      - name: Surface non-blocking 3.14 failure
-        # continue-on-error hides a red 3.14 job behind a green check; make the
-        # failure loud (annotation + step summary) without blocking the merge.
-        # Tracking: https://github.com/Wynelson94/longhand/issues/40
-        if: matrix.python-version == '3.14' && steps.pytest.outcome == 'failure'
-        run: |
-          echo "::warning title=Python 3.14 tests failed (non-blocking)::pytest failed on 3.14. The job is continue-on-error (onnxruntime cp314 SIGILL, issue #40), so this does NOT block the merge — but look before releasing."
-          echo "### :warning: Python 3.14 tests FAILED (non-blocking — issue #40)" >> "$GITHUB_STEP_SUMMARY"
       - name: Surface non-blocking Windows failure
         # Same loud-warning pattern as 3.14: never block the merge, never let
         # a red Windows run hide behind a green check either.


### PR DESCRIPTION
## Why

Issue #40 has been open since 2026-07-09: the 3.14 test job is `continue-on-error`, so a real 3.14 regression would merge and ship silently. Its plan had three items — (1) add a visible annotation step, (2) watch onnxruntime for working cp314 wheels, (3) hard-gate 3.14 before v1.0.

Item 1 already shipped. **Item 2's external blocker has now cleared**, which makes item 3 actionable.

## Evidence

| Signal | Status |
|---|---|
| onnxruntime cp314 wheels | **1.27.0 ships 7**, including `manylinux_2_28_x86_64` — the runner target |
| 3.14 CI leg since v0.13.0 | **8 consecutive green**, 0 red |
| Full suite on local 3.14.2 | **524 passed** |
| DeprecationWarnings on 3.14 | **95** (issue #40 cited 5,534 from the 07-09 audit) |

The SIGILL was always the native embedding lib, never CPython. With working wheels published, the reason for `continue-on-error` no longer exists.

## What changed

- `continue-on-error` narrowed from `3.14 || windows` to **windows only**. 3.10–3.14 are all gated.
- Dropped the "Surface non-blocking 3.14 failure" annotation step — it exists purely to make a *non-blocking* red job visible, and is dead weight once the job blocks.
- The Windows evidence leg is untouched and stays non-blocking.

## Required follow-up (repo setting, not in this diff)

This PR makes the job **fail**; branch protection is what makes the merge **refuse**. Required checks on `main` currently are:

`Tests (Python 3.10)`, `Tests (Python 3.11)`, `Tests (Python 3.12)`, `Tests (Python 3.13)`, `Ruff`, `Version sync`

`Tests (Python 3.14)` must be added after this merges, or the gate is cosmetic.

## Separately: `mypy` is not a required check either

Noticed while reading branch protection. The `mypy` job runs on every PR and CLAUDE.md treats it as blocking — it caught an arg-type error that ruff and pytest both missed on PR #54 — but it is **not** in the required-checks list. A PR with red mypy can auto-merge today. Same defect class as #40. Not changed here; flagging for a decision.

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)