### PR TITLE
feat!: the 0.13 deprecation window closes — removals for 1.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ When a user asks about past work:
 - **Never paginate `get_session_timeline` in a loop** looking for something. Use `search` with `session_id` + `context_events` instead.
 - **Never use `search` without `session_id`** when you know which session to look in. Unscoped search returns noise from all sessions.
 - **Never skip `recall`** for "do you remember" questions. It was built for exactly this use case.
-- **Don't call the deprecated names** — `search_in_context`, `get_latest_events`, `get_project_timeline`, `get_session_commits`, `get_episode`, `match_project` still answer (with a migration preamble), but the surviving tools take the same parameters directly.
+- **Don't call the retired names** — `search_in_context`, `get_latest_events`, `get_project_timeline`, `get_session_commits`, `get_episode`, `match_project` left the tool listing at 1.0. They still answer forever (with a migration preamble) so older docs never hard-fail, but the surviving tools take the same parameters directly.
 
 ## Tool Pairing Patterns
 
@@ -51,4 +51,4 @@ When a user asks about past work:
 
 ## Deeper Tools (less common starting points)
 
-Beyond the decision tree above: `get_session_timeline` with `tail` (the last N events, replaces get_latest_events), `find_episodes` with `episode_id` (full detail: referenced events, diff, post-fix file state), `list_projects` with `match` (fuzzy candidates with scored reasons — "which project did you mean?"), `list_plans` (browse plan-file writes), `get_stats` (store health), and `reconcile` (re-ingest drift) — **pass `fix` explicitly**: `fix=true` heals now; the implicit default flips to dry-run at v1.0.
+Beyond the decision tree above: `get_session_timeline` with `tail` (the last N events, replaces get_latest_events), `find_episodes` with `episode_id` (full detail: referenced events, diff, post-fix file state), `list_projects` with `match` (fuzzy candidates with scored reasons — "which project did you mean?"), `list_plans` (browse plan-file writes), `get_stats` (store health), and `reconcile` (re-ingest drift) — **`reconcile` defaults to a dry run; pass `fix=true` to actually heal.**

--- a/longhand/cli/_commands.py
+++ b/longhand/cli/_commands.py
@@ -78,13 +78,9 @@ _UPDATE_CHECK_EXCLUDED = {
     "__prompt-hook-run",
     "backfill-episodes",
     "context",
-    "continue",
     "ingest-live",
     "ingest-session",
     "mcp-server",
-    "patterns",
-    "reanalyze",
-    "recap",
 }
 
 
@@ -1153,14 +1149,6 @@ def reattribute(
             release_ingest_lock(store)
 
 
-def _deprecated(old: str, new: str) -> None:
-    """Print a deprecation warning for an aliased command.
-
-    Aliases that print this are removed in v1.0.
-    """
-    console.print(f"[yellow]`longhand {old}` is deprecated — use `longhand {new}`.[/yellow]")
-
-
 # -----------------------------------------------------------------------------
 # PROJECTS
 # -----------------------------------------------------------------------------
@@ -2040,135 +2028,6 @@ def _session_to_markdown(store, session_id: str) -> str:
 
 
 # -----------------------------------------------------------------------------
-# PATTERNS — recurring fix patterns across episodes
-# -----------------------------------------------------------------------------
-
-
-@app.command(hidden=True, rich_help_panel="Browse & insights")
-def patterns(
-    limit: int = typer.Option(10, "--limit", "-n", help="Top N pattern groups to show"),
-    min_count: int = typer.Option(2, "--min", help="Minimum episode count per pattern"),
-    data_dir: str | None = typer.Option(None, "--data-dir"),
-):
-    """Deprecated — use `longhand recall "<topic>"`. Removed in v1.0.
-
-    Groups episodes by error category and shared keywords from problem descriptions.
-    """
-    _deprecated("patterns", 'recall "<topic>"')
-    import json as _json
-    import re as _re
-    from collections import defaultdict
-
-    store = _get_store(data_dir)
-
-    # Pull all resolved/partial episodes
-    episodes = store.sqlite.query_episodes(limit=10000)
-
-    if not episodes:
-        console.print("[yellow]No episodes found. Run `longhand analyze --all` first.[/yellow]")
-        return
-
-    # Group by (category-tag, normalized error keyword)
-    groups: dict[tuple[str, str], list[dict]] = defaultdict(list)
-
-    for ep in episodes:
-        problem = (ep.get("problem_description") or "")[:300].lower()
-
-        # Pull tags
-        tags: list[str] = []
-        if ep.get("tags_json"):
-            try:
-                tags = _json.loads(ep["tags_json"])
-            except Exception:
-                pass
-        category = tags[0] if tags else "unknown"
-
-        # Extract distinctive keywords from problem
-        words = _re.findall(r"[a-z][a-z0-9]{4,}", problem)
-        # Remove common words
-        common = {
-            "error",
-            "type",
-            "test",
-            "tests",
-            "module",
-            "import",
-            "imports",
-            "fail",
-            "failed",
-            "value",
-            "result",
-            "check",
-            "found",
-            "missing",
-            "expected",
-            "received",
-            "actual",
-            "passed",
-            "running",
-        }
-        meaningful = [w for w in words if w not in common]
-        # Most distinctive token (the longest non-common one)
-        keyword = sorted(meaningful, key=len, reverse=True)[0] if meaningful else ""
-
-        if not keyword:
-            keyword = "general"
-
-        groups[(category, keyword)].append(ep)
-
-    # Sort groups by count
-    ranked = sorted(
-        [(key, eps) for key, eps in groups.items() if len(eps) >= min_count],
-        key=lambda kv: len(kv[1]),
-        reverse=True,
-    )[:limit]
-
-    if not ranked:
-        console.print(f"[yellow]No patterns found with at least {min_count} occurrences.[/yellow]")
-        return
-
-    console.print(
-        Panel.fit(
-            f"[bold]Recurring fix patterns[/bold]\n"
-            f"[dim]Found {len(ranked)} pattern(s) across {len(episodes)} episode(s)[/dim]",
-            border_style="cyan",
-        )
-    )
-    console.print()
-
-    for (category, keyword), eps in ranked:
-        # Header
-        header = Text()
-        header.append(f"× {len(eps)}  ", style="bold cyan")
-        header.append(f"{category}", style="magenta")
-        if keyword and keyword != "general":
-            header.append(f" · {keyword}", style="yellow")
-        console.print(header)
-
-        # Show 3 example problems
-        seen_problems: set[str] = set()
-        shown = 0
-        for ep in eps:
-            problem = (ep.get("problem_description") or "")[:120].strip()
-            problem_key = problem.lower()[:60]
-            if problem_key in seen_problems or not problem:
-                continue
-            seen_problems.add(problem_key)
-            console.print(f"  • {problem}")
-            shown += 1
-            if shown >= 3:
-                break
-
-        # If any have a fix summary, show one example fix
-        for ep in eps:
-            if ep.get("fix_summary"):
-                console.print(f"  [dim]example fix:[/dim] {ep['fix_summary'][:160]}")
-                break
-
-        console.print()
-
-
-# -----------------------------------------------------------------------------
 # RECAP — what have I been working on recently
 # -----------------------------------------------------------------------------
 
@@ -2299,20 +2158,6 @@ def _recap_digest(
             console.print(f"  [dim]topics:[/dim] {', '.join(entry['topics'])}")
 
         console.print()
-
-
-@app.command(hidden=True, rich_help_panel="Recall")
-def recap(
-    days: int = typer.Option(7, "--days", "-d", help="How far back to look"),
-    limit: int = typer.Option(10, "--limit", "-n"),
-    project: str | None = typer.Option(
-        None, "--project", "-p", help="Filter by project id or name"
-    ),
-    data_dir: str | None = typer.Option(None, "--data-dir"),
-):
-    """Deprecated alias for `longhand status`. Removed in v1.0."""
-    _deprecated("recap", "status --days N")
-    _recap_digest(_get_store(data_dir), days, limit, project)
 
 
 # -----------------------------------------------------------------------------
@@ -2504,17 +2349,6 @@ def _session_tail(store, session_id: str, n: int, json_out: bool = False) -> Non
                 border_style="yellow",
             )
         )
-
-
-@app.command("continue", hidden=True, rich_help_panel="Recall")
-def continue_cmd(
-    session_id: str = typer.Argument(..., help="Session ID prefix"),
-    n: int = typer.Option(10, "--events", "-n", help="How many recent events to show"),
-    data_dir: str | None = typer.Option(None, "--data-dir"),
-):
-    """Deprecated alias for `longhand status --session`. Removed in v1.0."""
-    _deprecated("continue", "status --session <prefix>")
-    _session_tail(_get_store(data_dir), session_id, n)
 
 
 # -----------------------------------------------------------------------------
@@ -2792,18 +2626,6 @@ def doctor(
 ):
     """Diagnose Longhand installation and data."""
     _doctor(json_out=json_out)
-
-
-@app.command("reanalyze", hidden=True)
-def reanalyze(
-    data_dir: str | None = typer.Option(None, "--data-dir"),
-    limit: int = typer.Option(0, "--limit", help="Deprecated — ignored."),
-):
-    """Deprecated alias for `longhand analyze --all`. Removed in v1.0."""
-    _deprecated("reanalyze", "analyze --all")
-    if limit > 0:
-        console.print("[dim]--limit is deprecated and ignored; analyzing all sessions.[/dim]")
-    analyze(all_sessions=True, session=None, data_dir=data_dir)
 
 
 @app.command("backfill-episodes", hidden=True)

--- a/longhand/mcp_server.py
+++ b/longhand/mcp_server.py
@@ -295,65 +295,6 @@ async def list_tools() -> list[Tool]:
             annotations=_READ_ONLY,
         ),
         _tool(
-            name="search_in_context",
-            title="Search a Session With Surrounding Context",
-            description=(
-                "[DEPRECATED — use search with context_events] "
-                "Search within a specific session and return matches WITH surrounding "
-                "conversation context. This is the tool you want when you know WHICH "
-                "session to look in but need to FIND a specific discussion or event. "
-                "Returns each semantic match plus N events before/after it from the "
-                "timeline, so you can read the full conversation flow. "
-                "Much more efficient than paginating get_session_timeline manually."
-            ),
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "session_id": {
-                        "type": "string",
-                        "description": "Session ID (prefix match — first 8 chars usually enough)",
-                    },
-                    "query": {
-                        "type": "string",
-                        "description": "Natural language query to find within the session",
-                    },
-                    "context_events": {
-                        "type": "integer",
-                        "default": 5,
-                        "description": "Number of events to include before AND after each match (default 5)",
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "default": 3,
-                        "description": "Max number of matches to return with context (default 3)",
-                    },
-                    "event_type": {
-                        "type": "string",
-                        "description": "Optional: filter matches to a single event type",
-                    },
-                    "max_chars": {
-                        "type": "integer",
-                        "default": 20000,
-                        "description": "Max total output characters (default 20000)",
-                    },
-                },
-                "required": ["session_id", "query"],
-            },
-            outputSchema={
-                "type": "array",
-                "description": "Array of matches; each match wraps the matched event plus the surrounding window.",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "match": _EVENT_ROW_SCHEMA,
-                        "context_before": {"type": "array", "items": _EVENT_ROW_SCHEMA},
-                        "context_after": {"type": "array", "items": _EVENT_ROW_SCHEMA},
-                    },
-                },
-            },
-            annotations=_READ_ONLY,
-        ),
-        _tool(
             name="list_sessions",
             title="List Indexed Sessions",
             description=(
@@ -369,7 +310,7 @@ async def list_tools() -> list[Tool]:
                 "get_project_timeline. When a `project` filter matches a known project "
                 "and its on-disk transcripts exceed what's indexed, the response wraps "
                 "a `{stale, stale_reason, sessions}` envelope — call the `reconcile` "
-                "tool to catch up."
+                "tool with fix=true to catch up."
             ),
             inputSchema={
                 "type": "object",
@@ -474,45 +415,6 @@ async def list_tools() -> list[Tool]:
                     "tail": {"type": ["integer", "null"]},
                     "events": {"type": "array", "items": _EVENT_ROW_SCHEMA},
                 },
-            },
-            annotations=_READ_ONLY,
-        ),
-        _tool(
-            name="get_latest_events",
-            title="Latest Events in a Session",
-            description=(
-                "[DEPRECATED — use get_session_timeline with tail] "
-                "Get the N most recent events in a session, in reverse chronological order "
-                "(sequence DESC). Use this when you need 'what was the latest X' — e.g., "
-                "the last user message, the last tool call, the last assistant response. "
-                "Semantic search is the wrong tool for recency; this one is. Supports "
-                "session id prefix match."
-            ),
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "session_id": {"type": "string"},
-                    "limit": {
-                        "type": "integer",
-                        "default": 10,
-                        "description": "Max events to return (default 10, capped at 1000)",
-                    },
-                    "event_type": {
-                        "type": "string",
-                        "description": "Optional: filter to a single event type (user_message, assistant_text, tool_call, etc.)",
-                    },
-                    "max_chars": {
-                        "type": "integer",
-                        "default": 16000,
-                        "description": "Max total output characters",
-                    },
-                },
-                "required": ["session_id"],
-            },
-            outputSchema={
-                "type": "array",
-                "description": "Events in reverse chronological order (most recent first).",
-                "items": _EVENT_ROW_SCHEMA,
             },
             annotations=_READ_ONLY,
         ),
@@ -719,8 +621,8 @@ async def list_tools() -> list[Tool]:
                 "and errors. Idempotent — re-running with the same on-disk state is a "
                 "no-op. Acquires the ingest lock — serialized with concurrent ingestion. "
                 "May take 30s+ on cold state because it runs embeddings and episode "
-                "extraction during re-ingest. Pass `fix` EXPLICITLY: the implicit "
-                "default is true today but flips to false (dry-run) at v1.0."
+                "extraction during re-ingest. Defaults to a DRY RUN: pass `fix=true` "
+                "to actually re-ingest."
             ),
             inputSchema={
                 "type": "object",
@@ -749,44 +651,6 @@ async def list_tools() -> list[Tool]:
                 },
             },
             annotations=_RECONCILE_HINTS,
-        ),
-        _tool(
-            name="match_project",
-            title="Fuzzy Project Match",
-            description=(
-                "[DEPRECATED — use list_projects with match] "
-                "Fuzzy project matching. Given a partial project name, category, or "
-                "description, returns candidate projects with match reasons. Useful for "
-                "confirming 'which game did you mean?' before drilling into episodes."
-            ),
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "query": {"type": "string"},
-                    "top_k": {
-                        "type": "integer",
-                        "default": 5,
-                        "description": "Max project matches to return",
-                    },
-                },
-                "required": ["query"],
-            },
-            outputSchema={
-                "type": "array",
-                "description": "Project candidates with match reasons.",
-                "items": {
-                    "type": "object",
-                    "properties": {
-                        "project_id": {"type": "string"},
-                        "display_name": {"type": ["string", "null"]},
-                        "canonical_path": {"type": ["string", "null"]},
-                        "category": {"type": ["string", "null"]},
-                        "score": {"type": ["number", "null"]},
-                        "reasons": {"type": "array", "items": {"type": "string"}},
-                    },
-                },
-            },
-            annotations=_READ_ONLY,
         ),
         _tool(
             name="find_episodes",
@@ -858,87 +722,6 @@ async def list_tools() -> list[Tool]:
                         "has_fix": {"type": "boolean"},
                     },
                 },
-            },
-            annotations=_READ_ONLY,
-        ),
-        _tool(
-            name="get_episode",
-            title="Full Episode Detail (Problem → Fix → Verify)",
-            description=(
-                "[DEPRECATED — use find_episodes with episode_id] "
-                "Full detail for one episode by episode_id. Includes all referenced events "
-                "(problem, diagnosis thinking block, fix edit, verification), the diff, "
-                "and the reconstructed file state after the fix. NOT for browsing — call "
-                "`find_episodes` first to discover episode_ids. NOT for finding episodes by "
-                "topic — `recall` is the narrative entry point."
-            ),
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "episode_id": {
-                        "type": "string",
-                        "description": "Exact episode_id from find_episodes or recall",
-                    }
-                },
-                "required": ["episode_id"],
-            },
-            outputSchema={
-                "type": "object",
-                "description": "Episode metadata, referenced events, diff, and post-fix file state.",
-                "properties": {
-                    "episode_id": {"type": "string"},
-                    "summary": {"type": ["string", "null"]},
-                    "fix_summary": {"type": ["string", "null"]},
-                    "events": {"type": "array", "items": _EVENT_ROW_SCHEMA},
-                    "diff": {"type": ["string", "null"]},
-                    "file_state_after_fix": {"type": ["string", "null"]},
-                },
-            },
-            annotations=_READ_ONLY,
-        ),
-        _tool(
-            name="get_session_commits",
-            title="Get Git Operations from a Session",
-            description=(
-                "[DEPRECATED — use find_commits with session_id and no query] "
-                "Returns every git operation (commit, push, pull, checkout, merge, etc.) "
-                "captured during a single Claude Code session, in chronological order. "
-                "Each row carries the timestamp, operation type, branch, hash, and "
-                "commit message — the in-between that `git log` doesn't capture, like "
-                "the failed pushes, mid-work checkouts, and rolled-back merges. "
-                "Use when you want to reconstruct the git story of one session, link a "
-                "specific session event to its commit, or audit a session's history. NOT "
-                "for cross-session search — use `find_commits` if you don't already have "
-                "a session_id. Filter by `operation_type` to focus (e.g. only commits)."
-            ),
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "session_id": {
-                        "type": "string",
-                        "description": "Session ID (prefix match — first 8 chars usually enough)",
-                    },
-                    "operation_type": {
-                        "type": "string",
-                        "description": "Filter by operation: commit, push, pull, checkout, merge, fetch, rebase, etc.",
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "default": 100,
-                        "description": "Max results (default 100, capped at 1000)",
-                    },
-                    "max_chars": {
-                        "type": "integer",
-                        "default": 12000,
-                        "description": "Max output characters (default 12000); response truncates with a hint past this size",
-                    },
-                },
-                "required": ["session_id"],
-            },
-            outputSchema={
-                "type": "array",
-                "description": "Git operations in chronological order.",
-                "items": _GIT_OP_ROW_SCHEMA,
             },
             annotations=_READ_ONLY,
         ),
@@ -1040,50 +823,6 @@ async def list_tools() -> list[Tool]:
                         "last_seen": {"type": ["string", "null"]},
                     },
                 },
-            },
-            annotations=_READ_ONLY,
-        ),
-        _tool(
-            name="get_project_timeline",
-            title="Project Session Timeline",
-            description=(
-                "[DEPRECATED — use list_sessions with project_id] "
-                "Session-level timeline for a project — bird's-eye view of what's been "
-                "happening. Returns each session's start/end time, event count, outcome "
-                "(shipped / fixed / stuck / exploratory), and a summary line. Use this "
-                "after list_projects to understand velocity and recent activity on a "
-                "specific project. Filter by date range with since/until (ISO format). "
-                "NOT for content-level search within a project — use `search` with "
-                "`project_name` instead. NOT a starting point if you don't have a "
-                "project_id — call `list_projects` or `match_project` first."
-            ),
-            inputSchema={
-                "type": "object",
-                "properties": {
-                    "project_id": {
-                        "type": "string",
-                        "description": "Project ID from list_projects or match_project",
-                    },
-                    "since": {
-                        "type": "string",
-                        "description": "ISO date — only sessions after this date",
-                    },
-                    "until": {
-                        "type": "string",
-                        "description": "ISO date — only sessions before this date",
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "default": 50,
-                        "description": "Max results (default 50, capped at 1000)",
-                    },
-                },
-                "required": ["project_id"],
-            },
-            outputSchema={
-                "type": "array",
-                "description": "Sessions for the project, each enriched with outcome + summary.",
-                "items": _SESSION_ROW_SCHEMA,
             },
             annotations=_READ_ONLY,
         ),
@@ -1821,21 +1560,19 @@ async def _tool_get_project_timeline(
 async def _tool_reconcile(store: LonghandStore, arguments: dict[str, Any]) -> list[TextContent]:
     """Bridge disk↔DB drift from inside an MCP session.
 
-    With `fix=True` (the default for MCP callers): re-ingests any on-disk
-    transcripts that are missing from the sessions table or have NULL
-    project_id. Closes the loop so Claude can self-heal the index after a
-    staleness banner fires, without shelling out to the CLI.
+    Defaults to a dry run: reports on-disk transcripts that are missing from
+    the sessions table or have NULL project_id, without touching anything.
+    Pass `fix=true` to re-ingest them, closing the loop so Claude can self-heal
+    the index after a staleness banner fires, without shelling out to the CLI.
+
+    The default flipped from fix=true at 1.0, warned one full minor ahead by
+    the 0.13 in-payload deprecation notice (Promise 1).
     """
-    fix = _bool(arguments.get("fix"), True)
+    fix = _bool(arguments.get("fix"), False)
     report = run_reconcile(store, fix=fix)
     payload = report.to_dict()
-    if "fix" not in arguments:
-        # The implicit default flips to fix=false (dry-run) at v1.0 — nudge
-        # callers to say what they mean while both behaviors still work.
-        payload["deprecation_warning"] = (
-            "reconcile ran with the implicit default fix=true; at v1.0 the "
-            "default flips to fix=false (dry-run). Pass fix explicitly."
-        )
+    if not fix:
+        payload["hint"] = "pass fix=true to apply"
     output = json.dumps(payload, indent=2, default=str)
     return [TextContent(type="text", text=output)]
 

--- a/longhand/recall/recall_pipeline.py
+++ b/longhand/recall/recall_pipeline.py
@@ -717,7 +717,7 @@ def _detect_project_drift(
         plural = "session" if n == 1 else "sessions"
         stale_reason = (
             f"{n} {plural} on disk not yet indexed for this project — "
-            f"run `longhand reconcile --fix` to catch up"
+            f"call the `reconcile` tool with fix=true to catch up"
         )
 
     return {

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -320,47 +320,24 @@ def test_status_json_digest(runner: CliRunner, sample_session_file: Path, tmp_pa
     assert any(s["session_id"] == sid for s in payload["sessions"])
 
 
-def test_recap_alias_delegates_with_deprecation_notice(
-    runner: CliRunner, sample_session_file: Path, tmp_path: Path
-):
-    data_dir = tmp_path / "lh"
-    sid = _seed_session(sample_session_file, data_dir)
+@pytest.mark.parametrize("removed", ["recap", "continue", "patterns", "reanalyze"])
+def test_deprecated_aliases_are_gone_at_1_0(runner: CliRunner, tmp_path: Path, removed: str):
+    """The 0.13 deprecation window closed — these four no longer exist.
 
-    result = runner.invoke(app, ["recap", "--days", "3650", "--data-dir", str(data_dir)])
+    Typer exits 2 ("No such command") rather than running anything. The
+    survivors are `status` (recap/continue), `recall` (patterns) and
+    `analyze --all` (reanalyze).
+    """
+    result = runner.invoke(app, [removed, "--data-dir", str(tmp_path / "lh")])
 
-    assert result.exit_code == 0, result.output
-    assert "deprecated" in result.stdout.lower()
-    assert sid[:8] in result.stdout  # the digest still renders
-
-
-def test_continue_alias_delegates_with_deprecation_notice(
-    runner: CliRunner, sample_session_file: Path, tmp_path: Path
-):
-    data_dir = tmp_path / "lh"
-    sid = _seed_session(sample_session_file, data_dir)
-
-    result = runner.invoke(app, ["continue", sid[:8], "--data-dir", str(data_dir)])
-
-    assert result.exit_code == 0, result.output
-    assert "deprecated" in result.stdout.lower()
-    assert "Last" in result.stdout  # the tail still renders
+    assert result.exit_code == 2, result.output
 
 
-def test_patterns_warns_deprecated_but_still_runs(runner: CliRunner, tmp_path: Path):
-    result = runner.invoke(app, ["patterns", "--data-dir", str(tmp_path / "lh")])
-
-    assert result.exit_code == 0, result.output
-    assert "deprecated" in result.stdout.lower()
-    assert "No episodes" in result.stdout  # the body still ran (deleted at 1.0)
-
-
-def test_deprecated_resume_commands_are_hidden():
-    hidden = {
-        (info.name or info.callback.__name__.replace("_", "-"))
-        for info in app.registered_commands
-        if info.hidden
+def test_removed_commands_are_not_registered():
+    names = {
+        (info.name or info.callback.__name__.replace("_", "-")) for info in app.registered_commands
     }
-    assert {"recap", "continue", "patterns"} <= hidden
+    assert not ({"recap", "continue", "patterns", "reanalyze"} & names)
 
 
 def test_hook_config_honors_data_dir_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_cli_render.py
+++ b/tests/test_cli_render.py
@@ -233,7 +233,6 @@ def test_help_hides_plumbing_commands(runner: CliRunner):
         "ingest-session",
         "ingest-live",
         "backfill-episodes",
-        "reanalyze",
         "mcp-server",
     ):
         assert hidden_cmd not in out, f"plumbing command leaked into --help: {hidden_cmd}"
@@ -246,13 +245,15 @@ def test_hidden_commands_still_callable(runner: CliRunner):
         assert result.exit_code == 0, f"{cmd} --help failed"
 
 
-def test_reanalyze_alias_warns_and_delegates(runner: CliRunner, tmp_path: Path, monkeypatch):
+def test_reanalyze_is_removed_at_1_0(runner: CliRunner, tmp_path: Path, monkeypatch):
+    """`reanalyze` was a deprecated alias through 0.13; `analyze --all` survives."""
     monkeypatch.setenv("HOME", str(tmp_path))
     result = runner.invoke(app, ["reanalyze", "--data-dir", str(tmp_path / "store")])
-    assert result.exit_code == 0
-    out = plain(result.stdout)
-    assert "deprecated" in out.lower()
-    assert "analyze --all" in out
+    assert result.exit_code == 2
+
+    analyze = runner.invoke(app, ["analyze", "--help"])
+    assert analyze.exit_code == 0
+    assert "--all" in plain(analyze.stdout)
 
 
 def test_stats_splits_low_confidence_noise(runner: CliRunner, tmp_path: Path, monkeypatch):

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -61,14 +61,19 @@ def _tools():
     return {t.name: t for t in asyncio.run(mcp_server.list_tools())}
 
 
-def test_retired_tools_stay_listed_with_deprecated_prefix():
+def test_retired_tools_leave_the_listing_at_1_0():
     tools = _tools()
-    assert len(tools) == 19  # nothing leaves list_tools() until 1.0
-    for name, survivor in RETIRED.items():
-        assert tools[name].description.startswith("[DEPRECATED — use "), name
-        assert survivor in tools[name].description.splitlines()[0], name
-    for name in set(tools) - set(RETIRED):
+    assert len(tools) == 13  # the 6 retired names left list_tools() at 1.0
+    assert not (set(tools) & set(RETIRED))
+    for name in tools:
         assert not tools[name].description.startswith("[DEPRECATED"), name
+
+
+def test_retired_tools_still_answer_forever():
+    """Removed from the listing, never removed from _DISPATCH — stale user
+    CLAUDE.md files must never hard-fail."""
+    for name in RETIRED:
+        assert name in mcp_server._DISPATCH, name
 
 
 def test_retired_payloads_carry_migration_preamble(temp_store, sample_session_file):
@@ -165,21 +170,27 @@ def test_list_projects_absorbs_match(temp_store, sample_session_file):
     assert "reasons" in payload[0]  # the match_project shape
 
 
-def test_reconcile_implicit_fix_carries_deprecation_warning(temp_store, monkeypatch):
+def test_reconcile_defaults_to_dry_run_at_1_0(temp_store, monkeypatch):
+    """The 0.13 warning promised this flip; at 1.0 the implicit default is dry-run."""
     from types import SimpleNamespace
 
-    monkeypatch.setattr(
-        mcp_server,
-        "run_reconcile",
-        lambda store, fix: SimpleNamespace(to_dict=lambda: {"missing": 0, "ingested": 0}),
-    )
+    seen: list[bool] = []
+
+    def _fake(store, fix):
+        seen.append(fix)
+        return SimpleNamespace(to_dict=lambda: {"missing": 0, "ingested": 0})
+
+    monkeypatch.setattr(mcp_server, "run_reconcile", _fake)
 
     implicit = _payload(_call(mcp_server._DISPATCH["reconcile"], temp_store, {}))
-    assert "deprecation_warning" in implicit
-    assert "fix" in implicit["deprecation_warning"]
+    assert seen == [False]
+    assert implicit["hint"] == "pass fix=true to apply"
+    assert "deprecation_warning" not in implicit  # the window closed; no more nagging
 
+    seen.clear()
     explicit = _payload(_call(mcp_server._DISPATCH["reconcile"], temp_store, {"fix": True}))
-    assert "deprecation_warning" not in explicit
+    assert seen == [True]
+    assert "hint" not in explicit  # not a dry run, nothing to hint at
 
 
 # ─── auto-scope threshold + observability ────────────────────────────────────
@@ -236,12 +247,12 @@ def test_no_tool_declares_output_schema():
 
     Claude Code's MCP validator rejects any tool whose outputSchema.type is not
     "object", and our handlers return TextContent (not structuredContent), so we
-    strip outputSchema entirely. Guards issue #9 — 12 of 19 tools silently failed
-    to load when array/oneOf outputSchemas were declared.
+    strip outputSchema entirely. Guards issue #9 — 12 of the then-19 tools
+    silently failed to load when array/oneOf outputSchemas were declared.
     """
     tools = asyncio.run(mcp_server.list_tools())
     assert tools, "list_tools returned no tools"
-    assert len(tools) == 19
+    assert len(tools) == 13
     offenders = [t.name for t in tools if getattr(t, "outputSchema", None) is not None]
     assert not offenders, (
         f"tools must not declare outputSchema (Claude Code rejects them): {offenders}"
@@ -485,6 +496,10 @@ def test_tool_recall_project_status_exposes_staleness(
     assert payload["stale"] is True
     assert payload["stale_reason"]
     assert "reconcile" in payload["stale_reason"]
+    # The banner is MCP-only, so it must name the tool call — not the CLI.
+    # `fix=true` is now explicit because the implicit default is dry-run at 1.0.
+    assert "fix=true" in payload["stale_reason"]
+    assert "--fix" not in payload["stale_reason"]
     # Narrative should include the drift warning up front.
     assert "⚠" in payload["narrative"] or "reconcile" in payload["narrative"]
 
@@ -928,8 +943,8 @@ def test_tool_reconcile_fix_ingests_missing(sample_session_file, temp_store, tmp
     assert payload["lock_unavailable"] is False
 
 
-def test_tool_reconcile_default_fix_is_true(temp_store, monkeypatch):
-    """When `fix` is omitted, the MCP tool defaults to fix=True (CLI defaults to False)."""
+def test_tool_reconcile_default_fix_is_false(temp_store, monkeypatch):
+    """When `fix` is omitted, the MCP tool defaults to a dry run — matching the CLI."""
     from longhand.recall import reconcile as reconcile_mod
 
     captured: dict[str, bool] = {}
@@ -944,7 +959,7 @@ def test_tool_reconcile_default_fix_is_true(temp_store, monkeypatch):
     monkeypatch.setattr(mcp_server, "run_reconcile", fake_run)
 
     _call(mcp_server._tool_reconcile, temp_store, {})
-    assert captured["fix"] is True
+    assert captured["fix"] is False
 
 
 # ─── End-to-end dispatch ────────────────────────────────────────────────────


### PR DESCRIPTION
Roadmap **PR 11** of the 1.0 train. The v0.13.0 bake ran its full course (2026-07-11 → 08-11) with zero defects surfaced, so the deprecation window closes.

Everything removed here was warned one full minor ahead, which is exactly what **Promise 1** (stable surface) commits to.

## CLI — four deprecated aliases deleted

| Removed | Survivor |
|---|---|
| `patterns` | `recall "<topic>"` — the 120-line keyword heuristic goes with it |
| `recap` | `status --days N` |
| `continue` | `status --session <prefix>` |
| `reanalyze` | `analyze --all` |

`_recap_digest` and `_session_tail` **stay** — they're the shared bodies behind `status`, not alias-only code. The now-orphaned `_deprecated()` helper and the four stale `_UPDATE_CHECK_EXCLUDED` entries are cleaned up with them.

## MCP — retired names leave the listing, never stop answering

`list_tools()` goes 19 → 13. The 6 retired names (`search_in_context`, `get_latest_events`, `get_project_timeline`, `get_session_commits`, `get_episode`, `match_project`) keep answering from `_DISPATCH` **forever**, with their migration preamble intact — a stale user `CLAUDE.md` must never hard-fail.

## MCP `reconcile` defaults to dry run

The flip the 0.13 in-payload warning promised. Dry runs carry `"hint": "pass fix=true to apply"`; the `deprecation_warning` retires with the window. The staleness banner is MCP-only, so it now names the tool call (`fix=true`) rather than the CLI `--fix` form, and `CLAUDE.md` matches.

## Gate

ruff + format + mypy clean; **526 passed** (was 524 — net +2 from the parametrized removal test).

Tests were written red-first: each removal asserts exit code 2 and absence from `app.registered_commands`, and the retired MCP names assert *absent from the listing but present in `_DISPATCH`*.

Roadmap: `~/.claude/plans/i-lost-power-in-noble-canyon.md` · Next: PR 12 (promises + policy docs).