### PR TITLE
docs: the five promises, migration policy, and an honest hook-error remedy

### DIFF
--- a/COMPATIBILITY.md
+++ b/COMPATIBILITY.md
@@ -1,0 +1,63 @@
+# Compatibility promises
+
+Longhand 1.0 is a commitment, not a version bump. This document is that commitment: five promises, each with a named artifact in the repo that enforces it. A promise without an enforcement artifact is a wish, so every one below points at code you can read and a test that fails if the promise breaks.
+
+Scope: these promises bind all of **1.x**. Breaking any of them requires 2.0.
+
+---
+
+## 1. Stable surface
+
+The CLI commands and MCP tools shipped at 1.0 keep working through 1.x. Removals and renames happen only at a major version, and anything slated for removal warns for **one full minor** first.
+
+**Enforced by:** the 0.13 deprecation cycle (every 1.0 removal warned in 0.13, one full minor ahead) and the retired MCP names, which left `list_tools()` at 1.0 but keep answering from `_DISPATCH` **forever** with a migration preamble — see `_RETIRED_TOOLS` in `longhand/mcp_server.py`.
+
+That last part is deliberate. Users paste tool names into their own `CLAUDE.md` files, and those files are not ours to update. A retired name must never hard-fail; it answers, tells you what replaced it, and does the work anyway.
+
+**Additive changes are always allowed:** new commands, new tools, new optional parameters, new fields in a response.
+
+## 2. Forward data compatibility
+
+Any database written by 0.11 or later opens on any 1.x release at least as new as its last writer. Migrations are automatic, one-time, and never renumbered.
+
+The promise is **forward-shaped**, and the distinction matters: older code does not silently tolerate a newer database — it **refuses loudly**, with an instruction to upgrade. Operating blind on a schema you do not understand is how data gets corrupted quietly. Refusing is the feature.
+
+**Enforced by:** `SchemaTooNewError` in `longhand/storage/migrations.py` (the downgrade guard), the migration authoring policy in that module's header, and a 0.11-schema fixture database under `tests/fixtures/db/` that is loaded, migrated, and queried in the test suite.
+
+## 3. Hook guarantees
+
+Longhand's Claude Code hooks **never raise, never touch the network, and never block your prompt**.
+
+This is the promise that matters most in daily use, because a hook runs on every turn. A memory tool that occasionally breaks your editor is worse than no memory tool. When a hook fails it exits 0, writes a one-line breadcrumb to `logs/hook-errors-YYYY-MM-DD.log`, and leaves the transcript for `reconcile` to pick up.
+
+**Enforced by:** `tests/test_hook_guarantees.py`, CI-gated on every PR.
+
+**Field record:** across the v0.13 bake (2026-07-11 → 08-12) there were 23 hook failures. Every one exited 0, left a breadcrumb, and never blocked a prompt.
+
+## 4. Upstream drift is never silent
+
+Claude Code's transcript format is not ours to control. When an unknown entry type appears, Longhand **preserves it** (stored as `raw_json`), **surfaces it** (the "Transcript format" row in `longhand doctor`), and **regression-gates it** (transcript-shapes fixture test). It does not drop data it does not recognize, and it does not pretend nothing changed.
+
+**Enforced by:** the doctor row, the fixture test under `tests/fixtures/transcript_shapes/`, and the raw_json preservation path in the parser.
+
+### raw_json storage compatibility
+
+Readers accept both the inline and normalized forms of preserved entries, indefinitely. A future 1.x may normalize `raw_json` storage into a dedicated `entries` table for deduplication — that change is **additive and opt-in**, both forms stay readable, and no existing database is rewritten without an explicit command. Nothing about that work can break a database written by an earlier 1.x.
+
+## 5. Honest metrics
+
+Error, fix, and resolved counts reflect real signals. Longhand does not inflate what it found, and it does not recommend a remedy that cannot work.
+
+**Enforced by:** the verification gate and context-aware error suppression in `longhand/extractors/errors.py` (which cut optimistic bias from both directions — benign noise no longer becomes a "problem," and real errors are suppressed by context rather than by deleting patterns), plus the class-aware hook-error remedy in `_hook_errors_status()`.
+
+That last one earned its place. Through 0.13, `doctor` told every hook error to run `reconcile --fix`. But `reconcile` enumerates from **disk**, so a transcript that never landed is invisible to it forever — the advice was a no-op for that entire class. Over the bake, **21 of 23** real hook errors were exactly that class. The row now splits the remedy by class and says plainly when there is nothing to heal.
+
+---
+
+## What is explicitly *not* promised
+
+- **Episode extraction quality.** Episodes are a heuristic over your transcripts, not a guarantee. Precision and recall may change between minors as the extractors improve.
+- **Performance characteristics.** Ingest and recall latency may change in either direction.
+- **The Chroma vector index on disk.** It is a derived cache. Any release may require a re-index; your SQLite store is the source of truth and is covered by Promise 2.
+- **Python versions below the floor in `pyproject.toml`.** Dropping an end-of-life Python is a minor-version change, not a major one.
+- **Windows.** CI-tested on a best-effort basis (`windows-latest × py3.12`, non-blocking). Not a supported tier — see the README for the current evidence.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing
+
+Longhand is a personal-memory tool that runs on every Claude Code turn. That shapes what "done" means here more than any style guide would: a change that is correct but occasionally blocks someone's prompt is not an improvement.
+
+## The gate
+
+Every pull request must pass, and these are required checks on `main`:
+
+```
+ruff check longhand tests
+ruff format --check longhand tests
+mypy longhand
+pytest
+```
+
+Tests run on Python 3.10 through 3.14. A Windows leg (`windows-latest × py3.12`) runs non-blocking as evidence, not as a gate.
+
+Work on a branch and open a PR — `main` is protected and takes no direct pushes.
+
+## Before you change the schema
+
+Read the **migration authoring policy** in the header of `longhand/storage/migrations.py`. It is not style advice; it is what makes Promise 2 in [COMPATIBILITY.md](COMPATIBILITY.md) true. The short version:
+
+- Migrations are automatic, one-time, and **never renumbered** — a published version number is frozen forever, content included.
+- Anything beyond O(1) DDL does not run inline at store open. Store open is on the hook path.
+- Nothing destroys data without an explicit opt-in.
+- Every new migration ships a **prior-schema fixture test** under `tests/fixtures/db/` — a real dump, not a hand-written schema.
+
+## Before you change the hooks
+
+Read `tests/test_hook_guarantees.py` first. Hooks never raise, never touch the network, and never block the prompt (Promise 3). A hook that fails must exit 0, leave a breadcrumb, and let `reconcile` clean up later. If your change can make a hook slow, raise, or reach the network, it needs a different design rather than a passing test.
+
+## Before you change the CLI or MCP surface
+
+Promise 1 freezes the surface through 1.x. Additive changes — new commands, new tools, new optional parameters, new response fields — are always fine. Removals and renames are 2.0 material and must warn one full minor ahead first.
+
+Retired MCP tool names stay in `_DISPATCH` **forever**. Users paste tool names into their own `CLAUDE.md` files; those files are not ours to update, so a retired name answers with a migration preamble rather than failing.
+
+## Tests
+
+Write the test first and watch it fail. A test that has never been red has not been shown to test anything.
+
+Prefer a test that pins the behavior a user depends on over one that pins the current implementation. When a test encodes a decision, say why in the test or a comment near it — the reason is the part that gets lost.
+
+## Reporting a bug
+
+Include what `longhand doctor` prints. It covers store health, freshness, hook errors, and transcript-format drift, which is most of what a diagnosis needs. Redact paths if they are sensitive — Longhand indexes your real work.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/longhand?label=PyPI&color=blue)](https://pypi.org/project/longhand/)
 ![Python](https://img.shields.io/badge/python-3.10+-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
-![Tests](https://img.shields.io/badge/tests-524%20passing-brightgreen)
+![Tests](https://img.shields.io/badge/tests-530%20passing-brightgreen)
 ![Local](https://img.shields.io/badge/100%25-local-informational)
 [![SafeSkill 93/100](https://img.shields.io/badge/SafeSkill-93%2F100_Verified%20Safe-brightgreen)](https://safeskill.dev/scan/wynelson94-longhand)
 
@@ -76,7 +76,7 @@ longhand analyze --all           # fill in episodes + vectors whenever, safe to 
 
 Exact-text search, timelines, file history, and commit lookup all work after `--skip-analysis`. Semantic `recall` needs the `analyze --all` pass to complete. Typical throughput on an M-class Mac is ~1–2 sessions/sec for full analysis.
 
-> *Status: v0.13.0 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 387 real Claude Code sessions across 35 inferred projects. 524 unit tests passing.*
+> *Status: v0.13.0 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 433 real Claude Code sessions across 37 inferred projects (measured 2026-08-12). 530 unit tests passing.*
 
 **Full docs:** [Longhand Wiki](https://github.com/Wynelson94/longhand/wiki) — getting started, CLI reference, MCP tools reference, architecture, and troubleshooting.
 
@@ -106,13 +106,31 @@ The "memory crisis" in AI was an artificial constraint. Storage is solved. SQLit
 
 **Local. Complete. Yours.**
 
-> **Storage footprint:** ~4.5GB for a heavy power user (385+ sessions, 180k+ events, months of daily Opus usage across 35 inferred projects). Typical users: 200–400MB. Once Claude Code rotates the source files off disk, Longhand isn't a duplicate — it's the only copy.
+> **Storage footprint:** ~5GB for a heavy power user (430+ sessions, 195k+ events, months of daily Opus usage across 37 inferred projects). Typical users: 200–400MB. Once Claude Code rotates the source files off disk, Longhand isn't a duplicate — it's the only copy.
 
 ---
 
-## Python version note
+## Platform support
 
-Python 3.10 – 3.13 are fully supported. **On Python 3.14**, longhand pins `chromadb<1.0` automatically because chromadb's newer Rust bindings segfault on 3.14 (see [#4](https://github.com/Wynelson94/longhand/issues/4)). Once chromadb ships a 3.14-compatible 1.x wheel, the constraint will relax.
+**Python 3.10 – 3.14 are all fully supported and gated in CI** — every release must pass the full suite on all five before it can merge.
+
+Longhand pins `chromadb<1.0` for **every** Python version, not just 3.14. The pin originated with chromadb's newer Rust bindings segfaulting on 3.14 ([#4](https://github.com/Wynelson94/longhand/issues/4), now closed), and it stays until a 1.x chromadb is verified across the whole matrix.
+
+**Windows: CI-tested, best-effort.** A `windows-latest × py3.12` leg runs on every PR and has gone green on every run since v0.13.0, but it is non-blocking and covers one Python version on GitHub's runners. That is honest evidence, not a support tier — Linux and macOS are the tested platforms. Windows bugs are welcome as issues; they just aren't release-blocking.
+
+---
+
+## Compatibility
+
+Longhand 1.0 makes five promises, each backed by an enforcement artifact in the repo. The full text is in **[COMPATIBILITY.md](COMPATIBILITY.md)**; the short version:
+
+1. **Stable surface** — CLI and MCP frozen through 1.x. Removals only at a major version, and only after warning for one full minor.
+2. **Forward data compat** — a database written by 0.11+ opens on any later 1.x. Migrations are automatic, one-time, never renumbered. Older code refuses a newer database loudly rather than operating blind.
+3. **Hook guarantees** — hooks never raise, never touch the network, never block your prompt.
+4. **Upstream drift is never silent** — unknown transcript entries are preserved, surfaced in `doctor`, and regression-gated.
+5. **Honest metrics** — counts reflect real signals, and `doctor` never recommends a remedy that cannot work.
+
+**Deprecation policy:** anything slated for removal warns for at least one full minor release first, and the warning names its replacement. Retired MCP tool names are the one thing that never goes away — they leave the tool listing but keep answering forever with a migration note, because those names live in users' own `CLAUDE.md` files.
 
 ---
 
@@ -262,8 +280,8 @@ longhand status --days 30 -p bsoi           # filtered digest
 longhand status <project-name>              # where did we leave off on a project (git-aware)
 longhand status --session <session-id>      # pick up where a session left off
 longhand history src/app/route.ts           # every edit ever to a file
-# (recap / continue / patterns still work through 0.x — they print a pointer
-#  to their status/recall replacements and are removed at v1.0)
+# (recap / continue / patterns / reanalyze were deprecated aliases through
+#  0.13 and were removed at 1.0 — use status, recall, and analyze --all)
 
 # Semantic search
 longhand search "race condition"
@@ -456,18 +474,18 @@ Summary memory and Longhand solve different problems. Summary memory is good for
 
 ## Stats
 
-Corpus measured 2026-07-24 against the author's live store on v0.13.0:
-- 387 unique sessions
-- 181,705 events
-- 58,338 tool calls
-- 13,743 file edits
+Corpus measured 2026-08-12 against the author's live store on v0.13.0:
+- 433 unique sessions
+- 197,978 events
+- 64,364 tool calls
+- 15,202 file edits
 - 224 thinking blocks
-- 35 projects inferred automatically
-- 1,033 problem→fix episodes extracted (385 resolved)
-- 3,789 conversation segments (design, story, debugging, discussion, planning)
-- 2,326 git operations extracted (106 commits linked)
-- 128,021 vectors indexed
-- Storage footprint: 4.5 GB total (3.5 GB SQLite + 970 MB ChromaDB) across 387 sessions — ~12 MB per session
+- 37 projects inferred automatically
+- 1,119 problem→fix episodes extracted — 618 are low-confidence (fixless) and excluded from the rate, leaving 423 of 501 resolved (84%)
+- 4,286 conversation segments (design, story, debugging, discussion, planning)
+- 2,661 git operations extracted (107 commits linked)
+- 142,897 vectors indexed
+- Storage footprint: 5.0 GB total (3.9 GB SQLite + 1.0 GB ChromaDB) across 433 sessions — ~12 MB per session
 
 Latency, benchmarked on the earlier 246-session corpus (M-class Mac) and not re-measured since:
 - Vector search: ~56ms median (p90 ~62ms)
@@ -501,7 +519,7 @@ Longhand is flat-cost: the cap is per-call, not per-corpus. Recalling across 10 
 
 ---
 
-524 unit tests passing. All 13 MCP tools stress-tested. Full security audit: zero critical findings, zero high findings. `~/.longhand/` created with 0700 permissions, all SQL parameterized, all inputs bounded. Dependencies: chromadb, typer, rich, pydantic, mcp.
+530 unit tests passing. All 13 MCP tools stress-tested. Full security audit: zero critical findings, zero high findings. `~/.longhand/` created with 0700 permissions, all SQL parameterized, all inputs bounded. Dependencies: chromadb, typer, rich, pydantic, mcp.
 
 ---
 

--- a/longhand/setup_commands.py
+++ b/longhand/setup_commands.py
@@ -1089,16 +1089,45 @@ def _transcript_format_status(store: LonghandStore, days: int = 30) -> str:
     )
 
 
+# Hook-error classes that `reconcile` can actually heal. reconcile enumerates
+# from DISK (discover_sessions), so it can only re-ingest a transcript that is
+# still there: `ingest-failed` qualifies, and nothing else does. A
+# `missing-transcript` never landed and is invisible to the heal path forever;
+# `oversize-transcript` would hit the same cap on re-ingest; `store-open-failed`
+# blocks reconcile itself. Recommending reconcile for those is a no-op, which
+# is a Promise 5 (honest metrics) violation — over the v0.13 bake, 21 of 23
+# real hook errors were the unhealable class.
+_RECONCILE_HEALABLE = frozenset({"ingest-failed"})
+
+
+def _hook_error_class(line: str) -> str:
+    """Extract the class token from a breadcrumb line, or "unknown".
+
+    _log_hook_error writes ``<iso-ts> <command> <class>: <detail>`` — the
+    class token is already there, so the split needs no new plumbing.
+    """
+    parts = line.split()
+    if len(parts) < 3 or not parts[2].endswith(":"):
+        return "unknown"
+    return parts[2].removesuffix(":")
+
+
 def _hook_errors_status(store: LonghandStore, days: int = 7) -> str:
     """Rich-formatted count of hook-error breadcrumbs in the last `days` days.
 
     Complements _freshness_status: freshness says "something is missing";
     this row says why — every hook-mode ingest failure leaves one line in
     logs/hook-errors-YYYY-MM-DD.log (see _log_hook_error).
+
+    The remedy is split by class: only classes reconcile can genuinely heal
+    get the reconcile advice. Anything else says plainly that there is
+    nothing to heal, rather than recommending a command that cannot help.
     """
+    from collections import Counter
+
     logs = store.data_dir / "logs"
     window_start = datetime.now(timezone.utc).date() - timedelta(days=days - 1)
-    count = 0
+    counts: Counter[str] = Counter()
     for f in logs.glob("hook-errors-*.log"):
         try:
             day = date.fromisoformat(f.stem.removeprefix("hook-errors-"))
@@ -1108,15 +1137,30 @@ def _hook_errors_status(store: LonghandStore, days: int = 7) -> str:
             continue
         try:
             with f.open() as fh:
-                count += sum(1 for line in fh if line.strip())
+                counts.update(_hook_error_class(line) for line in fh if line.strip())
         except OSError:
             continue
+    count = sum(counts.values())
     if count == 0:
         return f"[green]✓[/green] none in the last {days} days"
+
+    healable = sum(n for cls, n in counts.items() if cls in _RECONCILE_HEALABLE)
+    # Largest class first so the dominant failure mode leads the remedy.
+    breakdown = ", ".join(
+        f"{n} {cls}" for cls, n in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))
+    )
+    if healable == count:
+        remedy = "[bold]longhand reconcile --fix[/bold] heals missed ingests"
+    elif healable:
+        remedy = (
+            f"[bold]longhand reconcile --fix[/bold] heals the {healable} ingest-failed; "
+            "the rest were never written — nothing to heal"
+        )
+    else:
+        remedy = "these were never written — nothing to heal"
     return (
-        f"[yellow]⚠[/yellow] {count} in the last {days} days — see "
-        f"[bold]{logs}/hook-errors-*.log[/bold]; "
-        "[bold]longhand reconcile --fix[/bold] heals missed ingests"
+        f"[yellow]⚠[/yellow] {count} in the last {days} days ({breakdown}) — see "
+        f"[bold]{logs}/hook-errors-*.log[/bold]; {remedy}"
     )
 
 

--- a/longhand/storage/migrations.py
+++ b/longhand/storage/migrations.py
@@ -3,6 +3,33 @@ Schema migrations for Longhand.
 
 Version-aware SQL evolution. Each migration is a SQL string keyed by version.
 Migrations are applied in order, once, and logged in the `schema_version` table.
+
+Migration authoring policy (1.0, Promise 2 — forward data compat)
+-----------------------------------------------------------------
+Promise 2 says any DB written by 0.11+ opens on any 1.x at least as new as its
+last writer. These rules are what make that true; see COMPATIBILITY.md.
+
+1. **Automatic.** Migrations apply on store open. A user never runs a command
+   to make their existing database work with a newer Longhand.
+2. **One-time.** Applied once, recorded in `schema_version`, never re-run.
+3. **Never renumbered.** A published version number is frozen forever — its
+   content included. Fixing a shipped migration means adding a new one, not
+   editing history: renumbering silently re-applies or silently skips,
+   depending on which side of the number a given user sits.
+4. **Bounded work on open.** Anything beyond O(1) DDL — a data rewrite that
+   walks every row — must not run inline at open. Ship it chunked with
+   progress, or behind an opt-in `db migrate-*` command. Store open is on the
+   hook path; an unbounded migration there blocks a user's prompt.
+5. **Never destructive without opt-in.** No migration drops a column, deletes
+   rows, or discards data a previous version wrote. Additive only; if data
+   must be reshaped, write the new shape alongside and leave the old.
+6. **Every migration ships a prior-schema fixture test** — a real dump of the
+   schema as it existed *before* the migration, committed under
+   `tests/fixtures/db/`, loaded and migrated in a test. Hand-written schemas
+   drift from reality and prove nothing.
+
+M1-M8 predate this policy and are grandfathered: they are already published,
+so rule 3 freezes them as-is. The policy binds M9 onward.
 """
 
 from __future__ import annotations

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -570,6 +570,97 @@ def test_hook_errors_status_counts_recent_and_ignores_old(tmp_path: Path):
     assert "hook-errors-*.log" in status
 
 
+# ─── doctor hook-error remedy is class-aware (Promise 5) ─────────────────────
+#
+# reconcile enumerates from DISK. A transcript that never landed is invisible
+# to it forever, so "run reconcile --fix" is a no-op for that class. Over the
+# v0.13 bake (2026-07-11..08-12) 21 of 23 real hook errors were exactly that
+# class — the row recommended a no-op for 91% of what it reported.
+
+
+def _write_hook_log(store, *lines: str) -> None:
+    from datetime import datetime, timezone
+
+    logs = store.data_dir / "logs"
+    logs.mkdir(parents=True, exist_ok=True)
+    today = datetime.now(timezone.utc).date()
+    (logs / f"hook-errors-{today.isoformat()}.log").write_text("".join(f"{ln}\n" for ln in lines))
+
+
+def test_hook_errors_unhealable_class_does_not_recommend_reconcile(tmp_path: Path):
+    from longhand.setup_commands import _hook_errors_status
+    from longhand.storage import LonghandStore
+
+    store = LonghandStore(data_dir=tmp_path / "longhand")
+    _write_hook_log(
+        store,
+        "2026-08-11T17:10:51+00:00 ingest-session missing-transcript: /tmp/never-landed.jsonl",
+        "2026-08-11T21:51:19+00:00 ingest-session missing-transcript: /tmp/also-gone.jsonl",
+    )
+
+    status = _hook_errors_status(store)
+
+    assert "2 in the last 7 days" in status
+    assert "missing-transcript" in status
+    assert "nothing to heal" in status
+    assert "reconcile" not in status  # the no-op recommendation is gone
+
+
+def test_hook_errors_healable_class_keeps_reconcile_advice(tmp_path: Path):
+    from longhand.setup_commands import _hook_errors_status
+    from longhand.storage import LonghandStore
+
+    store = LonghandStore(data_dir=tmp_path / "longhand")
+    _write_hook_log(
+        store,
+        "2026-07-25T00:07:46+00:00 ingest-session ingest-failed: a.jsonl: RuntimeError: boom",
+    )
+
+    status = _hook_errors_status(store)
+
+    assert "1 in the last 7 days" in status
+    assert "reconcile" in status  # genuinely healable — keep the advice
+
+
+def test_hook_errors_mixed_classes_split_the_remedy(tmp_path: Path):
+    """The live shape: a healable minority alongside an unhealable majority."""
+    from longhand.setup_commands import _hook_errors_status
+    from longhand.storage import LonghandStore
+
+    store = LonghandStore(data_dir=tmp_path / "longhand")
+    _write_hook_log(
+        store,
+        "2026-08-11T17:10:51+00:00 ingest-session missing-transcript: /tmp/gone.jsonl",
+        "2026-08-11T17:11:51+00:00 ingest-session missing-transcript: /tmp/gone2.jsonl",
+        "2026-07-25T00:07:46+00:00 ingest-session ingest-failed: a.jsonl: RuntimeError: boom",
+    )
+
+    status = _hook_errors_status(store)
+
+    assert "3 in the last 7 days" in status
+    assert "1 ingest-failed" in status
+    assert "2 missing-transcript" in status
+    assert "reconcile" in status  # scoped to the 1 that it can actually fix
+
+
+def test_hook_errors_unknown_class_never_claims_healability(tmp_path: Path):
+    """Unparseable or new class tokens count, but must not inherit the advice."""
+    from longhand.setup_commands import _hook_errors_status
+    from longhand.storage import LonghandStore
+
+    store = LonghandStore(data_dir=tmp_path / "longhand")
+    _write_hook_log(
+        store,
+        "2026-08-11T17:10:51+00:00 ingest-session store-open-failed: OSError: disk gone",
+        "a malformed line with no class token at all",
+    )
+
+    status = _hook_errors_status(store)
+
+    assert "2 in the last 7 days" in status
+    assert "reconcile" not in status
+
+
 # ─── doctor transcript-format drift ──────────────────────────────────────────
 
 


### PR DESCRIPTION
Roadmap **PR 12** of the 1.0 train. Docs plus one code change — the bake finding F2.

## COMPATIBILITY.md (new)

The five promises, each named with the artifact in this repo that enforces it. A promise without an enforcement artifact is a wish.

Promise 2 is written **forward-shaped** on purpose: older code *refuses* a newer database loudly rather than tolerating it. Operating blind on a schema you don't understand is how data gets corrupted quietly — refusing is the feature, not a limitation.

Also documents what is explicitly **not** promised (episode extraction quality, latency, the Chroma index on disk, EOL Pythons, Windows).

## Migration authoring policy

Lands in the `longhand/storage/migrations.py` header — where an author actually works — and is summarized in a new `CONTRIBUTING.md`. Automatic, one-time, **never renumbered**; no unbounded work at store open (store open is on the hook path); nothing destructive without opt-in; every new migration ships a prior-schema fixture test. M1–M8 are grandfathered, since rule 3 freezes what's already published.

## F2 — the hook-error remedy was a no-op for 91% of what it reported

`_hook_errors_status()` told **every** hook error to run `reconcile --fix`. But `reconcile` enumerates from **disk**, so a transcript that never landed is invisible to the heal path forever.

Measured across the full v0.13 bake: **23 hook errors, 21 of them the unhealable class.** All 21 of those transcripts are still absent from disk today — they never landed and never will.

The remedy now splits by class. Only `ingest-failed` is reconcile-healable; `missing-transcript`, `oversize-transcript`, and `store-open-failed` are not, and an unknown or newly-added class token never inherits the advice. Live `doctor` output:

```
⚠ 23 in the last 40 days (21 missing-transcript, 2 ingest-failed) — see
~/.longhand/logs/hook-errors-*.log; longhand reconcile --fix heals the 2
ingest-failed; the rest were never written — nothing to heal
```

Promise 5. Four tests, written red-first, cover each branch including the unknown-token case.

## README finalized

- **Windows** stated as CI-tested / best-effort per the 17-for-17 evidence, and explicitly **not** a support tier.
- **Corpus re-measured** against the live store and dated: 433 sessions, 197,978 events, 37 projects (was July's 387/181,705/35).
- **Episode line now shows the honest denominator** — 618 low-confidence excluded, 423 of 501 resolved (84%) — instead of an unqualified "1,033 extracted (385 resolved)" that read as 37%.
- Deprecation policy + promise summary, linking COMPATIBILITY.md.
- Quick Start no longer advertises the removed aliases.

**Corrects a real README error:** it claimed `chromadb<1.0` was pinned "on Python 3.14". The pin is unconditional for every Python version, and issue #4 is closed. 3.10–3.14 are all gated in CI now.

## Gate

ruff + format + mypy clean; **530 passed**. Version sync OK (still 0.13.0 — the bump belongs to the release PR).

Next: PR 13 (the 1.0 gates — 0.11 fixture DB, surface-consistency check).