### PR TITLE
test: the 1.0 gates — Promise 2's fixture DB and a surface-consistency check

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/longhand?label=PyPI&color=blue)](https://pypi.org/project/longhand/)
 ![Python](https://img.shields.io/badge/python-3.10+-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
-![Tests](https://img.shields.io/badge/tests-530%20passing-brightgreen)
+![Tests](https://img.shields.io/badge/tests-541%20passing-brightgreen)
 ![Local](https://img.shields.io/badge/100%25-local-informational)
 [![SafeSkill 93/100](https://img.shields.io/badge/SafeSkill-93%2F100_Verified%20Safe-brightgreen)](https://safeskill.dev/scan/wynelson94-longhand)
 
@@ -76,7 +76,7 @@ longhand analyze --all           # fill in episodes + vectors whenever, safe to 
 
 Exact-text search, timelines, file history, and commit lookup all work after `--skip-analysis`. Semantic `recall` needs the `analyze --all` pass to complete. Typical throughput on an M-class Mac is ~1–2 sessions/sec for full analysis.
 
-> *Status: v0.13.0 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 433 real Claude Code sessions across 37 inferred projects (measured 2026-08-12). 530 unit tests passing.*
+> *Status: v0.13.0 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 433 real Claude Code sessions across 37 inferred projects (measured 2026-08-12). 541 unit tests passing.*
 
 **Full docs:** [Longhand Wiki](https://github.com/Wynelson94/longhand/wiki) — getting started, CLI reference, MCP tools reference, architecture, and troubleshooting.
 
@@ -519,7 +519,7 @@ Longhand is flat-cost: the cap is per-call, not per-corpus. Recalling across 10 
 
 ---
 
-530 unit tests passing. All 13 MCP tools stress-tested. Full security audit: zero critical findings, zero high findings. `~/.longhand/` created with 0700 permissions, all SQL parameterized, all inputs bounded. Dependencies: chromadb, typer, rich, pydantic, mcp.
+541 unit tests passing. All 13 MCP tools stress-tested. Full security audit: zero critical findings, zero high findings. `~/.longhand/` created with 0700 permissions, all SQL parameterized, all inputs bounded. Dependencies: chromadb, typer, rich, pydantic, mcp.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,11 @@ include = ["longhand*"]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 filterwarnings = [
+    # A 1.0 gate: Longhand must emit zero deprecation warnings of its own.
+    # Anything we deprecate warns for a full minor and is then REMOVED, so a
+    # warning still firing from our own package at release time means a
+    # removal was missed. Third-party noise is triaged individually below.
+    "error::DeprecationWarning:longhand",
     # Third-party deprecation noise, triaged 2026-07-10 (audit P3). Both come
     # from chromadb's internals, not our code; re-check on chromadb upgrades.
     "ignore:asyncio.iscoroutinefunction:DeprecationWarning",

--- a/tests/fixtures/db/v0_11_2_schema.sql
+++ b/tests/fixtures/db/v0_11_2_schema.sql
@@ -1,0 +1,183 @@
+-- Genuine v0.11.2 schema: produced by executing that tag's own SCHEMA and
+-- apply_migrations() (migrations 1-6, _apply_alters included), then seeding
+-- one project / one session / two events (one of them a file edit).
+-- Regeneration recipe lives in tests/test_db_compat.py. Do NOT hand-edit.
+BEGIN TRANSACTION;
+CREATE TABLE conversation_segments (
+        segment_id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        project_id TEXT,
+        started_at TEXT NOT NULL,
+        ended_at TEXT NOT NULL,
+        start_sequence INTEGER NOT NULL,
+        end_sequence INTEGER NOT NULL,
+        segment_type TEXT NOT NULL,
+        topic TEXT NOT NULL,
+        summary TEXT NOT NULL,
+        event_count INTEGER NOT NULL,
+        user_message_count INTEGER NOT NULL,
+        keywords_json TEXT NOT NULL,
+        FOREIGN KEY (session_id) REFERENCES sessions(session_id)
+    );
+CREATE TABLE episodes (
+        episode_id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        project_id TEXT,
+        started_at TEXT NOT NULL,
+        ended_at TEXT NOT NULL,
+        problem_event_id TEXT,
+        diagnosis_event_id TEXT,
+        fix_event_id TEXT,
+        verification_event_id TEXT,
+        problem_description TEXT,
+        diagnosis_summary TEXT,
+        fix_summary TEXT,
+        touched_files_json TEXT,
+        tags_json TEXT,
+        confidence REAL DEFAULT 0.5,
+        status TEXT DEFAULT 'unresolved'
+    , fix_commit_hash TEXT);
+CREATE TABLE events (
+    event_id TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    parent_event_id TEXT,
+    event_type TEXT NOT NULL,
+    sequence INTEGER NOT NULL,
+    timestamp TEXT NOT NULL,
+    cwd TEXT,
+    git_branch TEXT,
+    model TEXT,
+    content TEXT NOT NULL,
+    is_sidechain INTEGER DEFAULT 0,
+    tool_name TEXT,
+    tool_use_id TEXT,
+    tool_input_json TEXT,
+    tool_output TEXT,
+    tool_success INTEGER,
+    file_path TEXT,
+    file_operation TEXT,
+    old_content TEXT,
+    new_content TEXT,
+    error_detected INTEGER DEFAULT 0,
+    error_snippet TEXT,
+    raw_json TEXT NOT NULL,
+    FOREIGN KEY (session_id) REFERENCES sessions(session_id)
+);
+INSERT INTO "events" VALUES('ev_fixture_0001','11111111-2222-3333-4444-555555555555',NULL,'user_message',0,'2026-06-18T00:00:30+00:00',NULL,NULL,NULL,'the fixture question',0,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,NULL,0,NULL,'{"type":"user"}');
+INSERT INTO "events" VALUES('ev_fixture_0002','11111111-2222-3333-4444-555555555555',NULL,'tool_call',1,'2026-06-18T00:00:45+00:00',NULL,NULL,NULL,'edited the file',0,'Edit',NULL,NULL,NULL,NULL,'/tmp/fixture-project/main.py','edit',NULL,NULL,0,NULL,'{"type":"assistant"}');
+CREATE TABLE git_operations (
+        git_op_id TEXT PRIMARY KEY,
+        session_id TEXT NOT NULL,
+        event_id TEXT NOT NULL,
+        operation_type TEXT NOT NULL,
+        commit_hash TEXT,
+        commit_message TEXT,
+        branch TEXT,
+        remote TEXT,
+        files_changed_count INTEGER,
+        timestamp TEXT NOT NULL,
+        success INTEGER NOT NULL DEFAULT 1
+    );
+CREATE TABLE ingestion_log (
+    transcript_path TEXT PRIMARY KEY,
+    session_id TEXT NOT NULL,
+    ingested_at TEXT NOT NULL,
+    file_size INTEGER NOT NULL,
+    event_count INTEGER NOT NULL
+, last_offset INTEGER NOT NULL DEFAULT 0);
+CREATE TABLE projects (
+        project_id TEXT PRIMARY KEY,
+        canonical_path TEXT NOT NULL,
+        display_name TEXT NOT NULL,
+        aliases_json TEXT NOT NULL,
+        keywords_json TEXT NOT NULL,
+        languages_json TEXT NOT NULL,
+        category TEXT,
+        first_seen TEXT NOT NULL,
+        last_seen TEXT NOT NULL,
+        session_count INTEGER DEFAULT 0,
+        total_edits INTEGER DEFAULT 0
+    );
+INSERT INTO "projects" VALUES('p_fixture0001','/tmp/fixture-project','fixture-project','[]','[]','[]','tool','2026-06-18T00:00:00+00:00','2026-06-18T01:00:00+00:00',1,1);
+CREATE TABLE schema_version (
+            version INTEGER PRIMARY KEY,
+            applied_at TEXT NOT NULL
+        );
+INSERT INTO "schema_version" VALUES(1,'2026-08-12T11:05:33.900402');
+INSERT INTO "schema_version" VALUES(2,'2026-08-12T11:05:33.901656');
+INSERT INTO "schema_version" VALUES(3,'2026-08-12T11:05:33.902947');
+INSERT INTO "schema_version" VALUES(4,'2026-08-12T11:05:33.903132');
+INSERT INTO "schema_version" VALUES(5,'2026-08-12T11:05:33.903788');
+INSERT INTO "schema_version" VALUES(6,'2026-08-12T11:05:33.903987');
+CREATE TABLE session_outcomes (
+        session_id TEXT PRIMARY KEY,
+        outcome TEXT NOT NULL,
+        confidence REAL NOT NULL,
+        error_count INTEGER DEFAULT 0,
+        fix_count INTEGER DEFAULT 0,
+        test_pass_count INTEGER DEFAULT 0,
+        test_fail_count INTEGER DEFAULT 0,
+        first_error_event_id TEXT,
+        resolution_event_id TEXT,
+        summary TEXT NOT NULL,
+        topics_json TEXT NOT NULL,
+        computed_at TEXT NOT NULL
+    );
+CREATE TABLE sessions (
+    session_id TEXT PRIMARY KEY,
+    project_path TEXT,
+    transcript_path TEXT NOT NULL,
+    started_at TEXT NOT NULL,
+    ended_at TEXT NOT NULL,
+    event_count INTEGER DEFAULT 0,
+    user_message_count INTEGER DEFAULT 0,
+    assistant_message_count INTEGER DEFAULT 0,
+    tool_call_count INTEGER DEFAULT 0,
+    file_edit_count INTEGER DEFAULT 0,
+    git_branch TEXT,
+    cwd TEXT,
+    model TEXT,
+    ingested_at TEXT NOT NULL
+, project_id TEXT);
+INSERT INTO "sessions" VALUES('11111111-2222-3333-4444-555555555555','/tmp/fixture-project','/tmp/fixture.jsonl','2026-06-18T00:00:00+00:00','2026-06-18T01:00:00+00:00',2,0,0,0,0,NULL,NULL,NULL,'2026-06-18T01:05:00+00:00','p_fixture0001');
+CREATE TABLE tool_pairs (
+        tool_use_id TEXT PRIMARY KEY,
+        call_event_id TEXT NOT NULL,
+        result_event_id TEXT,
+        success INTEGER,
+        error_detected INTEGER DEFAULT 0,
+        error_snippet TEXT
+    );
+CREATE INDEX idx_events_session ON events(session_id, sequence);
+CREATE INDEX idx_events_timestamp ON events(timestamp);
+CREATE INDEX idx_events_type ON events(event_type);
+CREATE INDEX idx_events_tool ON events(tool_name) WHERE tool_name IS NOT NULL;
+CREATE INDEX idx_events_file ON events(file_path) WHERE file_path IS NOT NULL;
+CREATE INDEX idx_events_tool_use_id ON events(tool_use_id) WHERE tool_use_id IS NOT NULL;
+CREATE INDEX idx_projects_last_seen ON projects(last_seen DESC);
+CREATE INDEX idx_projects_category ON projects(category);
+CREATE INDEX idx_outcomes_outcome ON session_outcomes(outcome);
+CREATE INDEX idx_episodes_project ON episodes(project_id);
+CREATE INDEX idx_episodes_session ON episodes(session_id);
+CREATE INDEX idx_episodes_ended_at ON episodes(ended_at DESC);
+CREATE INDEX idx_episodes_status ON episodes(status);
+CREATE INDEX idx_tool_pairs_call ON tool_pairs(call_event_id);
+CREATE INDEX idx_tool_pairs_error ON tool_pairs(error_detected) WHERE error_detected = 1;
+CREATE INDEX idx_git_ops_session ON git_operations(session_id, timestamp);
+CREATE INDEX idx_git_ops_hash ON git_operations(commit_hash) WHERE commit_hash IS NOT NULL;
+CREATE INDEX idx_git_ops_type ON git_operations(operation_type);
+CREATE INDEX idx_segments_session ON conversation_segments(session_id);
+CREATE INDEX idx_segments_project ON conversation_segments(project_id);
+CREATE INDEX idx_segments_ended_at ON conversation_segments(ended_at DESC);
+CREATE INDEX idx_segments_type ON conversation_segments(segment_type);
+CREATE VIEW plans_index AS
+    SELECT
+        session_id,
+        event_id,
+        file_path,
+        timestamp,
+        length(new_content) AS bytes
+    FROM events
+    WHERE file_path LIKE '%/.claude/plans/%.md'
+      AND file_operation IN ('write', 'edit', 'multi_edit');
+COMMIT;

--- a/tests/test_db_compat.py
+++ b/tests/test_db_compat.py
@@ -1,0 +1,129 @@
+"""Promise 2 (forward data compatibility) — the enforcement artifact.
+
+COMPATIBILITY.md promises that any database written by 0.11+ opens on any 1.x
+at least as new as its last writer, with migrations applied automatically and
+no data loss. This module is what makes that a tested claim rather than a
+hopeful one.
+
+The fixture is a GENUINE v0.11.2 schema, not a hand-written approximation.
+Hand-written schemas drift from what actually shipped and prove nothing, so
+`tests/fixtures/db/v0_11_2_schema.sql` was produced by executing that tag's
+own code. To regenerate it after a new baseline is chosen:
+
+    SCHEMA = re.search(r'^SCHEMA = \"\"\"(.*?)\"\"\"',
+                       git_show("<tag>:longhand/storage/sqlite_store.py"),
+                       re.S | re.M).group(1)
+    ns = {}; exec(git_show("<tag>:longhand/storage/migrations.py"), ns)
+    conn.executescript(SCHEMA)
+    ns["apply_migrations"](conn)     # the tag's real code path, _apply_alters included
+    # ...seed representative rows, then conn.iterdump()
+
+Note that v0.11.2 predates `MAX_KNOWN_MIGRATION` — the downgrade guard arrived
+in 0.13. That absence is part of what makes this a real 0.11 database.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from longhand.storage import LonghandStore
+from longhand.storage.migrations import MAX_KNOWN_MIGRATION
+
+FIXTURE = Path(__file__).parent / "fixtures" / "db" / "v0_11_2_schema.sql"
+
+# What the v0.11.2 fixture ships with. Migrations 7+ are what a 1.x release
+# must apply on top without losing anything.
+V0_11_MIGRATIONS = [1, 2, 3, 4, 5, 6]
+SESSION_ID = "11111111-2222-3333-4444-555555555555"
+PROJECT_ID = "p_fixture0001"
+
+
+def _applied(db: Path) -> list[int]:
+    conn = sqlite3.connect(db)
+    try:
+        return [r[0] for r in conn.execute("SELECT version FROM schema_version ORDER BY version")]
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def v011_data_dir(tmp_path: Path) -> Path:
+    """A data dir holding an un-migrated v0.11.2 database."""
+    data_dir = tmp_path / "longhand"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(data_dir / "longhand.db")
+    conn.executescript(FIXTURE.read_text())
+    conn.commit()
+    conn.close()
+    return data_dir
+
+
+def test_fixture_really_is_a_v0_11_database(v011_data_dir: Path):
+    """Guard the guard: if the fixture drifts forward, the rest proves nothing."""
+    assert _applied(v011_data_dir / "longhand.db") == V0_11_MIGRATIONS
+    assert V0_11_MIGRATIONS[-1] < MAX_KNOWN_MIGRATION, (
+        "fixture is not actually behind current — pick an older baseline"
+    )
+
+
+def test_v0_11_database_opens_and_migrates_automatically(v011_data_dir: Path):
+    """Promise 2: no command to run, no flag to pass — it just opens."""
+    LonghandStore(data_dir=v011_data_dir)
+
+    applied = _applied(v011_data_dir / "longhand.db")
+    assert applied == list(range(1, MAX_KNOWN_MIGRATION + 1))
+    # The migrations the 0.11 database was missing actually ran.
+    assert set(applied) - set(V0_11_MIGRATIONS)
+
+
+def test_migration_preserves_the_0_11_data(v011_data_dir: Path):
+    """Promise 2 is about data, not just DDL. Nothing may be dropped."""
+    store = LonghandStore(data_dir=v011_data_dir)
+
+    with store.sqlite.connect() as conn:
+        sessions = conn.execute(
+            "SELECT session_id, project_id, event_count FROM sessions"
+        ).fetchall()
+        events = conn.execute("SELECT event_id, content FROM events ORDER BY sequence").fetchall()
+        project = conn.execute(
+            "SELECT display_name FROM projects WHERE project_id = ?", (PROJECT_ID,)
+        ).fetchone()
+
+    assert [tuple(r) for r in sessions] == [(SESSION_ID, PROJECT_ID, 2)]
+    assert [r[0] for r in events] == ["ev_fixture_0001", "ev_fixture_0002"]
+    assert [r[1] for r in events] == ["the fixture question", "edited the file"]
+    assert project[0] == "fixture-project"
+
+
+def test_core_queries_work_against_a_migrated_0_11_store(v011_data_dir: Path):
+    """A migrated database must be usable, not merely openable."""
+    store = LonghandStore(data_dir=v011_data_dir)
+
+    listed = store.sqlite.list_sessions(limit=10)
+    assert any(s["session_id"] == SESSION_ID for s in listed)
+
+    events = store.sqlite.get_events(SESSION_ID)
+    assert len(events) == 2
+
+    history = store.sqlite.get_events(file_path="/tmp/fixture-project/main.py")
+    assert [e["event_id"] for e in history] == ["ev_fixture_0002"]
+
+    # The ReplayEngine reads through the same migrated schema.
+    from longhand.replay import ReplayEngine
+
+    edits = ReplayEngine(store.sqlite).file_history("/tmp/fixture-project/main.py")
+    assert [e["event_id"] for e in edits] == ["ev_fixture_0002"]
+
+
+def test_migration_is_one_time(v011_data_dir: Path):
+    """Re-opening applies nothing further and changes nothing (rule 2)."""
+    LonghandStore(data_dir=v011_data_dir)
+    first = _applied(v011_data_dir / "longhand.db")
+
+    LonghandStore(data_dir=v011_data_dir)
+    assert _applied(v011_data_dir / "longhand.db") == first
+    # No duplicate rows from a second pass.
+    assert len(first) == len(set(first))

--- a/tests/test_surface_consistency.py
+++ b/tests/test_surface_consistency.py
@@ -1,0 +1,158 @@
+"""Docs must not out-live the surface they describe.
+
+This exists because of a real, shipped regression. PR #69 fixed the README's
+Tests badge but missed the closing line of the same file, which still claimed
+"316 unit tests passing. All 19 MCP tools stress-tested." — wrong on both
+counts, contradicting its own badge two screens above, for two weeks. PR #72
+fixed it by hand, along with an undated corpus block and a distribution blurb
+claiming 17 MCP tools.
+
+Hand-fixing a count is not a fix; it is the same bug waiting to recur. These
+tests assert the docs against the code, so the next drift fails CI instead of
+shipping.
+
+Counts are derived, never hardcoded — a test that hardcodes 13 has to be
+hand-edited too, which is the very failure mode it is meant to prevent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from longhand import mcp_server
+from longhand.cli import app
+
+REPO = Path(__file__).parent.parent
+README = REPO / "README.md"
+CLAUDE_MD = REPO / "CLAUDE.md"
+
+
+def _listed_tools() -> set[str]:
+    return {t.name for t in asyncio.run(mcp_server.list_tools())}
+
+
+def _collected_test_count() -> int:
+    """Ask pytest, since parametrized cases are why grepping `def test_` lies."""
+    out = subprocess.run(
+        [sys.executable, "-m", "pytest", "--collect-only", "-q", "-p", "no:cacheprovider"],
+        cwd=REPO,
+        capture_output=True,
+        text=True,
+    ).stdout
+    m = re.search(r"^(\d+) tests collected", out, re.M)
+    if not m:
+        pytest.skip(f"could not parse collection output: {out[-300:]!r}")
+    return int(m.group(1))
+
+
+# ─── MCP surface ─────────────────────────────────────────────────────────────
+
+
+def test_readme_mcp_tool_count_matches_the_listing():
+    """The count in the docs is the number of tools a user actually sees."""
+    listed = len(_listed_tools())
+    claims = [int(n) for n in re.findall(r"(\d+)\s+MCP tools", README.read_text())]
+    assert claims, "README no longer states an MCP tool count — update this test or the README"
+    for claimed in claims:
+        assert claimed == listed, (
+            f"README claims {claimed} MCP tools; list_tools() returns {listed}"
+        )
+
+
+def test_retired_tools_are_absent_from_the_listing_but_still_dispatch():
+    """The two halves of Promise 1 that are easy to break independently."""
+    listed = _listed_tools()
+    retired = set(mcp_server._RETIRED_TOOLS)
+    assert not (listed & retired), f"retired tools leaked back into the listing: {listed & retired}"
+    for name in retired:
+        assert name in mcp_server._DISPATCH, f"retired tool {name} stopped answering"
+
+
+def test_claude_md_names_only_real_tools():
+    """Backticked tool names in CLAUDE.md must resolve to something callable.
+
+    CLAUDE.md is instructions to an agent — a name that no longer exists sends
+    it down a dead path.
+    """
+    text = CLAUDE_MD.read_text()
+    known = _listed_tools() | set(mcp_server._DISPATCH)
+    # Only check names we already know are tool-shaped; prose words in
+    # backticks are not our business.
+    mentioned = {m for m in re.findall(r"`([a-z_]+)`", text) if m in known or m.endswith("_tool")}
+    unknown = {m for m in mentioned if m not in known}
+    assert not unknown, f"CLAUDE.md names tools that do not exist: {sorted(unknown)}"
+
+
+# ─── CLI surface ─────────────────────────────────────────────────────────────
+
+
+def test_docs_do_not_advertise_removed_commands():
+    """The 1.0 removals must not survive anywhere in user-facing docs.
+
+    Substring matching would be useless here (`status` contains no removal,
+    but `continue` appears inside ordinary prose), so match a command
+    invocation shape: `longhand <name>`.
+    """
+    removed = ["recap", "continue", "patterns", "reanalyze"]
+    registered = {
+        (info.name or info.callback.__name__.replace("_", "-")) for info in app.registered_commands
+    }
+    for name in removed:
+        assert name not in registered, f"{name} was supposed to be removed at 1.0"
+
+    for doc in (README, CLAUDE_MD):
+        text = doc.read_text()
+        for name in removed:
+            # Allow prose that explains the removal; forbid anything that
+            # reads as a live invocation the user could copy.
+            for line in text.splitlines():
+                if re.search(rf"^\s*longhand {name}\b", line):
+                    raise AssertionError(f"{doc.name} still shows `longhand {name}` as usable")
+
+
+# ─── Measured figures ────────────────────────────────────────────────────────
+
+
+def test_readme_test_count_matches_collection():
+    """Both the badge and the prose, since #69 fixed one and missed the other."""
+    actual = _collected_test_count()
+    text = README.read_text()
+
+    badge = re.search(r"tests-(\d+)%20passing", text)
+    assert badge, "Tests badge missing from README"
+    assert int(badge.group(1)) == actual, (
+        f"README badge claims {badge.group(1)} tests; pytest collects {actual}"
+    )
+
+    for claimed in re.findall(r"(\d+) unit tests passing", text):
+        assert int(claimed) == actual, (
+            f"README prose claims {claimed} tests; pytest collects {actual}"
+        )
+
+
+def test_corpus_figures_carry_a_measurement_date():
+    """A session/event count with no date is a claim that silently rots.
+
+    The Stats section is the one place figures are quoted at scale, so it must
+    say when it was measured.
+    """
+    text = README.read_text()
+    stats = text.split("## Stats", 1)
+    assert len(stats) == 2, "README lost its Stats section"
+    body = stats[1].split("\n## ", 1)[0]
+
+    assert re.search(r"measured \d{4}-\d{2}-\d{2}", body), (
+        "Stats block must state the date it was measured"
+    )
+    # The latency figures come from an older benchmark; they must say so
+    # rather than reading as part of the same measurement.
+    if "ms median" in body:
+        assert "not re-measured" in body or re.search(r"benchmarked on[^\n]*corpus", body), (
+            "latency numbers must be attributed to the benchmark that produced them"
+        )


### PR DESCRIPTION
Roadmap **PR 13**, the last one before the release.

## Promise 2 gets a real artifact

`COMPATIBILITY.md` promises any 0.11+ database opens on any later 1.x. That was an untested claim until now.

The fixture is a **genuine v0.11.2 schema**, not a hand-written approximation — `tests/fixtures/db/v0_11_2_schema.sql` was produced by executing that tag's own `SCHEMA` and its own `apply_migrations()`. That distinction turned out to matter: `apply_migrations` calls `_apply_alters()` per version, and my first attempt reimplemented the loop and silently skipped it. Running the tag's real code path was the only way to get a schema that matches what actually shipped.

Seeded with one project, one session, and two events, so the tests prove **rows survive**, not just DDL.

Five tests: the fixture really is behind current (guard the guard), it opens and migrates with nothing to run, migrations 7–8 preserve every seeded row, core queries + `ReplayEngine` work against the migrated store, and re-opening is a no-op.

> Incidental confirmation the fixture is real: v0.11.2 has no `MAX_KNOWN_MIGRATION` at all — the downgrade guard arrived in 0.13.

## Surface-consistency check closes the F1 regression class

PR #69 fixed the README's Tests badge but missed the closing line of the same file, which still claimed *"316 unit tests passing. All 19 MCP tools stress-tested."* — wrong on both counts, contradicting its own badge two screens above, for two weeks.

Hand-fixing a count is not a fix. Counts here are **derived, never hardcoded** — `pytest --collect-only` for tests, `list_tools()` for MCP — because a test with a hardcoded `13` needs hand-editing too, which is the very failure mode it exists to prevent.

Also checks: retired tools absent from the listing *but still dispatching* (both halves of Promise 1), `CLAUDE.md` names no tool that doesn't exist, no doc shows a removed command as a live `longhand <cmd>` invocation, and corpus figures carry a measurement date.

**Verified by reintroducing the exact #69 wording:**

```
E  AssertionError: README claims 19 MCP tools; list_tools() returns 13
```

…then passing once restored. It also caught its own PR's drift live — the badge said 530 while collection had already moved to 541.

## Zero own-deprecation warnings is now a gate

`filterwarnings` gains `error::DeprecationWarning:longhand`. A warning still firing from our own package at release time means a removal was missed. All 95 remaining warnings are chromadb's, triaged separately.

## Confirmed, not rebuilt

`Tests (Python 3.14)` and `mypy` are both still required checks on `main` — the roadmap's remaining item here needed confirmation, not work.

## Gate

ruff + format + mypy clean; **541 passed**; version sync OK (still 0.13.0 — the bump belongs to the release).

Next: full dogfood + `recall_diff`, then the 1.0.0 release.