### PR TITLE
fix: three doctor rows that guessed the cause instead of reporting it

### DIFF
--- a/.fieldnotes/notes/0002-project-inference-cwd-mode.md
+++ b/.fieldnotes/notes/0002-project-inference-cwd-mode.md
@@ -5,8 +5,8 @@ references:
 - advisory: false
   lines: null
   path: longhand/parser.py
-  pinned_at: '2026-07-11T19:29:10.325279Z'
-  sha: c4e50bbda7b0b0a3c6ed239ba30888a54235aaf5102389c4b15d52d6422574f5
+  pinned_at: '2026-08-12T18:30:57.277614Z'
+  sha: 24868412a3d739fa85f504ed1d3611a3cb51cea2d9b53f568fe2ba804404b318
   symbol: null
 session_id: null
 superseded_by: '0006'
@@ -22,6 +22,8 @@ validations:
 - at: '2026-07-10T18:16:41.805585Z'
   by: unknown
 - at: '2026-07-10T20:55:48.497843Z'
+  by: unknown
+- at: '2026-08-12T18:31:12.049473Z'
   by: unknown
 written_at: '2026-04-26T05:28:36.808901Z'
 written_by: claude-opus-4-7

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![PyPI version](https://img.shields.io/pypi/v/longhand?label=PyPI&color=blue)](https://pypi.org/project/longhand/)
 ![Python](https://img.shields.io/badge/python-3.10+-blue)
 ![License](https://img.shields.io/badge/license-MIT-green)
-![Tests](https://img.shields.io/badge/tests-541%20passing-brightgreen)
+![Tests](https://img.shields.io/badge/tests-546%20passing-brightgreen)
 ![Local](https://img.shields.io/badge/100%25-local-informational)
 [![SafeSkill 93/100](https://img.shields.io/badge/SafeSkill-93%2F100_Verified%20Safe-brightgreen)](https://safeskill.dev/scan/wynelson94-longhand)
 
@@ -85,7 +85,7 @@ longhand analyze --all           # fill in episodes + vectors whenever, safe to 
 
 Exact-text search, timelines, file history, and commit lookup all work after `--skip-analysis`. Semantic `recall` needs the `analyze --all` pass to complete. Typical throughput on an M-class Mac is ~1–2 sessions/sec for full analysis.
 
-> *Status: v1.0.0 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 433 real Claude Code sessions across 37 inferred projects (measured 2026-08-12). 541 unit tests passing.*
+> *Status: v1.0.0 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 433 real Claude Code sessions across 37 inferred projects (measured 2026-08-12). 546 unit tests passing.*
 
 **Full docs:** [Longhand Wiki](https://github.com/Wynelson94/longhand/wiki) — getting started, CLI reference, MCP tools reference, architecture, and troubleshooting.
 
@@ -528,7 +528,7 @@ Longhand is flat-cost: the cap is per-call, not per-corpus. Recalling across 10 
 
 ---
 
-541 unit tests passing. All 13 MCP tools stress-tested. Full security audit: zero critical findings, zero high findings. `~/.longhand/` created with 0700 permissions, all SQL parameterized, all inputs bounded. Dependencies: chromadb, typer, rich, pydantic, mcp.
+546 unit tests passing. All 13 MCP tools stress-tested. Full security audit: zero critical findings, zero high findings. `~/.longhand/` created with 0700 permissions, all SQL parameterized, all inputs bounded. Dependencies: chromadb, typer, rich, pydantic, mcp.
 
 ---
 

--- a/longhand/parser.py
+++ b/longhand/parser.py
@@ -41,6 +41,14 @@ KNOWN_SKIP_ENTRY_TYPES = frozenset(
         "attachment",
         "ai-title",
         "agent-name",
+        # file-history-delta: checkpoint/undo bookkeeping behind Claude Code's
+        # file-history feature — {messageId, snapshotMessageId, trackingPath,
+        # backup: {backupFileName, version, backupTime, realParentDir}}. It
+        # carries no content, and the edit each one shadows is already stored
+        # as a tool_call event with the real diff, so parsing it would add
+        # rows and no recall. Triaged 2026-08-12, found by the doctor drift
+        # row on the live corpus (276 in 30 days) the day 1.0.0 shipped.
+        "file-history-delta",
     }
 )
 

--- a/longhand/setup_commands.py
+++ b/longhand/setup_commands.py
@@ -1084,8 +1084,32 @@ def _transcript_format_status(store: LonghandStore, days: int = 30) -> str:
     capped = "+" if len(rows) == 500 else ""
     return (
         f"[yellow]⚠[/yellow] {sum(counter.values())}{capped} unrecognized entries in the "
-        f"last {days} days ({top}) — the transcript format may have drifted; "
-        "try [bold]pip install -U longhand[/bold]"
+        f"last {days} days ({top}) — the transcript format has drifted; {_drift_remedy()}"
+    )
+
+
+def _drift_remedy() -> str:
+    """Recommend upgrading only when a newer release actually exists.
+
+    Telling someone already on the newest version to upgrade is a no-op, and
+    a no-op remedy is the same Promise 5 defect the hook-error row had: the
+    type genuinely isn't handled by any release yet, so the useful action is
+    to report it. Cache-only — this row must never touch the network.
+    """
+    from longhand import update_check
+    from longhand.version import __version__
+
+    try:
+        cached = update_check.read_cache()
+        latest = cached.get("latest") if cached else None
+        if latest and update_check.newer_available(__version__, latest):
+            return f"[bold]pip install -U longhand[/bold] ({latest} is available)"
+    except Exception:
+        pass  # never let a diagnostic row raise
+    return (
+        "you are on the newest longhand, so these types aren't handled by any "
+        "release yet — please report them at "
+        "[bold]https://github.com/Wynelson94/longhand/issues[/bold]"
     )
 
 

--- a/longhand/update_check.py
+++ b/longhand/update_check.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 
 import json
 import os
+import ssl
 import sys
 import tempfile
 import time
@@ -34,6 +35,39 @@ from longhand.version import __version__
 CACHE_TTL_SECONDS = 24 * 60 * 60
 PYPI_JSON_URL = "https://pypi.org/pypi/longhand/json"
 _TIMEOUT_SECONDS = 2.0
+
+# Why the last refresh failed, so doctor can report the cause instead of
+# guessing one. "offline?" was wrong for the dominant real-world case: on a
+# python.org macOS install, urllib verifies against OpenSSL's own trust store
+# rather than the system keychain, so pypi.org fails with
+# CERTIFICATE_VERIFY_FAILED while `curl` to the same URL succeeds. Sending
+# that user to debug their network is a Promise 5 violation.
+_last_failure: str | None = None
+
+
+def last_failure() -> str | None:
+    """Failure class of the most recent refresh: 'tls-trust', 'unreachable',
+    'bad-payload', or None if the last attempt succeeded or never ran."""
+    return _last_failure
+
+
+def _ssl_context() -> ssl.SSLContext:
+    """Verify against certifi's CA bundle when it is importable.
+
+    certifi is present transitively (chromadb pulls requests/httpx), but this
+    stays a soft import: if it ever goes away we fall back to the default
+    context and report the honest failure rather than breaking.
+
+    This exists because a python.org macOS install verifies against OpenSSL's
+    own trust store, not the system keychain — so pypi.org fails with
+    CERTIFICATE_VERIFY_FAILED while `curl` to the same URL succeeds.
+    """
+    try:
+        import certifi
+
+        return ssl.create_default_context(cafile=certifi.where())
+    except Exception:
+        return ssl.create_default_context()
 
 
 def is_disabled() -> bool:
@@ -110,15 +144,39 @@ def refresh(data_dir: str | Path | None = None, *, force: bool = False) -> str |
     cached = read_cache(data_dir)
     if not force and cached and time.time() - cached["checked_at"] < CACHE_TTL_SECONDS:
         return cached["latest"]
+    global _last_failure
     try:
-        with urllib.request.urlopen(PYPI_JSON_URL, timeout=_TIMEOUT_SECONDS) as resp:
+        with urllib.request.urlopen(
+            PYPI_JSON_URL, timeout=_TIMEOUT_SECONDS, context=_ssl_context()
+        ) as resp:
             latest = json.load(resp)["info"]["version"]
         if not isinstance(latest, str):
+            _last_failure = "bad-payload"
             return None
-    except Exception:
+    except Exception as e:
+        _last_failure = _classify(e)
         return None
+    _last_failure = None
     _write_cache(data_dir, latest)
     return latest
+
+
+def _classify(exc: BaseException) -> str:
+    """Map a refresh exception to a failure class doctor can act on.
+
+    Checks the whole cause chain: urllib wraps the SSL error in a URLError,
+    so the certificate failure is one `.reason` deep.
+    """
+    seen: list[BaseException] = []
+    cur: BaseException | None = exc
+    while cur is not None and cur not in seen:
+        seen.append(cur)
+        if isinstance(cur, ssl.SSLError):
+            return "tls-trust"
+        cur = getattr(cur, "reason", None) or cur.__cause__ or cur.__context__
+    if "certificate" in str(exc).lower():
+        return "tls-trust"
+    return "unreachable"
 
 
 def _write_cache(data_dir: str | Path | None, latest: str) -> None:
@@ -162,18 +220,43 @@ def after_command(data_dir: str | Path | None = None) -> None:
         pass
 
 
+def _failure_line(why: str | None) -> str:
+    """Name the failure and give a remedy that matches it.
+
+    "offline?" is only honest when the network is actually the problem. A
+    trust-store failure has a completely different fix, and telling that user
+    to check their connection wastes their time.
+    """
+    if why == "tls-trust":
+        hint = (
+            "[yellow]⚠[/yellow] pypi.org TLS certificate verification failed — "
+            "your Python cannot verify HTTPS certificates"
+        )
+        if sys.platform == "darwin":
+            return (
+                f"{hint}; run [bold]Install Certificates.command[/bold] in your "
+                "Python.app folder, or [bold]pip install -U certifi[/bold]"
+            )
+        return f"{hint}; try [bold]pip install -U certifi[/bold]"
+    if why == "bad-payload":
+        return "[yellow]⚠[/yellow] pypi.org returned an unexpected response"
+    return "[yellow]⚠[/yellow] could not reach pypi.org (offline?)"
+
+
 def doctor_status(data_dir: str | Path | None = None) -> str:
     """Rich-markup status line for the doctor table. Refreshes (forced)."""
     if is_disabled():
         return "[dim]disabled (LONGHAND_NO_UPDATE_CHECK)[/dim]"
     latest = refresh(data_dir, force=True)
     if latest is None:
+        why = last_failure()
         cached = read_cache(data_dir)
         if cached is None:
-            return "[yellow]⚠[/yellow] could not reach pypi.org (offline?)"
+            return _failure_line(why)
         age_days = max(0.0, (time.time() - cached["checked_at"]) / 86400)
         latest = cached["latest"]
-        suffix = f" [dim](cached {age_days:.0f}d ago; pypi.org unreachable)[/dim]"
+        reason = "TLS certificate verification failed" if why == "tls-trust" else "unreachable"
+        suffix = f" [dim](cached {age_days:.0f}d ago; pypi.org {reason})[/dim]"
     else:
         suffix = ""
     if newer_available(__version__, latest):

--- a/tests/fixtures/transcript_shapes/entries.jsonl
+++ b/tests/fixtures/transcript_shapes/entries.jsonl
@@ -14,3 +14,4 @@
 {"type":"summary","summary":"Fixed the auth token refresh by adding a mutex around the cache","leafUuid":"shape-asst-1"}
 {"type":"pr-link","sessionId":"s-shapes","prNumber":42,"prUrl":"https://github.com/example/repo/pull/42","prRepository":"example/repo","timestamp":"2026-07-01T10:00:20.000Z"}
 {"type":"worktree-state","sessionId":"s-shapes","worktreeSession":{"originalCwd":"/tmp/shapes-project","worktreePath":"/tmp/shapes-project/.claude/worktrees/wt-1","worktreeName":"wt-1","worktreeBranch":"worktree-wt-1","originalBranch":"main","originalHeadCommit":"0000000000000000000000000000000000000000","sessionId":"s-shapes"}}
+{"type":"file-history-delta","messageId":"shape-fhd-1","snapshotMessageId":"shape-fhs-1","trackingPath":"/tmp/shapes-project/main.py","backup":{"backupFileName":null,"version":3,"backupTime":"2026-08-11T10:00:00.000Z","realParentDir":"/tmp/shapes-project"},"timestamp":"2026-08-11T10:00:00.000Z"}

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -700,7 +700,46 @@ def test_transcript_format_status_yellow_names_the_drifting_type(tmp_path: Path)
     assert "yellow" in status
     assert "flux-capacitor" in status
     assert "ancient" not in status
-    assert "pip install -U longhand" in status
+
+
+def _seed_drift(store) -> None:
+    from longhand.timeutil import utcnow
+
+    with store.sqlite.connect() as conn:
+        conn.execute(
+            "INSERT INTO events (event_id, session_id, event_type, sequence,"
+            " timestamp, content, raw_json) VALUES ('unk-1', 's-drift', 'unknown', 1, ?, '', ?)",
+            (utcnow().isoformat(), json.dumps({"type": "flux-capacitor"})),
+        )
+        conn.commit()
+
+
+def test_transcript_format_only_suggests_upgrading_when_one_exists(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """Same Promise 5 rule as the hook-error row: don't recommend a no-op.
+
+    `pip install -U longhand` cannot help someone already on the newest
+    release — the type genuinely isn't handled by any version yet.
+    """
+    from longhand import update_check
+    from longhand.setup_commands import _transcript_format_status
+    from longhand.storage import LonghandStore
+
+    store = LonghandStore(data_dir=tmp_path / "longhand")
+    _seed_drift(store)
+
+    monkeypatch.setattr(update_check, "hint_from_cache", lambda *a, **k: None)
+    monkeypatch.setattr(update_check, "newer_available", lambda *a, **k: False)
+    on_latest = _transcript_format_status(store)
+    assert "pip install -U longhand" not in on_latest
+    assert "flux-capacitor" in on_latest
+    assert "report" in on_latest.lower() or "issue" in on_latest.lower()
+
+    monkeypatch.setattr(update_check, "newer_available", lambda *a, **k: True)
+    monkeypatch.setattr(update_check, "read_cache", lambda *a, **k: {"latest": "99.0.0"})
+    behind = _transcript_format_status(store)
+    assert "pip install -U longhand" in behind
 
 
 def test_transcript_format_status_ignores_dispositioned_types(tmp_path: Path):

--- a/tests/test_update_check.py
+++ b/tests/test_update_check.py
@@ -117,7 +117,7 @@ def test_refresh_fresh_cache_skips_network(enabled, monkeypatch):
 def test_refresh_expired_cache_fetches_and_writes(enabled, monkeypatch):
     _seed_cache(enabled, "0.11.9", age_seconds=update_check.CACHE_TTL_SECONDS + 60)
     body = io.StringIO(json.dumps({"info": {"version": "0.12.5"}}))
-    monkeypatch.setattr("urllib.request.urlopen", lambda url, timeout: body)
+    monkeypatch.setattr("urllib.request.urlopen", lambda url, timeout, context=None: body)
     assert update_check.refresh() == "0.12.5"
     cached = update_check.read_cache()
     assert cached is not None and cached["latest"] == "0.12.5"
@@ -226,6 +226,78 @@ def test_doctor_status_update_available(enabled, monkeypatch):
 def test_doctor_status_offline_without_cache(enabled, monkeypatch):
     monkeypatch.setattr(update_check, "refresh", lambda *a, **k: None)
     assert "could not reach" in update_check.doctor_status()
+
+
+# ─── failure class is reported, not guessed (Promise 5) ─────────────────────
+#
+# On a python.org macOS install, urllib verifies against OpenSSL's trust store
+# rather than the system keychain, so pypi.org fails with
+# CERTIFICATE_VERIFY_FAILED while `curl` to the same URL succeeds. Reporting
+# that as "offline?" sends the user to debug a network that is fine. Longhand
+# ran with this misdiagnosis for weeks and it was logged as "unexplained".
+
+
+def test_refresh_records_the_failure_class(enabled, monkeypatch):
+    import ssl
+
+    def _boom(*a, **k):
+        raise ssl.SSLCertVerificationError("certificate verify failed")
+
+    monkeypatch.setattr(update_check.urllib.request, "urlopen", _boom)
+
+    assert update_check.refresh(enabled, force=True) is None
+    assert update_check.last_failure() == "tls-trust"
+
+
+def test_refresh_distinguishes_a_real_network_failure(enabled, monkeypatch):
+    def _boom(*a, **k):
+        raise OSError("Network is unreachable")
+
+    monkeypatch.setattr(update_check.urllib.request, "urlopen", _boom)
+
+    assert update_check.refresh(enabled, force=True) is None
+    assert update_check.last_failure() == "unreachable"
+
+
+def test_doctor_status_names_the_trust_store_problem(enabled, monkeypatch):
+    import ssl
+
+    def _boom(*a, **k):
+        raise ssl.SSLCertVerificationError("certificate verify failed")
+
+    monkeypatch.setattr(update_check.urllib.request, "urlopen", _boom)
+
+    line = update_check.doctor_status(enabled)
+    assert "offline" not in line.lower(), "a TLS trust failure is not being offline"
+    assert "certificate" in line.lower()
+    # The remedy must be actionable and specific to the real cause.
+    assert "Install Certificates" in line or "certifi" in line
+
+
+def test_refresh_succeeds_through_a_certifi_bundle(enabled, monkeypatch):
+    """The fix, not just the message: verify against certifi when it is there."""
+    pytest.importorskip("certifi")
+    seen: dict = {}
+
+    class _Resp:
+        def read(self):
+            return b'{"info": {"version": "9.9.9"}}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+    def _fake(url, timeout=None, context=None):
+        seen["context"] = context
+        return _Resp()
+
+    monkeypatch.setattr(update_check.urllib.request, "urlopen", _fake)
+    monkeypatch.setattr(update_check.json, "load", lambda r: {"info": {"version": "9.9.9"}})
+
+    assert update_check.refresh(enabled, force=True) == "9.9.9"
+    assert seen["context"] is not None, "urlopen was called without an explicit SSL context"
 
 
 def test_doctor_status_offline_falls_back_to_stale_cache(enabled, monkeypatch):


### PR DESCRIPTION
Found by dogfooding **1.0.0** on the live corpus, minutes after it shipped. All three are the same defect the 1.0 hook-error fix addressed: **a diagnostic that recommends a remedy which cannot work for the case it is reporting** (Promise 5).

## 1. "could not reach pypi.org (offline?)" was never a network problem

`doctor`'s Version row reported pypi.org unreachable while `curl` to the identical URL returned 200. The 0.13 bake notes recorded this as *"unexplained, not blocking."*

It's explained. A python.org macOS install verifies against **OpenSSL's own trust store, not the system keychain**, so `urllib` fails with `CERTIFICATE_VERIFY_FAILED` where `curl` succeeds. `except Exception: return None` was swallowing it.

Both halves fixed:
- `refresh()` verifies against **certifi's CA bundle** when importable — present transitively via chromadb, kept a soft import with a default-context fallback. The check now actually works.
- Failures are **classified** (`tls-trust` / `unreachable` / `bad-payload`) so the row names the real cause and gives the matching remedy — `Install Certificates.command` on macOS, or `pip install -U certifi`. `_classify` walks the cause chain, since urllib buries the SSL error one `.reason` deep.

This is the update channel, so it's also a distribution fix: users on the most common macOS Python were never being told a new version existed.

## 2. The drift row told everyone to upgrade, including people already current

`try pip install -U longhand` is a **guaranteed no-op** for someone on the newest release — the entry type isn't handled by *any* version yet. It now suggests the upgrade only when the cached check shows one exists, and otherwise asks for a bug report. Cache-only; this row still never touches the network.

## 3. `file-history-delta` triaged

Claude Code added this type upstream. **The drift canary caught it on the live corpus — 276 in 30 days — the day 1.0.0 shipped.** Promise 4 working exactly as designed.

It's checkpoint/undo bookkeeping (`trackingPath` + a backup version stamp) with no content, and every edit it shadows is already stored as a `tool_call` event with the real diff. Parsing it would add rows and no recall, so it goes to `KNOWN_SKIP_ENTRY_TYPES` with a written reason — the same disposition as the other eight content-free orchestration types.

The alternative was `TRIAGED_UNKNOWN` (preserve as unknown, revisit later). I went with skip because the entry carries nothing recallable, which is precisely the rationale the skip set already documents. Easy to flip if you'd rather preserve them.

Fixture line added first; the shapes gate failed, then passed.

## Verification

All three confirmed on the live 435-session corpus:

```
Version            ⚠ 1.0.0 available (installed 0.11.2) — run pip install -U longhand
Hook errors (7d)   ⚠ 2 in the last 7 days (2 missing-transcript) — ...
                   these were never written — nothing to heal
Transcript format  ✓ no undispositioned entry types in the last 30 days
```

The Version row previously said "offline?"; it now reaches PyPI. The Transcript-format row was yellow with 276 unrecognized entries; it's green.

Gate: ruff + format + mypy clean, **546 passed**. The surface-consistency check from #76 caught the badge drift again (541 → 546) — third time it's earned its keep.