### PR TITLE
v1.0.1: honest doctor diagnostics

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "longhand",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Persistent local memory for Claude Code. Every tool call, every file edit, every thinking block from every session \u2014 stored verbatim on your machine. Semantic recall in ~126ms with zero API calls.",
   "author": {
     "name": "Nate Nelson",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ commits and tag annotations of those releases.
 
 ---
 
+## [1.0.1] — 2026-08-12
+
+Three `doctor` rows told you the wrong thing. Found by dogfooding 1.0.0 on a
+live corpus within the hour, all the same defect Promise 5 exists to prevent:
+a diagnostic recommending a remedy that cannot work for the case it reports.
+
+### Fixed
+
+- **The update check never worked on a python.org macOS install, and said
+  "offline?" instead of saying so.** `urllib` verifies against OpenSSL's own
+  trust store rather than the system keychain, so pypi.org failed with
+  `CERTIFICATE_VERIFY_FAILED` while `curl` to the same URL succeeded — which
+  is exactly why it looked like a network problem and sat "unexplained" since
+  0.13. Longhand now verifies against certifi's CA bundle when it is
+  importable, so the check works; and when it still fails, the row names the
+  real class (TLS trust vs unreachable vs bad response) and gives the matching
+  remedy — `Install Certificates.command` on macOS, or `pip install -U certifi`.
+  If you never saw an update notice on macOS, this is why.
+- **The transcript-drift row told everyone to `pip install -U longhand`,
+  including people already on the newest release**, for whom it is a
+  guaranteed no-op — an unrecognized entry type is not handled by *any*
+  version yet. It now suggests upgrading only when one actually exists, and
+  otherwise asks you to report the type. Still cache-only; it never touches
+  the network.
+- **`file-history-delta` is now dispositioned.** Claude Code added the type
+  upstream and the drift canary caught it on a live corpus (276 in 30 days)
+  the day 1.0.0 shipped — Promise 4 doing its job. It is checkpoint bookkeeping
+  with no content, and every edit it shadows is already stored as a `tool_call`
+  event with the real diff, so it joins the skip set rather than becoming
+  unknown-event bloat.
+
+---
+
 ## [1.0.0] — 2026-08-12
 
 **The promise release.** 1.0 is a commitment, not a version bump: five

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim
 
-RUN pip install --no-cache-dir longhand==1.0.0
+RUN pip install --no-cache-dir longhand==1.0.1
 
 ENTRYPOINT ["longhand", "mcp-server"]

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ longhand analyze --all           # fill in episodes + vectors whenever, safe to 
 
 Exact-text search, timelines, file history, and commit lookup all work after `--skip-analysis`. Semantic `recall` needs the `analyze --all` pass to complete. Typical throughput on an M-class Mac is ~1–2 sessions/sec for full analysis.
 
-> *Status: v1.0.0 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 433 real Claude Code sessions across 37 inferred projects (measured 2026-08-12). 546 unit tests passing.*
+> *Status: v1.0.1 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 433 real Claude Code sessions across 37 inferred projects (measured 2026-08-12). 546 unit tests passing.*
 
 **Full docs:** [Longhand Wiki](https://github.com/Wynelson94/longhand/wiki) — getting started, CLI reference, MCP tools reference, architecture, and troubleshooting.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "longhand"
-version = "1.0.0"
+version = "1.0.1"
 description = "Persistent local memory for Claude Code. Total recall from your session files — no API calls, no summaries, no AI deciding what matters."
 readme = "README.md"
 license = { text = "MIT" }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Wynelson94/longhand",
   "title": "Longhand",
   "description": "Local memory for Claude Code: 13 MCP tools for semantic recall, file replay, project timelines, and git history across your session JSONL \u2014 zero API calls, all local.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "repository": {
     "url": "https://github.com/Wynelson94/longhand",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "longhand",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Patch release for the three defects found by dogfooding 1.0.0 on a live corpus within the hour of shipping. Code already reviewed and merged in #79 — this PR is the version bump + changelog.

All three are the same class Promise 5 exists to prevent: **a diagnostic that recommends a remedy which cannot work for the case it reports.**

1. **The update check never worked on a python.org macOS install** — `urllib` verifies against OpenSSL's trust store, not the system keychain, so pypi.org failed with `CERTIFICATE_VERIFY_FAILED` while `curl` succeeded. It reported that as "offline?", which is why it sat "unexplained" since the 0.13 bake. Now verifies through certifi's CA bundle, and names the real failure class when it still can't connect. **If you never saw an update notice on macOS, this is why.**
2. **The drift row told everyone to upgrade**, including users already current, for whom it's a guaranteed no-op. Now conditional, and asks for a bug report otherwise.
3. **`file-history-delta` dispositioned** — upstream drift the canary caught on day one of 1.0.0. Promise 4 working.

Gate: ruff + format + mypy clean, **546 passed**, version sync OK at 1.0.1.