### PR TITLE
v1.1.0: one archive for Claude Code and Codex

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "longhand",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Persistent local memory for Claude Code. Every tool call, every file edit, every thinking block from every session \u2014 stored verbatim on your machine. Semantic recall in ~126ms with zero API calls.",
   "author": {
     "name": "Nate Nelson",

--- a/.fieldnotes/notes/0002-project-inference-cwd-mode.md
+++ b/.fieldnotes/notes/0002-project-inference-cwd-mode.md
@@ -25,6 +25,8 @@ validations:
   by: unknown
 - at: '2026-08-12T18:31:12.049473Z'
   by: unknown
+- at: '2026-09-07T22:38:05.209162Z'
+  by: unknown
 written_at: '2026-04-26T05:28:36.808901Z'
 written_by: claude-opus-4-7
 ---

--- a/.fieldnotes/notes/0002-project-inference-cwd-mode.md
+++ b/.fieldnotes/notes/0002-project-inference-cwd-mode.md
@@ -5,8 +5,8 @@ references:
 - advisory: false
   lines: null
   path: longhand/parser.py
-  pinned_at: '2026-08-12T18:30:57.277614Z'
-  sha: 24868412a3d739fa85f504ed1d3611a3cb51cea2d9b53f568fe2ba804404b318
+  pinned_at: '2026-09-07T22:37:31.948558Z'
+  sha: 38dc7615e81960be2721dfb35c0fc0cf4c0b75ee8209a348c656f83bb0fbe0ae
   symbol: null
 session_id: null
 superseded_by: '0006'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ commits and tag annotations of those releases.
 
 ---
 
-## [Unreleased]
+## [1.1.0] — 2026-09-07
 
 Longhand now keeps one archive for Claude Code **and** Codex. This is the
 first release that captures a second client, and it holds that client to the

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-slim
 
-RUN pip install --no-cache-dir longhand==1.0.1
+RUN pip install --no-cache-dir longhand==1.1.0
 
 ENTRYPOINT ["longhand", "mcp-server"]

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ longhand analyze --all           # fill in episodes + vectors whenever, safe to 
 
 Exact-text search, timelines, file history, and commit lookup all work after `--skip-analysis`. Semantic `recall` needs the `analyze --all` pass to complete. Typical throughput on an M-class Mac is ~1–2 sessions/sec for full analysis.
 
-> *Status: v1.0.1 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 433 real Claude Code sessions across 37 inferred projects (measured 2026-08-12). 580 unit tests passing.*
+> *Status: v1.1.0 — stable, daily-driver tested, security-audited (zero critical findings), on PyPI, available as a Claude Code plugin. Validated against 433 real Claude Code sessions across 37 inferred projects (measured 2026-08-12). 580 unit tests passing.*
 
 **Full docs:** [Longhand Wiki](https://github.com/Wynelson94/longhand/wiki) — getting started, CLI reference, MCP tools reference, architecture, and troubleshooting.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "longhand"
-version = "1.0.1"
+version = "1.1.0"
 description = "Persistent local memory for Claude Code. Total recall from your session files — no API calls, no summaries, no AI deciding what matters."
 readme = "README.md"
 license = { text = "MIT" }

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Wynelson94/longhand",
   "title": "Longhand",
   "description": "Local memory for Claude Code: 13 MCP tools for semantic recall, file replay, project timelines, and git history across your session JSONL \u2014 zero API calls, all local.",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "repository": {
     "url": "https://github.com/Wynelson94/longhand",
     "source": "github"
@@ -13,7 +13,7 @@
       "registryType": "pypi",
       "registryBaseUrl": "https://pypi.org",
       "identifier": "longhand",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "runtimeHint": "uvx",
       "transport": {
         "type": "stdio"


### PR DESCRIPTION
Release commit for **1.1.0**: version bump across `pyproject.toml`, `server.json`, `.claude-plugin/plugin.json`, `Dockerfile`, and the README status line (`scripts/bump_version.py`, verified by `scripts/check_version_sync.py`); the CHANGELOG `[Unreleased]` heading becomes `[1.1.0] — 2026-09-07`; fieldnote 0002 re-pinned to `parser.py` after review (#84 did not touch the cwd-mode attribution it documents). The feature landed in #84.

Local gates on this commit: `ruff check`, `ruff format --check`, `mypy longhand`, `pytest` — 580 passed.

After merge: tag `v1.1.0` on the merge commit → the publish workflow builds and publishes via Trusted Publishing (needs the `pypi` environment approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LzrMzN4dfuJJKc4UZP6SFb